### PR TITLE
Fix High Septon triggers + add better UI

### DIFF
--- a/server/game/cards/05-LoCR/HighSepton.js
+++ b/server/game/cards/05-LoCR/HighSepton.js
@@ -10,6 +10,7 @@ class HighSepton extends DrawCard {
                     event.targets.hasSingleTarget() &&
                     event.targets.anySelection(selection => (
                         selection.choosingPlayer !== this.controller &&
+                        selection.value.getType() === 'character' &&
                         selection.value.controller === this.controller
                     ))
                 )
@@ -29,6 +30,7 @@ class HighSepton extends DrawCard {
         return (
             selection.isEligible(card) &&
             card.controller === this.controller &&
+            card.getType() === 'character' &&
             card.hasTrait('The Seven')
         );
     }

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -97,6 +97,12 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                     source: event.source.getShortSummary(),
                     targets: event.targets.map(target => target.getShortSummary())
                 });
+            } else if(event.name === 'onTargetsChosen') {
+                controls.push({
+                    type: 'targeting',
+                    source: event.ability.card.getShortSummary(),
+                    targets: event.targets.getTargets().map(target => target.getShortSummary())
+                });
             }
         }
 

--- a/server/game/gamesteps/TriggeredAbilityWindowTitles.js
+++ b/server/game/gamesteps/TriggeredAbilityWindowTitles.js
@@ -7,8 +7,9 @@ const EventToTitleFunc = {
     onCharactersKilled: () => 'characters being killed',
     onPhaseEnded: event => `${event.phase} phase ending`,
     onPhaseStarted: event => `${event.phase} phase starting`,
+    onRemovedFromChallenge: event => `${event.card.name} being removed from the challenge`,
     onSacrificed: event => `${event.card.name} being sacrificed`,
-    onRemovedFromChallenge: event => `${event.card.name} being removed from the challenge`
+    onTargetsChosen: () => 'targets being chosen'
 };
 
 const AbilityTypeToWord = {


### PR DESCRIPTION
Limits High Septon to triggering on and choosing characters, and updates the prompt to display the same targeting indicator used for cancel abilities:
![screen shot 2018-05-18 at 5 44 58 pm](https://user-images.githubusercontent.com/145077/40263212-00159434-5ac4-11e8-8979-07f76bf39259.png)

Fixes #1980 
Fixes #1981 