### PR TITLE
Always look up faction name

### DIFF
--- a/server/api/cards.js
+++ b/server/api/cards.js
@@ -1,6 +1,7 @@
 const monk = require('monk');
 const config = require('../config.js');
 const CardService = require('../services/CardService.js');
+const Factions = require('../game/Factions');
 
 let db = monk(config.dbPath);
 let cardService = new CardService(db);
@@ -27,17 +28,7 @@ module.exports.init = function(server) {
     });
 
     server.get('/api/factions', function(req, res) {
-        let factions = [
-            { name: 'House Baratheon', value: 'baratheon' },
-            { name: 'House Greyjoy', value: 'greyjoy' },
-            { name: 'House Lannister', value: 'lannister' },
-            { name: 'House Martell', value: 'martell' },
-            { name: 'The Night\'s Watch', value: 'thenightswatch' },
-            { name: 'House Stark', value: 'stark' },
-            { name: 'House Targaryen', value: 'targaryen' },
-            { name: 'House Tyrell', value: 'tyrell' }
-        ];
-        res.send({ success: true, factions: factions });
+        res.send({ success: true, factions: Factions });
     });
 
     server.get('/api/restricted-list', function(req, res, next) {

--- a/server/game/Factions.js
+++ b/server/game/Factions.js
@@ -1,0 +1,10 @@
+module.exports = [
+    { name: 'House Baratheon', value: 'baratheon' },
+    { name: 'House Greyjoy', value: 'greyjoy' },
+    { name: 'House Lannister', value: 'lannister' },
+    { name: 'House Martell', value: 'martell' },
+    { name: 'The Night\'s Watch', value: 'thenightswatch' },
+    { name: 'House Stark', value: 'stark' },
+    { name: 'House Targaryen', value: 'targaryen' },
+    { name: 'House Tyrell', value: 'tyrell' }
+];

--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -4,6 +4,7 @@ const cards = require('./cards');
 const DrawCard = require('./drawcard.js');
 const PlotCard = require('./plotcard.js');
 const AgendaCard = require('./agendacard.js');
+const Factions = require('./Factions');
 
 class Deck {
     constructor(data) {
@@ -12,11 +13,14 @@ class Deck {
 
     createFactionCard(player) {
         if(this.data.faction) {
-            return new DrawCard(player, _.extend({
+            let factionData = Factions.find(faction => faction.value === this.data.faction.value);
+            return new DrawCard(player, {
                 code: this.data.faction.value,
                 type: 'faction',
-                faction: this.data.faction.value
-            }, this.data.faction));
+                faction: this.data.faction.value,
+                name: factionData && factionData.name,
+                label: factionData && factionData.name
+            });
         }
 
         return new DrawCard(player, { type: 'faction' });


### PR DESCRIPTION
Faction data for decks is inconsistently stored in the database -
sometimes it has the name / label for the faction, sometimes it doesn't.
This will ensure that the faction name is always associated with the
card data for the faction card.