### PR TITLE
Only apply attachment effects if there's a parent

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -222,7 +222,7 @@ class BaseCard {
      */
     whileAttached(properties) {
         this.persistentEffect({
-            condition: properties.condition,
+            condition: () => !!this.parent && (!properties.condition || properties.condition()),
             match: (card, context) => card === this.parent && (!properties.match || properties.match(card, context)),
             targetController: 'any',
             effect: properties.effect

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -167,5 +167,41 @@ describe('effects', function() {
                 });
             });
         });
+
+        describe('parent dependent "while attached" effects while being discarded', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Confiscation', 'A Noble Cause',
+                    'Daenerys Targaryen (Core)', 'Tokar'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.attachment = this.player1.findCardByName('Tokar', 'hand');
+                this.character = this.player1.findCardByName('Daenerys Targaryen', 'hand');
+
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.character);
+
+                this.completeSetup();
+
+                // Attach the Tokar
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.character);
+
+                this.player1.selectPlot('Confiscation');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should not crash', function() {
+                expect(() => {
+                    // Discard Tokar due to Confiscation
+                    this.player1.clickCard(this.attachment);
+                }).not.toThrow();
+            });
+        });
     });
 });


### PR DESCRIPTION
Previously, attachment related `whileAttached` effects were always
active, using a matching function to limit its targets to only the
parent card (if there was one). This led to crashes when the effect was
dependent on a parent card being present, such as Tokar. Now, the
attachment must have a parent before the effect is applied, and losing
the parent will immediately unapply the effect entirely instead of
recalculating.

Fixes THRONETEKI-26R