### PR TITLE
kill costs can be payed only using in-play characters

### DIFF
--- a/server/game/costs/KillCost.js
+++ b/server/game/costs/KillCost.js
@@ -4,7 +4,7 @@ class KillCost {
     }
 
     isEligible(card) {
-        return card.canBeKilled();
+        return card.location === 'play area' && card.canBeKilled();
     }
 
     pay(cards, context) {


### PR DESCRIPTION
Currently Given to the Drowned God allows to use in-hand cards to pay its
cost. While that could be fixed in the card, as per the rules killed characters
"leave play", so they have to be in play to be killed. Hence this change, which
enforces the fact that kill costs can be played only using in-play cards.