### PR TITLE
Implement Beneath the Bridge of Dream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2169,6 +2169,11 @@
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
+    "lodash.sample": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.sample/-/lodash.sample-4.2.1.tgz",
+      "integrity": "sha1-XkKRsMdT+hq+sKq4+ynfG2bwf20="
+    },
     "lodash.toplainobject": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.15.5",
     "jimp": "^0.2.28",
     "jsonwebtoken": "^7.4.3",
+    "lodash.sample": "^4.2.1",
     "moment": "^2.21.0",
     "mongodb": "^2.2.31",
     "monk": "^3.1.3",

--- a/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
+++ b/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
@@ -1,4 +1,4 @@
-const _ = require('underscore');
+const sample = require('lodash.sample');
 
 const DrawCard = require('../../drawcard');
 
@@ -15,7 +15,7 @@ class BeneathTheBridgeOfDream extends DrawCard {
                 }
                 // Delay picking the plot until the async recycle above resolves
                 this.game.queueSimpleStep(() => {
-                    let plot = _.sample(this.controller.plotDeck);
+                    let plot = sample(this.controller.plotDeck);
                     this.untilEndOfPhase(ability => ({
                         targetType: 'player',
                         targetController: 'current',

--- a/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
+++ b/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
@@ -1,0 +1,37 @@
+const _ = require('underscore');
+
+const DrawCard = require('../../drawcard');
+
+class BeneathTheBridgeOfDream extends DrawCard {
+    setupCardAbilities() {
+        this.interrupt({
+            when: {
+                onChoosePlot: event => event.players.includes(this.controller) && this.game.currentPhase === 'plot'
+            },
+            handler: () => {
+                this.game.addMessage('{0} plays {1} to shuffle their used pile into their plot deck, randomly choose a plot to reveal and give +2 gold to their revealed plot', this.controller, this);
+                for(const plot of this.controller.plotDiscard) {
+                    this.controller.moveCard(plot, 'plot deck');
+                }
+                // Delay picking the plot until the async recycle above resolves
+                this.game.queueSimpleStep(() => {
+                    let plot = _.sample(this.controller.plotDeck);
+                    this.untilEndOfPhase(ability => ({
+                        targetType: 'player',
+                        targetController: 'current',
+                        effect: ability.effects.mustRevealPlot(plot)
+                    }));
+                    this.untilEndOfRound(ability => ({
+                        condition: () => true,
+                        match: card => card === card.controller.activePlot,
+                        effect: ability.effects.modifyGold(2)
+                    }));
+                });
+            }
+        });
+    }
+}
+
+BeneathTheBridgeOfDream.code = '11011';
+
+module.exports = BeneathTheBridgeOfDream;

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -12,7 +12,7 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.clearNewCards()),
             new SimpleStep(game, () => this.startPlotPhase()),
             new SimpleStep(game, () => this.announceForcedPlotSelection()),
-            new SelectPlotPrompt(game),
+            new SimpleStep(game, () => this.choosePlots()),
             new SimpleStep(game, () => this.removeActivePlots()),
             new SimpleStep(game, () => this.flipPlotsFaceup()),
             () => new RevealPlots(game, this.getActivePlots()),
@@ -40,6 +40,13 @@ class PlotPhase extends Phase {
                 this.game.addMessage('{0} is forced to select a plot', player);
             }
         }
+    }
+
+    choosePlots() {
+        let choosingPlayers = this.game.getPlayers().filter(player => !player.mustRevealPlot);
+        this.game.raiseEvent('onChoosePlot', { players: choosingPlayers }, () => {
+            this.game.queueStep(new SelectPlotPrompt(this.game));
+        });
     }
 
     removeActivePlots() {

--- a/server/game/gamesteps/revealplots.js
+++ b/server/game/gamesteps/revealplots.js
@@ -1,4 +1,5 @@
 const _ = require('underscore');
+const sample = require('lodash.sample');
 const BaseStep = require('./basestep.js');
 const SimpleStep = require('./simplestep.js');
 const FirstPlayerPrompt = require('./plot/firstplayerprompt.js');
@@ -80,7 +81,7 @@ class RevealPlots extends BaseStep {
         this.game.raiseEvent('onInitiativeDetermined', { winner: initiativeWinner });
     }
 
-    getInitiativeResult(sampleFunc = _.sample) {
+    getInitiativeResult(sampleFunc = sample) {
         let result = { initiativeTied: false, powerTied: false, player: undefined };
         let playerInitiatives = _.map(this.game.getPlayers(), player => {
             return { player: player, initiative: player.getTotalInitiative(), power: player.getTotalPower() };


### PR DESCRIPTION
Currently the timing is implemented as before either player chooses their plot card. This may not be correct but I'd rather wait for a full ruling on timing before putting more time into it.

![](https://images-cdn.fantasyflightgames.com/filer_public/90/c5/90c5cef9-3012-4b02-a626-36c2c8fd7780/gt31_beneath-the-bridge-of-dream.png)