### PR TITLE
Implement Night's Watch cards from The Shadow City

### DIFF
--- a/server/game/cards/11.1-TSC/FreshRecruits.js
+++ b/server/game/cards/11.1-TSC/FreshRecruits.js
@@ -1,0 +1,48 @@
+const DrawCard = require('../../drawcard');
+
+class FreshRecruits extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Search deck',
+            handler: () => {
+                this.selectedCards = [];
+                this.game.promptForDeckSearch(this.controller, {
+                    activePromptTitle: 'Select cards',
+                    numToSelect: 3,
+                    cardCondition: card => card.getType() === 'character' && this.remainingTraits().some(trait => card.hasTrait(trait)),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
+                    source: this
+                });
+            }
+        });
+    }
+
+    remainingTraits() {
+        const traits = ['Ranger', 'Builder', 'Steward'];
+        return traits.filter(trait => !this.selectedCards.some(card => card.hasTrait(trait)));
+    }
+
+    cardSelected(player, card) {
+        this.selectedCards.push(card);
+        return true;
+    }
+
+    doneSelecting(player) {
+        if(this.selectedCards.length === 0) {
+            this.game.addMessage('{0} plays {1} to search their deck, but does not add any cards to their hand', player, this);
+            return true;
+        }
+
+        for(let card of this.selectedCards) {
+            player.moveCard(card, 'hand');
+        }
+        this.game.addMessage('{0} plays {1} to search their deck and adds {2} to their hand', player, this, this.selectedCards);
+
+        return true;
+    }
+}
+
+FreshRecruits.code = '11007';
+
+module.exports = FreshRecruits;

--- a/server/game/cards/11.1-TSC/JanosSlynt.js
+++ b/server/game/cards/11.1-TSC/JanosSlynt.js
@@ -1,0 +1,23 @@
+const DrawCard = require('../../drawcard');
+
+class JanosSlynt extends DrawCard {
+    setupCardAbilities() {
+        this.forcedReaction({
+            when: {
+                onCardEntersPlay: event => event.card === this && event.playingType === 'outOfShadows'
+            },
+            target: {
+                cardCondition: card => card.controller === this.controller && card.getType() === 'character' && card.isFaction('thenightswatch'),
+                gameAction: 'sacrifice'
+            },
+            handler: context => {
+                this.controller.sacrificeCard(context.target);
+                this.game.addMessage('{0} is forced by {1} to sacrifice {2}', this.controller, this, context.target);
+            }
+        });
+    }
+}
+
+JanosSlynt.code = '11006';
+
+module.exports = JanosSlynt;

--- a/server/game/gamesteps/decksearchprompt.js
+++ b/server/game/gamesteps/decksearchprompt.js
@@ -34,6 +34,8 @@ class DeckSearchPrompt extends UiPrompt {
         super(game);
 
         this.choosingPlayer = choosingPlayer;
+        this.isMultiSelect = properties.numToSelect !== undefined;
+        this.remainingCards = properties.numToSelect || 1;
         if(properties.source && !properties.waitingPromptTitle) {
             this.waitingPromptTitle = 'Waiting for opponent to use ' + properties.source.name;
         }
@@ -106,10 +108,17 @@ class DeckSearchPrompt extends UiPrompt {
             return false;
         }
 
-        if(this.properties.numToSelect !== undefined && this.properties.numToSelect > 1) {
-            this.properties.onSelect(player, card);
-            this.properties.numToSelect--;
-            this.properties.numCards--; // to avoid peaking into one *extra* card
+        if(this.isMultiSelect) {
+            if(this.remainingCards > 0) {
+                this.properties.onSelect(player, card);
+                this.remainingCards--;
+                this.properties.numCards--; // to avoid peaking into one *extra* card
+            }
+
+            if(this.remainingCards === 0) {
+                // Complete the search
+                this.cancelAndShuffle(player);
+            }
 
             return;
         }


### PR DESCRIPTION
Interface for Fresh Recruits is somewhat awkward (requires scrolling the prompt if you have a lot of Ranger/Builder/Steward characters, which you almost certainly will), but works.
![](https://i62.servimg.com/u/f62/19/51/35/85/4006a110.jpg)
![](https://i62.servimg.com/u/f62/19/51/35/85/748f1810.jpg)