### PR TITLE
Allow manual actions to override effects

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -285,9 +285,9 @@ class Game extends EventEmitter {
         }
 
         if(card.kneeled) {
-            player.standCard(card);
+            player.standCard(card, { force: true });
         } else {
-            player.kneelCard(card);
+            player.kneelCard(card, { force: true });
         }
 
         let standStatus = card.kneeled ? 'kneels' : 'stands';

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -926,18 +926,14 @@ class Game extends EventEmitter {
         });
     }
 
-    applyGameAction(actionType, cards, func) {
-        let wasArray = _.isArray(cards);
+    applyGameAction(actionType, cards, func, options = {}) {
+        let wasArray = Array.isArray(cards);
         if(!wasArray) {
             cards = [cards];
         }
-        let [allowed, disallowed] = _.partition(cards, card => card.allowGameAction(actionType));
+        let allowed = options.force ? cards : cards.filter(card => card.allowGameAction(actionType));
 
-        if(!_.isEmpty(disallowed)) {
-            // TODO: add a cannot / immunity message.
-        }
-
-        if(_.isEmpty(allowed)) {
+        if(allowed.length === 0) {
             return;
         }
 

--- a/server/game/gamesteps/killcharacters.js
+++ b/server/game/gamesteps/killcharacters.js
@@ -34,7 +34,7 @@ class KillCharacters extends BaseStep {
                     card.clearDanger();
                 });
             });
-        });
+        }, { force: this.options.force });
     }
 
     handleMultipleKills(event) {
@@ -48,7 +48,7 @@ class KillCharacters extends BaseStep {
     automaticSave(card) {
         if(card.location !== 'play area') {
             this.event.saveCard(card);
-        } else if(!card.canBeKilled()) {
+        } else if(!card.canBeKilled() && !this.options.force) {
             this.game.addMessage('{0} controlled by {1} cannot be killed',
                 card, card.controller);
             this.event.saveCard(card);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1174,7 +1174,7 @@ class Player extends Spectator {
         }
     }
 
-    kneelCard(card) {
+    kneelCard(card, options = {}) {
         if(card.kneeled) {
             return;
         }
@@ -1183,10 +1183,10 @@ class Player extends Spectator {
             card.kneeled = true;
 
             this.game.raiseEvent('onCardKneeled', { player: this, card: card });
-        });
+        }, { force: options.force });
     }
 
-    standCard(card) {
+    standCard(card, options = {}) {
         if(!card.kneeled) {
             return;
         }
@@ -1195,7 +1195,7 @@ class Player extends Spectator {
             card.kneeled = false;
 
             this.game.raiseEvent('onCardStood', { player: this, card: card });
-        });
+        }, { force: options.force });
     }
 
     removeCardFromPile(card) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -939,7 +939,7 @@ class Player extends Spectator {
             }
 
             if(target === 'discard pile') {
-                this.discardCard(card, false);
+                this.discardCard(card, false, { force: true });
                 return true;
             }
 
@@ -983,11 +983,11 @@ class Player extends Spectator {
         });
     }
 
-    discardCard(card, allowSave = true) {
-        this.discardCards([card], allowSave);
+    discardCard(card, allowSave = true, options = {}) {
+        this.discardCards([card], allowSave, () => true, options);
     }
 
-    discardCards(cards, allowSave = true, callback = () => true) {
+    discardCards(cards, allowSave = true, callback = () => true, options = {}) {
         this.game.applyGameAction('discard', cards, cards => {
             var params = {
                 player: this,
@@ -1007,7 +1007,7 @@ class Player extends Spectator {
                     callback(event.cards);
                 }
             });
-        });
+        }, { force: options.force });
     }
 
     returnCardToHand(card, allowSave = true) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -934,7 +934,7 @@ class Player extends Spectator {
             this.putIntoPlay(card, 'play', { force: true });
         } else {
             if(target === 'dead pile' && card.location === 'play area') {
-                this.killCharacter(card, false);
+                this.game.killCharacter(card, { allowSave: false, force: true });
                 return true;
             }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -612,7 +612,7 @@ class Player extends Spectator {
     }
 
     putIntoPlay(card, playingType = 'play', options = {}) {
-        if(!this.canPutIntoPlay(card, playingType, options)) {
+        if(!options.force && !this.canPutIntoPlay(card, playingType, options)) {
             return;
         }
 
@@ -931,7 +931,7 @@ class Player extends Spectator {
         }
 
         if(target === 'play area') {
-            this.putIntoPlay(card);
+            this.putIntoPlay(card, 'play', { force: true });
         } else {
             if(target === 'dead pile' && card.location === 'play area') {
                 this.killCharacter(card, false);

--- a/test/server/integration/ManualActions.spec.js
+++ b/test/server/integration/ManualActions.spec.js
@@ -1,0 +1,48 @@
+describe('manual actions', function() {
+    integration(function() {
+        describe('when cards cannot enter play', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'Barring the Gates',
+                    'Hedge Knight'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.skipSetupPhase();
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should allow them to be dragged into play', function() {
+                let card = this.player1.findCardByName('Hedge Knight', 'hand');
+                this.player1.dragCard(card, 'play area');
+
+                expect(card.location).toBe('play area');
+            });
+        });
+
+        describe('when a character is dead', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Arya Stark (Core)', 'Arya Stark (Core)'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.skipSetupPhase();
+                this.selectFirstPlayer(this.player1);
+
+                [this.character, this.deadCharacter] = this.player1.filterCardsByName('Arya Stark', 'hand');
+
+                this.player1.dragCard(this.deadCharacter, 'dead pile');
+            });
+
+            it('should allow them to be dragged into play', function() {
+                this.player1.dragCard(this.character, 'play area');
+
+                expect(this.character.location).toBe('play area');
+            });
+        });
+    });
+});

--- a/test/server/integration/ManualActions.spec.js
+++ b/test/server/integration/ManualActions.spec.js
@@ -144,5 +144,34 @@ describe('manual actions', function() {
                 expect(this.character.location).toBe('dead pile');
             });
         });
+
+        describe('when a card cannot stand', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'Frozen Expanse',
+                    'Hedge Knight'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.completeSetup();
+
+                this.character = this.player1.findCardByName('Hedge Knight', 'hand');
+
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.character);
+
+                // Manually kneel the character
+                this.player1.clickCard(this.character);
+            });
+
+            it('should allow it to be manually stood', function() {
+                this.player1.clickCard(this.character);
+
+                expect(this.character.kneeled).toBe(false);
+            });
+        });
     });
 });

--- a/test/server/integration/ManualActions.spec.js
+++ b/test/server/integration/ManualActions.spec.js
@@ -99,5 +99,50 @@ describe('manual actions', function() {
                 expect(this.card.location).toBe('discard pile');
             });
         });
+
+        describe('when a card cannot leave play', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Planky Town Trader', 'Hedge Knight'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.completeSetup();
+
+                this.planky = this.player1.findCardByName('Planky Town Trader', 'hand');
+                this.character = this.player1.findCardByName('Hedge Knight', 'hand');
+
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.planky);
+                this.player1.clickPrompt('2');
+
+                // Trigger Planky Town Trader
+                this.player1.dragCard(this.planky, 'hand');
+                this.player1.triggerAbility(this.planky);
+                this.player1.clickCard(this.character);
+            });
+
+            it('should allow it to be dragged to hand', function() {
+                this.player1.dragCard(this.character, 'hand');
+
+                expect(this.character.location).toBe('hand');
+            });
+
+            it('should allow it to be dragged to discard pile', function() {
+                this.player1.dragCard(this.character, 'discard pile');
+
+                expect(this.character.location).toBe('discard pile');
+            });
+
+            it('should allow it to be dragged to dead pile', function() {
+                this.player1.dragCard(this.character, 'dead pile');
+
+                expect(this.character.location).toBe('dead pile');
+            });
+        });
     });
 });

--- a/test/server/integration/ManualActions.spec.js
+++ b/test/server/integration/ManualActions.spec.js
@@ -74,5 +74,30 @@ describe('manual actions', function() {
                 expect(this.character.location).toBe('dead pile');
             });
         });
+
+        describe('when a card cannot be discarded', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'The God\'s Eye'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.card = this.player1.findCardByName('The God\'s Eye', 'hand');
+
+                this.player1.clickCard(this.card);
+
+                this.completeSetup();
+            });
+
+            it('should allow it to be dragged to the discard pile', function() {
+                this.player1.dragCard(this.card, 'discard pile');
+
+                expect(this.card.location).toBe('discard pile');
+            });
+        });
     });
 });

--- a/test/server/integration/ManualActions.spec.js
+++ b/test/server/integration/ManualActions.spec.js
@@ -44,5 +44,35 @@ describe('manual actions', function() {
                 expect(this.character.location).toBe('play area');
             });
         });
+
+        describe('when a character cannot be killed', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Hedge Knight', 'The Eyrie'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Hedge Knight', 'hand');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard('The Eyrie', 'hand');
+
+                this.completeSetup();
+
+                // Prevent the character from being killed
+                this.player1.triggerAbility('The Eyrie');
+                this.player1.clickCard(this.character);
+            });
+
+            it('should allow them to be dragged to the dead pile', function() {
+                this.player1.dragCard(this.character, 'dead pile');
+
+                expect(this.character.location).toBe('dead pile');
+            });
+        });
     });
 });

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -3,7 +3,7 @@ const Player = require('../../../server/game/player.js');
 describe('Player', () => {
     describe('drop()', function() {
         beforeEach(function() {
-            this.gameSpy = jasmine.createSpyObj('game', ['raiseEvent', 'playerDecked']);
+            this.gameSpy = jasmine.createSpyObj('game', ['killCharacter', 'raiseEvent', 'playerDecked']);
 
             this.player = new Player('1', { username: 'Player 1', settings: {} }, true, this.gameSpy);
             this.player.initialise();
@@ -311,7 +311,7 @@ describe('Player', () => {
 
                 let result = this.player.drop(this.cardSpy, 'play area', 'dead pile');
                 expect(result).toBe(true);
-                expect(this.player.killCharacter).toHaveBeenCalledWith(this.cardSpy, false);
+                expect(this.gameSpy.killCharacter).toHaveBeenCalledWith(this.cardSpy, { allowSave: false, force: true });
             });
         });
     });

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -45,7 +45,7 @@ describe('Player', () => {
 
                 it('should return true and add the card to the play area', function() {
                     expect(this.dropSucceeded).toBe(true);
-                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy);
+                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy, 'play', jasmine.objectContaining({ force: true }));
                 });
             });
 
@@ -58,7 +58,7 @@ describe('Player', () => {
 
                 it('should return true and add the card to the play area', function() {
                     expect(this.dropSucceeded).toBe(true);
-                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy);
+                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy, 'play', jasmine.objectContaining({ force: true }));
                 });
             });
 
@@ -84,7 +84,7 @@ describe('Player', () => {
 
                 it('should return true and play the card', function() {
                     expect(this.dropSucceeded).toBe(true);
-                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy);
+                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy, 'play', jasmine.objectContaining({ force: true }));
                 });
             });
         });


### PR DESCRIPTION
Dragging and clicking cards should always work now, even if they have an associated "cannot" effect applied to them.

Fixes #1104 