### PR TITLE
Remove restrictions when blanking an attachment

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -43,12 +43,6 @@ class DrawCard extends BaseCard {
         this.stealthLimit = 1;
         this.minCost = 0;
         this.eventPlacementLocation = 'discard pile';
-
-        // If setupCardAbilities did not set an attachment restriction, default
-        // to allowing attaching on any character.
-        if(this.getType() === 'attachment' && !this.attachmentRestrictions) {
-            this.attachmentRestriction({ type: 'character' });
-        }
     }
 
     createSnapshot() {
@@ -332,6 +326,10 @@ class DrawCard extends BaseCard {
     canAttach(player, card) {
         if(this.getType() !== 'attachment' || !card) {
             return false;
+        }
+
+        if(!this.attachmentRestrictions || this.isAnyBlank()) {
+            return card.getType() === 'character';
         }
 
         let context = { player: player };

--- a/test/server/integration/Attachments.spec.js
+++ b/test/server/integration/Attachments.spec.js
@@ -69,6 +69,50 @@ describe('attachments', function() {
             });
         });
 
+        describe('when a location attachment is blanked', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Catelyn Stark (Core)', 'Brother\'s Robes', 'Winterfell Castle', 'Frozen Solid'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Catelyn Stark', 'hand');
+                this.robes = this.player1.findCardByName('Brother\'s Robes', 'hand');
+                this.location = this.player1.findCardByName('Winterfell Castle', 'hand');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.robes);
+                this.player1.clickCard(this.location);
+
+                this.locationAttachment = this.player2.findCardByName('Frozen Solid', 'hand');
+
+                this.completeSetup();
+
+                // Attach Robes to character
+                this.player1.clickCard(this.robes);
+                this.player1.clickCard(this.character);
+
+                this.selectFirstPlayer(this.player2);
+
+                // Attach Frozen Solid to the location
+                this.player2.clickCard(this.locationAttachment);
+                this.player2.clickCard(this.location);
+
+                // Force activation of the robes
+                this.player1.clickCard(this.character);
+                this.player1.triggerAbility(this.robes);
+                this.player1.clickCard(this.locationAttachment);
+            });
+
+            it('should discard the attachment', function() {
+                expect(this.locationAttachment.location).toBe('discard pile');
+            });
+        });
+
         describe('when an attachment is dependent on another that gets discarded', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('stark', [


### PR DESCRIPTION
Previously, blanking an attachment did not blank the attachment
requirements imposed by the card text (e.g. only certain factions, only
opponent cards, etc). Normally this doesn't make a difference, but if an
attachment specifies that it goes on a location, blanking should cause
it to revert to an attachment for characters, which should cause the
attachment to be discarded as invalid.

Fixes #2014 