### PR TITLE
Fix Hand's Judgment + Nighttime Marauders vs "-" cost cards

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -100,7 +100,7 @@ For more complicated restrictions or restrictions that can't be checked with the
 
 ```javascript
 // Ward - character with cost 4 or less
-this.attachmentRestriction(card => card.getType() === 'character' && card.getCost() <= 4);
+this.attachmentRestriction(card => card.getType() === 'character' && card.getPrintedCost() <= 4);
 ```
 
 ### Persistent effects

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -291,6 +291,10 @@ class BaseCard {
         return (value === 'X' ? 0 : value) || 0;
     }
 
+    translateXValue(value) {
+        return value === '-' ? 0 : value;
+    }
+
     hasKeyword(keyword) {
         if(this.losesAllAspects.contains('keywords')) {
             return false;

--- a/server/game/cards/01-Core/ArianneMartell.js
+++ b/server/game/cards/01-Core/ArianneMartell.js
@@ -7,7 +7,7 @@ class ArianneMartell extends DrawCard {
             limit: ability.limit.perPhase(1),
             target: {
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller &&
-                                       card.getCost() <= 5 && card.getType() === 'character' && this.controller.canPutIntoPlay(card)
+                                       card.getPrintedCost() <= 5 && card.getType() === 'character' && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.player.putIntoPlay(context.target);

--- a/server/game/cards/01-Core/LordsportShipright.js
+++ b/server/game/cards/01-Core/LordsportShipright.js
@@ -21,7 +21,7 @@ class LordsportShipright extends DrawCard {
     cardCondition(card) {
         let cost = this.controller.firstPlayer ? 3 : 2;
 
-        return !card.kneeled && card.getType() === 'location' && card.getCost() <= cost && card.location === 'play area';
+        return !card.kneeled && card.getType() === 'location' && card.getPrintedCost() <= cost && card.location === 'play area';
     }
 }
 

--- a/server/game/cards/01-Core/Reinforcement.js
+++ b/server/game/cards/01-Core/Reinforcement.js
@@ -6,7 +6,7 @@ class Reinforcements extends PlotCard {
             target: {
                 cardCondition: card => (
                     this.controller === card.controller &&
-                    card.getCost() <= 5 &&
+                    card.getPrintedCost() <= 5 &&
                     card.getType() === 'character' &&
                     ['hand', 'discard pile'].includes(card.location) &&
                     this.controller.canPutIntoPlay(card)

--- a/server/game/cards/01-Core/TakeTheBlack.js
+++ b/server/game/cards/01-Core/TakeTheBlack.js
@@ -17,7 +17,7 @@ class TakeTheBlack extends DrawCard {
     }
 
     cardCondition(card) {
-        return card.controller !== this.controller && card.getType() === 'character' && !card.isUnique() && card.getCost() <= 6;
+        return card.controller !== this.controller && card.getType() === 'character' && !card.isUnique() && card.getPrintedCost() <= 6;
     }
 }
 

--- a/server/game/cards/01-Core/TheHandsJudgment.js
+++ b/server/game/cards/01-Core/TheHandsJudgment.js
@@ -28,7 +28,7 @@ class TheHandsJudgment extends DrawCard {
             return super.getCost();
         }
 
-        return this.eventToInterrupt.getPrintedCost();
+        return this.translateXValue(this.eventToInterrupt.getPrintedCost());
     }
 }
 

--- a/server/game/cards/01-Core/TheThingsIDoForLove.js
+++ b/server/game/cards/01-Core/TheThingsIDoForLove.js
@@ -15,7 +15,7 @@ class TheThingsIDoForLove extends DrawCard {
             ],
             target: {
                 cardCondition: (card, context) => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character' &&
-                                                  (context.xValue ? (card.getCost() <= context.xValue) : (card.getCost() <= this.controller.getSpendableGold()))
+                                                  (context.xValue ? (card.getPrintedCost() <= context.xValue) : (card.getPrintedCost() <= this.controller.getSpendableGold()))
             },
             handler: context => {
                 context.target.controller.returnCardToHand(context.target);
@@ -28,7 +28,7 @@ class TheThingsIDoForLove extends DrawCard {
     getMinimumCharCost() {
         let opponents = this.game.getOpponents(this.controller);
         let opponentCharacters = _.flatten(opponents.map(opponent => opponent.filterCardsInPlay(card => card.getType() === 'character')));
-        let charCosts = _.map(opponentCharacters, card => card.getCost());
+        let charCosts = _.map(opponentCharacters, card => card.getPrintedCost());
 
         return _.min(charCosts);
     }

--- a/server/game/cards/01-Core/TheThingsIDoForLove.js
+++ b/server/game/cards/01-Core/TheThingsIDoForLove.js
@@ -27,7 +27,7 @@ class TheThingsIDoForLove extends DrawCard {
 
     getMinimumCharCost() {
         let opponents = this.game.getOpponents(this.controller);
-        let opponentCharacters = _.flatten(opponents.map(opponent => opponent.filterCardsInPlay(card => card.getType() === 'character')));
+        let opponentCharacters = _.flatten(opponents.map(opponent => opponent.filterCardsInPlay(card => card.getType() === 'character' && card.hasPrintedCost())));
         let charCosts = _.map(opponentCharacters, card => card.getPrintedCost());
 
         return _.min(charCosts);

--- a/server/game/cards/01-Core/Yoren.js
+++ b/server/game/cards/01-Core/Yoren.js
@@ -7,7 +7,7 @@ class Yoren extends DrawCard {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             target: {
-                cardCondition: card => card.location === 'discard pile' && card.getType() === 'character' && card.owner !== this.controller && card.getCost() <= 3 && this.controller.canPutIntoPlay(card)
+                cardCondition: card => card.location === 'discard pile' && card.getType() === 'character' && card.owner !== this.controller && card.getPrintedCost() <= 3 && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/02.1-TtB/HereToServe.js
+++ b/server/game/cards/02.1-TtB/HereToServe.js
@@ -6,7 +6,7 @@ class HereToServe extends PlotCard {
             handler: () => {
                 this.game.promptForDeckSearch(this.controller, {
                     activePromptTitle: 'Select a card',
-                    cardCondition: card => card.hasTrait('Maester') && card.getCost() <= 3 && this.controller.canPutIntoPlay(card),
+                    cardCondition: card => card.hasTrait('Maester') && card.getPrintedCost() <= 3 && this.controller.canPutIntoPlay(card),
                     onSelect: (player, card) => this.cardSelected(player, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this

--- a/server/game/cards/02.1-TtB/SupportOfThePeople.js
+++ b/server/game/cards/02.1-TtB/SupportOfThePeople.js
@@ -13,7 +13,7 @@ class SupportOfThePeople extends DrawCard {
             handler: () => {
                 this.game.promptForDeckSearch(this.controller, {
                     activePromptTitle: 'Select a location',
-                    cardCondition: card => card.getType() === 'location' && card.getCost() <= 3,
+                    cardCondition: card => card.getType() === 'location' && card.getPrintedCost() <= 3,
                     onSelect: (player, card) => this.cardSelected(player, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this

--- a/server/game/cards/02.3-TKP/NewlyMadeLord.js
+++ b/server/game/cards/02.3-TKP/NewlyMadeLord.js
@@ -9,7 +9,7 @@ class NewlyMadeLord extends DrawCard {
             target: {
                 activePromptTitle: 'Select a location',
                 cardCondition: card => card.location === 'play area' && card.getType() === 'location' &&
-                                       !card.isLimited() && card.getCost() <= 3,
+                                       !card.isLimited() && card.getPrintedCost() <= 3,
                 gameAction: 'discard'
             },
             handler: context => {

--- a/server/game/cards/02.3-TKP/SerGregorClegane.js
+++ b/server/game/cards/02.3-TKP/SerGregorClegane.js
@@ -26,7 +26,7 @@ class SerGregorClegane extends DrawCard {
     }
 
     cardCondition(discarded, card) {
-        return card.location === 'play area' && card.getType() === 'character' && card.getCost() === discarded.getCost();
+        return card.location === 'play area' && card.getType() === 'character' && card.getPrintedCost() === discarded.getPrintedCost();
     }
 
     onCardSelected(player, card) {

--- a/server/game/cards/02.4-NMG/TheFirstSnowOfWinter.js
+++ b/server/game/cards/02.4-NMG/TheFirstSnowOfWinter.js
@@ -17,7 +17,7 @@ class TheFirstSnowOfWinter extends PlotCard {
     }
 
     returnCardsToHand(player) {
-        let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.getPrintedCost() <= 3);
+        let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.hasPrintedCost() && card.getPrintedCost() <= 3);
         _.each(characters, card => {
             player.returnCardToHand(card);
         });

--- a/server/game/cards/02.4-NMG/TheFirstSnowOfWinter.js
+++ b/server/game/cards/02.4-NMG/TheFirstSnowOfWinter.js
@@ -17,7 +17,7 @@ class TheFirstSnowOfWinter extends PlotCard {
     }
 
     returnCardsToHand(player) {
-        let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.getCost() <= 3);
+        let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.getPrintedCost() <= 3);
         _.each(characters, card => {
             player.returnCardToHand(card);
         });

--- a/server/game/cards/02.6-TS/DagmerCleftjaw.js
+++ b/server/game/cards/02.6-TS/DagmerCleftjaw.js
@@ -15,7 +15,7 @@ class DagmerCleftjaw extends DrawCard {
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card.getType() === 'location' &&
-                    card.getCost() <= 3 &&
+                    card.getPrintedCost() <= 3 &&
                     !card.isLimited() &&
                     card.controller === this.game.currentChallenge.loser)
             },

--- a/server/game/cards/02.6-TS/SerIlynPayne.js
+++ b/server/game/cards/02.6-TS/SerIlynPayne.js
@@ -7,7 +7,7 @@ class SerIlynPayne extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
             target: {
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getCost() <= 3,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getPrintedCost() <= 3,
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/02.6-TS/Ward.js
+++ b/server/game/cards/02.6-TS/Ward.js
@@ -2,7 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Ward extends DrawCard {
     setupCardAbilities(ability) {
-        this.attachmentRestriction(card => card.getType() === 'character' && card.getCost() <= 4);
+        this.attachmentRestriction(card => card.getType() === 'character' && card.getPrintedCost() <= 4);
         this.whileAttached({
             effect: [
                 ability.effects.addFaction('stark'),

--- a/server/game/cards/03-WotN/ATimeForWolves.js
+++ b/server/game/cards/03-WotN/ATimeForWolves.js
@@ -18,7 +18,7 @@ class ATimeForWolves extends PlotCard {
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
 
-        if(card.getCost() > 3 || !this.controller.canPutIntoPlay(card)) {
+        if(card.getPrintedCost() > 3 || !this.controller.canPutIntoPlay(card)) {
             this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
                 player, this, card);
             return;

--- a/server/game/cards/03-WotN/AsHardAsWinter.js
+++ b/server/game/cards/03-WotN/AsHardAsWinter.js
@@ -12,7 +12,7 @@ class AsHardAsWinter extends DrawCard {
                     card.location === 'hand' &&
                     card.getType() === 'character' &&
                     card.isFaction('stark') &&
-                    card.getCost() <= context.event.card.getCost() &&
+                    card.getPrintedCost() <= context.event.card.getPrintedCost() &&
                     this.controller.canPutIntoPlay(card)
                 )
             },

--- a/server/game/cards/03-WotN/FrozenSolid.js
+++ b/server/game/cards/03-WotN/FrozenSolid.js
@@ -2,7 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class FrozenSolid extends DrawCard {
     setupCardAbilities(ability) {
-        this.attachmentRestriction(card => card.getType() === 'location' && !card.isLimited() && card.getCost() <= 3);
+        this.attachmentRestriction(card => card.getType() === 'location' && !card.isLimited() && card.getPrintedCost() <= 3);
         this.whileAttached({
             effect: ability.effects.blankExcludingTraits
         });

--- a/server/game/cards/04.3-FFH/BattleOfOxcross.js
+++ b/server/game/cards/04.3-FFH/BattleOfOxcross.js
@@ -10,7 +10,7 @@ class BattleOfOxcross extends PlotCard {
                 && this.game.currentChallenge.number <= 1,
             match: (card) =>
                 card.getType() === 'character'
-                && card.getCost() >= 4,
+                && card.getPrintedCost() >= 4,
             targetController: 'opponent',
             effect: ability.effects.cannotBeDeclaredAsDefender()
         });

--- a/server/game/cards/04.5-GoH/JoffreyBaratheon.js
+++ b/server/game/cards/04.5-GoH/JoffreyBaratheon.js
@@ -13,7 +13,7 @@ class JoffreyBaratheon extends DrawCard {
             ],
             target: {
                 cardCondition: (card, context) => card.location === 'play area' && !card.hasTrait('King') && card.getType() === 'character' &&
-                                                  card.getCost() < context.event.card.getCost(),
+                                                  card.getPrintedCost() < context.event.card.getPrintedCost(),
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/04.5-GoH/QuietAsAShadow.js
+++ b/server/game/cards/04.5-GoH/QuietAsAShadow.js
@@ -5,7 +5,7 @@ class QuietAsAShadow extends DrawCard {
         this.action({
             title: 'Give character stealth',
             target: {
-                cardCondition: card => card.isUnique() && card.getType() === 'character' && card.getCost() <= 3 && card.location === 'play area'
+                cardCondition: card => card.isUnique() && card.getType() === 'character' && card.getPrintedCost() <= 3 && card.location === 'play area'
             },
             handler: context => {
                 this.untilEndOfPhase(ability => ({

--- a/server/game/cards/05-LoCR/AlerieTyrell.js
+++ b/server/game/cards/05-LoCR/AlerieTyrell.js
@@ -10,7 +10,7 @@ class AlerieTyrell extends DrawCard {
                 this.game.promptForDeckSearch(this.controller, {
                     numCards: 10,
                     activePromptTitle: 'Select a card',
-                    cardCondition: card => card.getType() === 'character' && card.isFaction('tyrell') && card.getCost() <= 3,
+                    cardCondition: card => card.getType() === 'character' && card.isFaction('tyrell') && card.getPrintedCost() <= 3,
                     onSelect: (player, card) => this.cardSelected(player, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this

--- a/server/game/cards/05-LoCR/RedKeepSpy.js
+++ b/server/game/cards/05-LoCR/RedKeepSpy.js
@@ -12,7 +12,7 @@ class RedKeepSpy extends DrawCard {
                     card.controller !== this.controller &&
                     card.controller.hand.length < this.controller.hand.length &&
                     card.getType() === 'character' &&
-                    card.getCost() <= 3)
+                    card.getPrintedCost() <= 3)
             },
             handler: context => {
                 context.target.owner.returnCardToHand(context.target);

--- a/server/game/cards/05-LoCR/ShieldOfLannisport.js
+++ b/server/game/cards/05-LoCR/ShieldOfLannisport.js
@@ -19,7 +19,7 @@ class ShieldOfLannisport extends DrawCard {
         return !this.controller.anyCardsInPlay(card => (
             card !== this.parent &&
             (card.hasTrait('Lord') || card.hasTrait('Lady')) &&
-            card.getCost() >= 4
+            card.getPrintedCost() >= 4
         ));
     }
 }

--- a/server/game/cards/05-LoCR/SummonedToCourt.js
+++ b/server/game/cards/05-LoCR/SummonedToCourt.js
@@ -42,7 +42,7 @@ class SummonedToCourt extends PlotCard {
     }
 
     chooseCard(player, card) {
-        this.playerChoices.push({ player: player, card: card, cost: card.getCost() });
+        this.playerChoices.push({ player: player, card: card, cost: card.getPrintedCost() });
         this.promptNextPlayerForChoice();
         return true;
     }

--- a/server/game/cards/05-LoCR/TimettSonOfTimett.js
+++ b/server/game/cards/05-LoCR/TimettSonOfTimett.js
@@ -11,7 +11,7 @@ class TimettSonOfTimett extends DrawCard {
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card.getType() === 'character' &&
-                    card.getCost() <= this.getNumberOfClansmen()),
+                    card.getPrintedCost() <= this.getNumberOfClansmen()),
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/06.2-GtR/GreatHall.js
+++ b/server/game/cards/06.2-GtR/GreatHall.js
@@ -8,7 +8,7 @@ class GreatHall extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
             handler: context => {
-                let amount = card => card.getCost() >= 6 ? 2 : 1;
+                let amount = card => card.getPrintedCost() >= 6 ? 2 : 1;
                 this.game.addMessage('{0} kneels {1} to reduce the cost of the next unique character by 1 (by 2 if it has cost of 6 or more)', context.player, this);
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,

--- a/server/game/cards/06.2-GtR/GuardingTheRealm.js
+++ b/server/game/cards/06.2-GtR/GuardingTheRealm.js
@@ -7,7 +7,7 @@ class GuardingTheRealm extends DrawCard {
             phase: 'marshal',
             target: {
                 cardCondition: card => card.controller !== this.controller && card.location === 'discard pile' &&
-                                       card.getType() === 'character' && card.getCost() <= 3 && this.controller.canPutIntoPlay(card)
+                                       card.getType() === 'character' && card.getPrintedCost() <= 3 && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/06.2-GtR/WexPyke.js
+++ b/server/game/cards/06.2-GtR/WexPyke.js
@@ -5,7 +5,7 @@ class WexPyke extends DrawCard {
         this.persistentEffect({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this),
             targetController: 'any',
-            match: card => card.getType() === 'character' && card.getCost() === this.tokens['gold'],
+            match: card => card.getType() === 'character' && card.getPrintedCost() === this.tokens['gold'],
             effect: ability.effects.cannotBeDeclaredAsDefender()
         });
 

--- a/server/game/cards/06.3-TFoA/Duel.js
+++ b/server/game/cards/06.3-TFoA/Duel.js
@@ -23,7 +23,7 @@ class Duel extends PlotCard {
                         card.location === 'play area' &&
                         !card.hasTrait('Army') &&
                         card.getType() === 'character' &&
-                        card.getCost() >= 6),
+                        card.getPrintedCost() >= 6),
                     onSelect: (player, cards) => this.targetsSelected(player, cards)
                 });
             }
@@ -65,7 +65,7 @@ class Duel extends PlotCard {
     }
 
     notEnoughTargets() {
-        let targets = this.game.findAnyCardsInPlay(card => !card.hasTrait('Army') && card.getType() === 'character' && card.getCost() >= 6);
+        let targets = this.game.findAnyCardsInPlay(card => !card.hasTrait('Army') && card.getType() === 'character' && card.getPrintedCost() >= 6);
         return targets.length <= 1;
     }
 }

--- a/server/game/cards/06.4-TRW/BreakerOfChains.js
+++ b/server/game/cards/06.4-TRW/BreakerOfChains.js
@@ -17,7 +17,7 @@ class BreakerOfChains extends DrawCard {
                     card.location === 'hand'
                     && card.controller === this.controller
                     && card.getType() === 'character'
-                    && card.getCost() <= 2
+                    && card.getPrintedCost() <= 2
                     && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
@@ -28,7 +28,7 @@ class BreakerOfChains extends DrawCard {
     }
 
     getSTRBoost() {
-        return this.controller.getNumberOfCardsInPlay(card => card.getType() === 'character' && card.getCost() <= 2);
+        return this.controller.getNumberOfCardsInPlay(card => card.getType() === 'character' && card.getPrintedCost() <= 2);
     }
 }
 

--- a/server/game/cards/06.4-TRW/TywinsStratagem.js
+++ b/server/game/cards/06.4-TRW/TywinsStratagem.js
@@ -8,7 +8,7 @@ class TywinsStratagem extends DrawCard {
             title: 'Return characters to hand',
             phase: 'challenge',
             target: {
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getCost() <= 2,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getPrintedCost() <= 2,
                 mode: 'eachPlayer',
                 gameAction: 'returnToHand'
             },

--- a/server/game/cards/06.5-OR/FleaBottom.js
+++ b/server/game/cards/06.5-OR/FleaBottom.js
@@ -7,7 +7,7 @@ class FleaBottom extends DrawCard {
             phase: 'challenge',
             target: {
                 cardCondition: card => card.location === 'discard pile' && card.controller === this.controller &&
-                                       card.getType() === 'character' && card.getCost() <= 3 && this.controller.canPutIntoPlay(card)
+                                       card.getType() === 'character' && card.getPrintedCost() <= 3 && this.controller.canPutIntoPlay(card)
             },
             cost: [
                 ability.costs.payGold(1),

--- a/server/game/cards/06.5-OR/MutinyAtCrastersKeep.js
+++ b/server/game/cards/06.5-OR/MutinyAtCrastersKeep.js
@@ -8,7 +8,7 @@ class MutinyAtCrastersKeep extends DrawCard {
             title: 'Discard character from play',
             phase: 'dominance',
             cost: ability.costs.sacrifice(card =>
-                card.getType() === 'character' && card.getCost() === this.getHighestCharacterCost()),
+                card.getType() === 'character' && card.getPrintedCost() === this.getHighestCharacterCost()),
             target: {
                 cardCondition: card => card.location === 'play area' && card.controller !== this.controller &&
                                        card.getType() === 'character'
@@ -23,7 +23,7 @@ class MutinyAtCrastersKeep extends DrawCard {
 
     getHighestCharacterCost() {
         let charactersInPlay = this.controller.filterCardsInPlay(card => card.getType() === 'character');
-        let costs = _.map(charactersInPlay, card => card.getCost());
+        let costs = _.map(charactersInPlay, card => card.getPrintedCost());
         return _.max(costs);
     }
 }

--- a/server/game/cards/06.5-OR/MutinyAtCrastersKeep.js
+++ b/server/game/cards/06.5-OR/MutinyAtCrastersKeep.js
@@ -22,7 +22,7 @@ class MutinyAtCrastersKeep extends DrawCard {
     }
 
     getHighestCharacterCost() {
-        let charactersInPlay = this.controller.filterCardsInPlay(card => card.getType() === 'character');
+        let charactersInPlay = this.controller.filterCardsInPlay(card => card.getType() === 'character' && card.hasPrintedCost());
         let costs = _.map(charactersInPlay, card => card.getPrintedCost());
         return _.max(costs);
     }

--- a/server/game/cards/07-WotW/NowMyWatchBegins.js
+++ b/server/game/cards/07-WotW/NowMyWatchBegins.js
@@ -7,7 +7,7 @@ class NowMyWatchBegins extends DrawCard {
                 onCardPlaced: event => event.card.location === 'discard pile' &&
                                        event.player !== this.controller &&
                                        event.card.getType() === 'character' &&
-                                       event.card.getCost() <= 5 &&
+                                       event.card.getPrintedCost() <= 5 &&
                                        this.controller.canPutIntoPlay(event.card)
             },
             handler: (context) => {

--- a/server/game/cards/07-WotW/PlazaOfPride.js
+++ b/server/game/cards/07-WotW/PlazaOfPride.js
@@ -11,7 +11,7 @@ class PlazaOfPride extends DrawCard {
             target: {
                 cardCondition: (card, context) =>
                     card.location === 'play area' && card.getType() === 'character' && card.kneeled &&
-                    (!context.costs.discardFromHand || card.getCost() <= context.costs.discardFromHand.getCost() + 3)
+                    (!context.costs.discardFromHand || card.getPrintedCost() <= context.costs.discardFromHand.getPrintedCost() + 3)
             },
             handler: context => {
                 context.target.controller.standCard(context.target);

--- a/server/game/cards/08.1-TAK/Ashemark.js
+++ b/server/game/cards/08.1-TAK/Ashemark.js
@@ -14,7 +14,7 @@ class Ashemark extends DrawCard {
             ],
             handler: context => {
                 _.each(this.game.getPlayers(), player => {
-                    let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.getPrintedCost() <= context.cardStateWhenInitiated.tokens.gold);
+                    let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.hasPrintedCost() && card.getPrintedCost() <= context.cardStateWhenInitiated.tokens.gold);
                     _.each(characters, card => {
                         card.owner.returnCardToHand(card);
                     });

--- a/server/game/cards/08.2-JtO/DevanSeaworth.js
+++ b/server/game/cards/08.2-JtO/DevanSeaworth.js
@@ -34,7 +34,7 @@ class DevanSeaworth extends DrawCard {
     }
 
     getMinimumDiscardGoldAmount() {
-        let deckLocations = this.controller.drawDeck.filter(card => card.getType() === 'location');
+        let deckLocations = this.controller.drawDeck.filter(card => card.getType() === 'location' && card.hasPrintedCost());
         let deckCosts = _.map(deckLocations, card => card.getPrintedCost());
         let lowestCost = _.min(deckCosts);
 

--- a/server/game/cards/08.4-FotOG/HightowerSpy.js
+++ b/server/game/cards/08.4-FotOG/HightowerSpy.js
@@ -11,7 +11,7 @@ class HightowerSpy extends DrawCard {
             },
             handler: context => {
                 let topCard = this.controller.drawDeck[0];
-                let increase = topCard.getCost();
+                let increase = topCard.getPrintedCost();
 
                 this.untilEndOfPhase(ability => ({
                     match: context.target,

--- a/server/game/cards/08.5-TFM/SacrificeToTheRedGod.js
+++ b/server/game/cards/08.5-TFM/SacrificeToTheRedGod.js
@@ -13,7 +13,7 @@ class SacrificeToTheRedGod extends DrawCard {
                     cardCondition: card =>
                         card.getType() === 'character' &&
                         card.hasTrait('R\'hllor') &&
-                        card.getCost() <= context.costs.sacrifice.getCost(),
+                        card.getPrintedCost() <= context.costs.sacrifice.getPrintedCost(),
                     onSelect: (player, card) => this.cardSelected(player, context.costs.sacrifice, card),
                     onCancel: player => this.doneSelecting(player, context.costs.sacrifice),
                     source: this

--- a/server/game/cards/08.5-TFM/SerPounce.js
+++ b/server/game/cards/08.5-TFM/SerPounce.js
@@ -2,7 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class SerPounce extends DrawCard {
     setupCardAbilities(ability) {
-        this.attachmentRestriction(card => card.getType() === 'character' && card.isUnique() && card.getCost() <= 3);
+        this.attachmentRestriction(card => card.getType() === 'character' && card.isUnique() && card.getPrintedCost() <= 3);
         this.whileAttached({
             effect: ability.effects.addIcon('intrigue')
         });

--- a/server/game/cards/10-SoD/NoUseForGrief.js
+++ b/server/game/cards/10-SoD/NoUseForGrief.js
@@ -15,7 +15,7 @@ class NoUseForGrief extends DrawCard {
 
                 this.game.promptForDeckSearch(context.player, {
                     activePromptTitle: 'Select a card',
-                    cardCondition: card => card.hasTrait('Sand Snake') && card.getType() === 'character' && card.getCost() <= costLimit,
+                    cardCondition: card => card.hasTrait('Sand Snake') && card.getType() === 'character' && card.getPrintedCost() <= costLimit,
                     onSelect: (player, card) => this.cardSelected(player, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this

--- a/server/game/cards/11.1-TSC/BoltonFlayer.js
+++ b/server/game/cards/11.1-TSC/BoltonFlayer.js
@@ -17,7 +17,7 @@ class BoltonFlayer extends DrawCard {
     }
 
     lowestPrintedCost() {
-        let charactersInPlay = this.game.filterCardsInPlay(card => card.getType() === 'character');
+        let charactersInPlay = this.game.filterCardsInPlay(card => card.getType() === 'character' && card.hasPrintedCost());
         let costs = charactersInPlay.map(card => card.getPrintedCost());
         return costs.reduce((lowest, cost) => Math.min(lowest, cost));
     }

--- a/server/game/cards/11.1-TSC/NighttimeMarauders.js
+++ b/server/game/cards/11.1-TSC/NighttimeMarauders.js
@@ -12,7 +12,7 @@ class NighttimeMarauders extends DrawCard {
             },
             handler: context => {
                 let opponent = context.target.controller;
-                let cardsToDiscard = opponent.hand.filter(card => card.getPrintedCost() === context.target.getPrintedCost());
+                let cardsToDiscard = opponent.hand.filter(card => card.hasPrintedCost() && card.getPrintedCost() === context.target.getPrintedCost());
                 opponent.discardCards(cardsToDiscard, false);
                 this.game.addMessage('{0} uses {1} to choose {2} and have {3} reveal their hand: {4}', this.controller, this, context.target, opponent, opponent.hand);
                 this.game.addMessage('{0} discards {1}', opponent, cardsToDiscard);

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -130,6 +130,10 @@ class DrawCard extends BaseCard {
         return this.icons.contains(icon);
     }
 
+    hasPrintedCost() {
+        return this.cardData.cost !== '-';
+    }
+
     getPrintedCost() {
         return this.getPrintedNumberFor(this.cardData.cost);
     }

--- a/test/server/cards/01-Core/TheHandsJudgment.spec.js
+++ b/test/server/cards/01-Core/TheHandsJudgment.spec.js
@@ -63,4 +63,35 @@ describe('The Hand\'s Judgment', function() {
             });
         });
     });
+
+    describe('vs - cost events', function() {
+        integration(function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'A Noble Cause',
+                    'Beneath the Bridge of Dream', 'The Hand\'s Judgment'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.event = this.player2.findCardByName('Beneath the Bridge of Dream', 'hand');
+
+                this.player2.clickCard(this.event);
+
+                this.completeSetup();
+
+                this.player2.triggerAbility(this.event);
+            });
+
+            it('should allow cancel at 0 cost', function() {
+                // Because Beneath the Bridge of Dream triggers before plot
+                // reveals, each player has 0 gold, so just checking that Hand's
+                // Judgment can be triggered is sufficient.
+                expect(this.player1).toAllowAbilityTrigger('The Hand\'s Judgment');
+            });
+        });
+    });
 });


### PR DESCRIPTION
Does not fix being able to target "-" cards for prompts that interact with printed cost.