### PR TITLE
Fix games being killed off when a player reconnects

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1007,7 +1007,7 @@ class Game extends EventEmitter {
     failedConnect(playerName) {
         var player = this.playersAndSpectators[playerName];
 
-        if(!player) {
+        if(!player || player.connectionSucceeded) {
             return;
         }
 

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -313,6 +313,7 @@ class GameServer {
 
         player.lobbyId = player.id;
         player.id = socket.id;
+        player.connectionSucceeded = true;
         if(player.disconnected) {
             logger.info('user \'%s\' reconnected to game', socket.user.username);
             game.reconnect(socket, player.name);


### PR DESCRIPTION
since failed connect notices trigger whenever anything bad happens on the socket, even after connecting, don't let those received after initial connect is made allow the game to be considered 'finished'