### PR TITLE
Implement saves using singular events

### DIFF
--- a/server/game/cards/01-Core/BodyGuard.js
+++ b/server/game/cards/01-Core/BodyGuard.js
@@ -6,13 +6,13 @@ class BodyGuard extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.cards.includes(this.parent) && this.parent.canBeSaved() && event.allowSave,
-                onCardsDiscarded: event => event.cards.includes(this.parent) && this.parent.canBeSaved() && event.allowSave
+                onCharacterKilled: event => event.card === this.parent && this.parent.canBeSaved() && event.allowSave,
+                onCardDiscarded: event => event.card === this.parent && this.parent.canBeSaved() && event.allowSave
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
                 let parent = context.cardStateWhenInitiated.parent;
-                context.event.saveCard(parent);
+                context.event.saveCard();
                 this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, parent);
             }
         });

--- a/server/game/cards/01-Core/MaesterAemon.js
+++ b/server/game/cards/01-Core/MaesterAemon.js
@@ -5,14 +5,11 @@ class MaesterAemon extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && event.card.isFaction('thenightswatch') && event.card.controller === this.controller
             },
             cost: ability.costs.kneelSelf(),
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && card.isFaction('thenightswatch') && card.controller === this.controller
-            },
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
                 this.game.addMessage('{0} kneels {1} to save {2}', this.controller, this, context.target);
             }
         });

--- a/server/game/cards/01-Core/RisenFromTheSea.js
+++ b/server/game/cards/01-Core/RisenFromTheSea.js
@@ -5,21 +5,18 @@ class RisenFromTheSea extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: () => true
+                onCharacterKilled: event => this.canSaveVsEvent(event)
             },
             location: 'hand',
-            target: {
-                cardCondition: (card, context) => this.cardCondition(card, context)
-            },
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
 
-                if(this.controller.canAttach(this, context.target)) {
-                    this.controller.attach(this.controller, this, context.target, 'play');
+                if(this.controller.canAttach(this, context.event.card)) {
+                    this.controller.attach(this.controller, this, context.event.card, 'play');
                     this.setCardType('attachment');
                 }
 
-                this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.target);
+                this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.event.card);
             }
         });
 
@@ -37,18 +34,20 @@ class RisenFromTheSea extends DrawCard {
         });
     }
 
-    cardCondition(card, context) {
-        if(!context.event.cards.includes(card) || !card.canBeSaved()) {
+    canSaveVsEvent(event) {
+        let card = event.card;
+
+        if(!card.canBeSaved()) {
             return false;
         }
 
-        let allowSave = context.event.allowSave || this.canSurviveBurn(card, context);
+        let allowSave = event.allowSave || event.isBurn && this.canSurviveBurn(card);
 
         return allowSave && card.isFaction('greyjoy') && card.controller === this.controller;
     }
 
-    canSurviveBurn(card, context) {
-        return context.event.isBurn && card.controller.canAttach(this, card) && card.getBoostedStrength(1 + card.burnValue) > 0;
+    canSurviveBurn(card) {
+        return card.controller.canAttach(this, card) && card.getBoostedStrength(1 + card.burnValue) > 0;
     }
 
     // Explicitly override since it has printed type 'event'.

--- a/server/game/cards/02.5-COW/BloodMagicRitual.js
+++ b/server/game/cards/02.5-COW/BloodMagicRitual.js
@@ -5,21 +5,18 @@ class BloodMagicRitual extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && !event.card.hasTrait('Army')
             },
             location: 'hand',
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && !card.hasTrait('Army')
-            },
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
 
-                if(this.controller.canAttach(this, context.target)) {
-                    this.controller.attach(this.controller, this, context.target, 'play');
+                if(this.controller.canAttach(this, context.event.card)) {
+                    this.controller.attach(this.controller, this, context.event.card, 'play');
                     this.setCardType('attachment');
                 }
 
-                this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.target);
+                this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.event.card);
             }
         });
 

--- a/server/game/cards/02.5-COW/IronMines.js
+++ b/server/game/cards/02.5-COW/IronMines.js
@@ -5,15 +5,12 @@ class IronMines extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && event.card.controller === this.controller
             },
             cost: ability.costs.sacrificeSelf(),
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && card.controller === context.player
-            },
             handler: context => {
-                context.event.saveCard(context.target);
-                this.game.addMessage('{0} sacrifices {1} to save {2}', context.player, this, context.target);
+                context.event.saveCard();
+                this.game.addMessage('{0} sacrifices {1} to save {2}', context.player, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/02.6-TS/SerBarristanSelmy.js
+++ b/server/game/cards/02.6-TS/SerBarristanSelmy.js
@@ -5,16 +5,13 @@ class SerBarristanSelmy extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
-            },
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && this.isControlledLordOrLady(card)
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && this.isControlledLordOrLady(event.card)
             },
             cost: ability.costs.standSelf(),
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
                 this.game.addMessage('{0} stands {1} to save {2}',
-                    this.controller, this, context.target);
+                    this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/03-WotN/HealingExpertise.js
+++ b/server/game/cards/03-WotN/HealingExpertise.js
@@ -5,17 +5,14 @@ class HealingExpertise extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && !event.card.hasTrait('Army') && event.card.controller === this.controller
             },
             location: 'hand',
             cost: ability.costs.kneel(card => card.hasTrait('Maester') && card.getType() === 'character'),
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && !card.hasTrait('Army') && card.controller === this.controller
-            },
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
                 this.game.addMessage('{0} plays {1} to kneel {2} to save {3}',
-                    this.controller, this, context.costs.kneel, context.target);
+                    this.controller, this, context.costs.kneel, context.event.card);
             }
         });
     }

--- a/server/game/cards/03-WotN/JoryCassel.js
+++ b/server/game/cards/03-WotN/JoryCassel.js
@@ -20,7 +20,7 @@ class JoryCassel extends DrawCard {
 
                 context.event.saveCard();
 
-                if(toKill.this.canGainPower && this.game.anyPlotHasTrait('Winter')) {
+                if(toKill.canGainPower() && this.game.anyPlotHasTrait('Winter')) {
                     toKill.modifyPower(1);
                     message += ' and have it gain 1 power';
                 }

--- a/server/game/cards/03-WotN/JoryCassel.js
+++ b/server/game/cards/03-WotN/JoryCassel.js
@@ -5,28 +5,22 @@ class JoryCassel extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
-            },
-            cost: ability.costs.sacrificeSelf(),
-            target: {
-                cardCondition: (card, context) => (
-                    card.location === 'play area' &&
-                    context.event.cards.includes(card) &&
-                    card.canBeSaved() &&
-                    card.controller === this.controller &&
-                    card.isUnique() &&
-                    card.isFaction('stark')
+                onCharacterKilled: event => (
+                    event.allowSave &&
+                    event.card.canBeSaved() &&
+                    event.card.controller === this.controller &&
+                    event.card.isUnique() &&
+                    event.card.isFaction('stark')
                 )
             },
+            cost: ability.costs.sacrificeSelf(),
             handler: context => {
-                let message = '{0} sacrifices {1} to save {2}';
-                let toKill = context.target;
+                let message = '{0} uses {1} to save {2}';
+                let toKill = context.event.card;
 
-                context.event.saveCard(toKill);
+                context.event.saveCard();
 
-                if(this.game.getPlayers().some(player => {
-                    return player.activePlot.hasTrait('Winter');
-                }) && toKill.canGainPower()) {
+                if(toKill.this.canGainPower && this.game.anyPlotHasTrait('Winter')) {
                     toKill.modifyPower(1);
                     message += ' and have it gain 1 power';
                 }

--- a/server/game/cards/04.6-TC/PodrickPayne.js
+++ b/server/game/cards/04.6-TC/PodrickPayne.js
@@ -6,21 +6,18 @@ class PodrickPayne extends DrawCard {
             canCancel: true,
             location: 'hand',
             when: {
-                onCharactersKilled: () => this.game.claim.isApplying && this.game.claim.type === 'military'
-            },
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && card.controller === this.controller
+                onCharacterKilled: event => this.game.claim.isApplying && this.game.claim.type === 'military' && event.allowSave && event.card.canBeSaved() && event.card.controller === this.controller
             },
             cost: [
                 ability.costs.payGold(2),
                 ability.costs.putSelfIntoPlay()
             ],
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
                 this.game.addMessage('{0} puts {1} into play and pays 2 gold to save {2}',
-                    this.controller, this, context.target);
+                    this.controller, this, context.event.card);
 
-                if(context.target.name === 'Tyrion Lannister' && this.controller.getSpendableGold() >= 2 &&
+                if(context.event.card.name === 'Tyrion Lannister' && this.controller.getSpendableGold() >= 2 &&
                    this.game.currentChallenge && this.game.currentChallenge.attackers.length >= 1) {
                     this.game.promptWithMenu(this.controller, this, {
                         activePrompt: {

--- a/server/game/cards/05-LoCR/VictarionGreyjoy.js
+++ b/server/game/cards/05-LoCR/VictarionGreyjoy.js
@@ -5,11 +5,11 @@ class VictarionGreyjoy extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave && event.cards.includes(this) && this.canBeSaved()
+                onCharacterKilled: event => event.allowSave && event.card === this && this.canBeSaved()
             },
             cost: ability.costs.discardPowerFromSelf(2),
             handler: context => {
-                context.event.saveCard(this);
+                context.event.saveCard();
                 this.game.addMessage('{0} uses {1} to save {2}', this.controller, this, this);
             }
         });

--- a/server/game/cards/06.4-TRW/StrongBelwas.js
+++ b/server/game/cards/06.4-TRW/StrongBelwas.js
@@ -5,18 +5,20 @@ class StrongBelwas extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
+                onCharacterKilled: event => (
+                    event.allowSave &&
+                    event.card.controller === this.controller &&
+                    event.card !== this &&
+                    event.card.isUnique() &&
+                    event.card.isFaction('targaryen') &&
+                    event.card.canBeSaved()
+                )
             },
             limit: ability.limit.perPhase(1),
             cost: ability.costs.discardGold(),
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.controller === this.controller &&
-                                                  card !== this && card.isUnique() && card.isFaction('targaryen') &&
-                                                  card.canBeSaved()
-            },
             handler: context => {
-                context.event.saveCard(context.target);
-                this.game.addMessage('{0} discards 1 gold from {1} to save {2}', this.controller, this, context.target);
+                context.event.saveCard();
+                this.game.addMessage('{0} discards 1 gold from {1} to save {2}', this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/06.6-TBWB/BericDondarrion.js
+++ b/server/game/cards/06.6-TBWB/BericDondarrion.js
@@ -21,11 +21,11 @@ class BericDondarrion extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave && event.cards.includes(this) && this.canBeSaved()
+                onCharacterKilled: event => event.allowSave && event.card === this && this.canBeSaved()
             },
             cost: ability.costs.discardTokenFromSelf('kiss'),
             handler: context => {
-                context.event.saveCard(this);
+                context.event.saveCard();
                 this.game.addMessage('{0} discards a kiss token to save {1}', this.controller, this);
             }
         });

--- a/server/game/cards/07-WotW/Ghost.js
+++ b/server/game/cards/07-WotW/Ghost.js
@@ -5,19 +5,13 @@ class Ghost extends DrawCard {
         this.attachmentRestriction({ faction: ['thenightswatch', 'stark'] });
         this.interrupt({
             when: {
-                onCharactersKilled: event => {
-                    if(event.cards.includes(this.parent) && this.parent.canBeSaved() && event.allowSave) {
-                        this.parentCard = this.parent;
-                        return true;
-                    }
-                    return false;
-                }
+                onCharacterKilled: event => event.card === this.parent && this.parent.canBeSaved() && event.allowSave
             },
             cost: ability.costs.returnSelfToHand(),
             canCancel: true,
             handler: context => {
-                context.event.saveCard(this.parentCard);
-                this.game.addMessage('{0} returns {1} to their hand to save {2}', this.controller, this, this.parentCard);
+                context.event.saveCard();
+                this.game.addMessage('{0} returns {1} to their hand to save {2}', this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/08.2-JtO/ThorosOfMyr.js
+++ b/server/game/cards/08.2-JtO/ThorosOfMyr.js
@@ -5,20 +5,22 @@ class ThorosOfMyr extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave
+                onCharacterKilled: event => (
+                    event.allowSave &&
+                    event.card !== this &&
+                    !event.card.isLoyal() &&
+                    event.card.controller === this.controller &&
+                    event.card.canBeSaved()
+                )
             },
             cost: [
                 ability.costs.kneelSelf(),
                 ability.costs.discardPowerFromSelf(1)
             ],
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card !== this && !card.isLoyal() &&
-                                                  card.controller === this.controller && card.canBeSaved()
-            },
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
                 this.game.addMessage('{0} kneels and discards 1 power from {1} to save {2}',
-                    context.player, this, context.target);
+                    context.player, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/09-HoT/SerDontosHollard.js
+++ b/server/game/cards/09-HoT/SerDontosHollard.js
@@ -5,17 +5,14 @@ class SerDontosHollard extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.allowSave,
-                onCardsDiscarded: event => event.allowSave
-            },
-            target: {
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.canBeSaved() && this.isControlledLady(card)
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && this.isControlledLady(event.card),
+                onCardDiscarded: event => event.allowSave && event.card.canBeSaved() && this.isControlledLady(event.card)
             },
             cost: ability.costs.standSelf(),
             handler: context => {
-                context.event.saveCard(context.target);
+                context.event.saveCard();
                 this.game.addMessage('{0} stands {1} to save {2}',
-                    this.controller, this, context.target);
+                    this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -31,6 +31,15 @@ class Event {
         return this.allowSave && this.automaticSaveWithDupe && !!this.card;
     }
 
+    saveCard() {
+        if(!this.card || this.cancelled) {
+            return;
+        }
+
+        this.card.game.saveCard(this.card);
+        this.cancel();
+    }
+
     cancel() {
         this.cancelled = true;
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -867,13 +867,17 @@ class Game extends EventEmitter {
         let dupe = card.dupes.find(dupe => dupe.owner === card.controller);
         if(card.canBeSaved() && dupe) {
             dupe.owner.discardCard(dupe, false);
-            card.markAsSaved();
+            this.saveCard(card);
             this.addMessage('{0} discards a duplicate to save {1}', player, card);
-            this.raiseEvent('onCardSaved', { card: card });
             return true;
         }
 
         return false;
+    }
+
+    saveCard(card) {
+        card.markAsSaved();
+        this.raiseEvent('onCardSaved', { card: card });
     }
 
     killCharacters(cards, options = {}) {

--- a/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
+++ b/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
@@ -27,8 +27,8 @@ describe('Valar Morghulis', function() {
                 this.player1.clickCard(this.marg2);
                 this.player1.clickCard(this.rickon);
 
-                this.player2.clickCard(this.samwell);
                 this.player2.clickCard(this.aemon);
+                this.player2.clickCard(this.samwell);
 
                 this.completeSetup();
 

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -381,10 +381,9 @@ describe('take control', function() {
                 this.player1.clickCard(knight);
 
                 this.player1.triggerAbility('Iron Mines');
-                expect(this.player1).toHavePrompt('Select a character');
-                this.player1.clickCard(knight);
+                // Because there is only one character to save, the choice of
+                // character is implicit and not prompted.
 
-                expect(this.player1).not.toHavePrompt('Select character to save');
                 expect(knight.location).toBe('play area');
             });
 


### PR DESCRIPTION
Previously, we used fake plural events such as onCharactersKilled to
simulate simultaneous resolution. Since then, support has been added for
simultaneous events as well as better UI for choosing which event you
want to match when triggering an ability. It is now possible to
implement saves directly on the singular onCharacterKilled event.