### PR TITLE
Event system enhancements

### DIFF
--- a/server/game/AtomicEvent.js
+++ b/server/game/AtomicEvent.js
@@ -68,6 +68,11 @@ class AtomicEvent {
         return this.childEvents[0];
     }
 
+    thenExecute(func) {
+        this.childEvents[0].thenExecute(func);
+        return this;
+    }
+
     toString() {
         return `atomic(${this.childEvents.map(e => e.toString()).join(' + ')})`;
     }

--- a/server/game/AtomicEvent.js
+++ b/server/game/AtomicEvent.js
@@ -3,9 +3,13 @@ class AtomicEvent {
         this.cancelled = false;
         this.childEvents = [];
         this.attachedEvents = [];
+        this.params = {};
     }
 
     addChildEvent(event) {
+        this.params = Object.assign({}, event.params, this.params);
+        Object.assign(this, this.params);
+
         event.parent = this;
         this.childEvents.push(event);
     }

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -10,7 +10,7 @@ class Event {
         this.attachedEvents = [];
 
         _.extend(this, params);
-        this.params = [this].concat([params]);
+        this.params = params;
     }
 
     addChildEvent(event) {

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -5,7 +5,7 @@ class Event {
         this.name = name;
         this.cancelled = false;
         this.handler = handler;
-        this.postHandler = postHandler;
+        this.postHandlers = [postHandler];
         this.childEvents = [];
         this.attachedEvents = [];
 
@@ -65,7 +65,9 @@ class Event {
     }
 
     executePostHandler() {
-        this.postHandler(this);
+        for(let postHandler of this.postHandlers) {
+            postHandler(this);
+        }
     }
 
     onChildCancelled(event) {
@@ -85,6 +87,11 @@ class Event {
     thenAttachEvent(event) {
         this.attachedEvents.push(event);
         this.addChildEvent(event);
+    }
+
+    thenExecute(func) {
+        this.postHandlers.push(func);
+        return this;
     }
 
     clearAttachedEvents() {

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -86,7 +86,6 @@ class Event {
 
     thenAttachEvent(event) {
         this.attachedEvents.push(event);
-        this.addChildEvent(event);
     }
 
     thenExecute(func) {
@@ -95,6 +94,9 @@ class Event {
     }
 
     clearAttachedEvents() {
+        for(let event of this.attachedEvents) {
+            this.addChildEvent(event);
+        }
         this.attachedEvents = [];
     }
 

--- a/server/game/gamesteps/BaseAbilityWindow.js
+++ b/server/game/gamesteps/BaseAbilityWindow.js
@@ -1,8 +1,6 @@
 const uuid = require('uuid');
 
-const BaseStep = require('./basestep.js');
-const SimultaneousEvents = require('../SimultaneousEvents');
-const InterruptWindow = require('./InterruptWindow');
+const BaseStep = require('./basestep');
 
 class BaseAbilityWindow extends BaseStep {
     constructor(game, properties) {
@@ -72,22 +70,7 @@ class BaseAbilityWindow extends BaseStep {
             return;
         }
 
-        let attachedEvents = [];
-        for(let event of this.event.getConcurrentEvents()) {
-            attachedEvents = attachedEvents.concat(event.attachedEvents);
-            event.clearAttachedEvents();
-        }
-
-        if(attachedEvents.length === 0) {
-            return;
-        }
-
-        let groupedEvent = new SimultaneousEvents();
-        for(let attachedEvent of attachedEvents) {
-            groupedEvent.addChildEvent(attachedEvent);
-        }
-
-        this.game.queueStep(new InterruptWindow(this.game, groupedEvent, this.postHandlerFunc));
+        this.game.openInterruptWindowForAttachedEvents(this.event);
     }
 }
 

--- a/server/game/gamesteps/InterruptWindow.js
+++ b/server/game/gamesteps/InterruptWindow.js
@@ -14,6 +14,7 @@ class InterruptWindow extends BaseStep {
             new SimpleStep(game, () => this.openAbilityWindow('forcedinterrupt')),
             new SimpleStep(game, () => this.openAbilityWindow('interrupt')),
             new SimpleStep(game, () => this.executeHandler()),
+            new SimpleStep(game, () => this.openWindowForAttachedEvents()),
             new SimpleStep(game, () => this.executePostHandler())
         ]);
         this.postHandlerFunc = postHandlerFunc;
@@ -72,6 +73,14 @@ class InterruptWindow extends BaseStep {
         }
 
         this.event.executeHandler();
+    }
+
+    openWindowForAttachedEvents() {
+        if(this.event.cancelled) {
+            return;
+        }
+
+        this.game.openInterruptWindowForAttachedEvents(this.event);
     }
 
     executePostHandler() {

--- a/server/game/gamesteps/InterruptWindow.js
+++ b/server/game/gamesteps/InterruptWindow.js
@@ -72,7 +72,6 @@ class InterruptWindow extends BaseStep {
         }
 
         this.event.executeHandler();
-        this.postHandlerFunc();
     }
 
     executePostHandler() {
@@ -81,6 +80,7 @@ class InterruptWindow extends BaseStep {
         }
 
         this.event.executePostHandler();
+        this.postHandlerFunc();
     }
 }
 

--- a/test/server/AtomicEvent.spec.js
+++ b/test/server/AtomicEvent.spec.js
@@ -70,7 +70,8 @@ describe('AtomicEvent', function() {
 
     describe('addChildEvent', function() {
         beforeEach(function() {
-            this.event = new AtomicEvent('onEvent', { foo: 'bar' });
+            this.childEventSpy1.params = { prop1: 'foo', prop2: 'bar' };
+            this.event = new AtomicEvent();
             this.event.addChildEvent(this.childEventSpy1);
         });
 
@@ -80,6 +81,11 @@ describe('AtomicEvent', function() {
 
         it('should set the parent for the child', function() {
             expect(this.childEventSpy1.parent).toBe(this.event);
+        });
+
+        it('should extend any properties of the child onto the event', function() {
+            expect(this.event.prop1).toBe('foo');
+            expect(this.event.prop2).toBe('bar');
         });
     });
 

--- a/test/server/game/openInterruptWindowForAttachedEvents.spec.js
+++ b/test/server/game/openInterruptWindowForAttachedEvents.spec.js
@@ -1,0 +1,55 @@
+const Game = require('../../../server/game/game');
+
+describe('Game', function() {
+    beforeEach(function() {
+        this.gameService = jasmine.createSpyObj('gameService', ['save']);
+        this.game = new Game({ owner: {} }, { gameService: this.gameService });
+
+        this.eventSpy = jasmine.createSpyObj('event', ['clearAttachedEvents', 'emitTo', 'getConcurrentEvents']);
+        this.eventSpy.getConcurrentEvents.and.returnValue([this.eventSpy]);
+
+        spyOn(this.game, 'queueStep');
+    });
+
+    describe('openWindowForAttachedEvents()', function() {
+        describe('when the event has no attached events', function() {
+            beforeEach(function() {
+                this.eventSpy.attachedEvents = [];
+                this.game.openInterruptWindowForAttachedEvents(this.eventSpy);
+            });
+
+            it('should not open an interrupt window', function() {
+                expect(this.game.queueStep).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the event has attached events', function() {
+            beforeEach(function() {
+                this.attachedEvent1 = { event: 1 };
+                this.attachedEvent2 = { event: 1 };
+                this.eventSpy.attachedEvents = [this.attachedEvent1, this.attachedEvent2];
+                this.game.openInterruptWindowForAttachedEvents(this.eventSpy);
+            });
+
+            it('should clear the attached events from the initial event', function() {
+                expect(this.eventSpy.clearAttachedEvents).toHaveBeenCalled();
+            });
+
+            it('should open an interrupt window', function() {
+                const InterruptWindow = require('../../../server/game/gamesteps/InterruptWindow');
+                expect(this.game.queueStep).toHaveBeenCalledWith(jasmine.any(InterruptWindow));
+            });
+
+            it('should create an event grouping the attached events', function() {
+                expect(this.game.queueStep).toHaveBeenCalledWith(jasmine.objectContaining({
+                    event: jasmine.objectContaining({
+                        childEvents: [
+                            this.attachedEvent1,
+                            this.attachedEvent2
+                        ]
+                    })
+                }));
+            });
+        });
+    });
+});

--- a/test/server/gamesteps/BaseAbilityWindow.spec.js
+++ b/test/server/gamesteps/BaseAbilityWindow.spec.js
@@ -130,46 +130,4 @@ describe('BaseAbilityWindow', function() {
             expect(this.window.hasResolvedAbility(this.abilitySpy, this.eventSpy));
         });
     });
-
-    describe('openWindowForAttachedEvents()', function() {
-        describe('when the event has no attached events', function() {
-            beforeEach(function() {
-                this.eventSpy.attachedEvents = [];
-                this.window.openWindowForAttachedEvents();
-            });
-
-            it('should not open an interrupt window', function() {
-                expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
-            });
-        });
-
-        describe('when the event has attached events', function() {
-            beforeEach(function() {
-                this.attachedEvent1 = { event: 1 };
-                this.attachedEvent2 = { event: 1 };
-                this.eventSpy.attachedEvents = [this.attachedEvent1, this.attachedEvent2];
-                this.window.openWindowForAttachedEvents();
-            });
-
-            it('should clear the attached events from the initial event', function() {
-                expect(this.eventSpy.clearAttachedEvents).toHaveBeenCalled();
-            });
-
-            it('should open an interrupt window', function() {
-                const InterruptWindow = require('../../../server/game/gamesteps/InterruptWindow');
-                expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(InterruptWindow));
-            });
-
-            it('should create an event grouping the attached events', function() {
-                expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.objectContaining({
-                    event: jasmine.objectContaining({
-                        childEvents: [
-                            this.attachedEvent1,
-                            this.attachedEvent2
-                        ]
-                    })
-                }));
-            });
-        });
-    });
 });

--- a/test/server/gamesteps/eventwindow.spec.js
+++ b/test/server/gamesteps/eventwindow.spec.js
@@ -2,7 +2,7 @@ const EventWindow = require('../../../server/game/gamesteps/eventwindow.js');
 
 describe('EventWindow', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['openAbilityWindow', 'saveWithDupe']);
+        this.gameSpy = jasmine.createSpyObj('game', ['openAbilityWindow', 'openInterruptWindowForAttachedEvents', 'saveWithDupe']);
         this.eventSpy = jasmine.createSpyObj('event', ['allowAutomaticSave', 'cancel', 'clearAttachedEvents', 'emitTo', 'executeHandler', 'executePostHandler', 'getConcurrentEvents']);
         this.eventSpy.attachedEvents = [];
         this.eventSpy.getConcurrentEvents.and.returnValue([]);


### PR DESCRIPTION
* Adds the ability to chain post-handlers onto an event using `thenExecute`. This is useful for generalizing callbacks within the event system (e.g. shuffling the deck after moving Benjen into it) rather than relying on every method needing a callback parameter.
* Updates atomic events so that they aggregate all of the event properties of their children. This is mostly so that the `card` property is available on the parent atomic event but may be useful in other scenarios as well. e.g. you should be able to access the `card` property of the atomic combination of a kill event and a leaves play event.
* Fixes the way attached events are executed. Previously it was executing the handler for the events twice if the event was attached in a handler - once inside the handler (because it was immediately added as a child to the current event) and then again in the separate interrupt window that's opened. Now the child is only added once the interrupt window has been opened.
* Fixes the order of attached events and post handlers. If an event has a post handler, it now executes after any nested attached events have been resolved.