### PR TITLE
Setting STR to lower value is considered reducing

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -102,7 +102,9 @@ class Effect {
                 return false;
             }
 
-            if(!target.allowGameAction(this.gameAction, { source: this.source, resolutionStage: 'effect' })) {
+            let gameAction = typeof this.gameAction === 'function' ? this.gameAction(target, this.context) : this.gameAction;
+
+            if(!target.allowGameAction(gameAction, { source: this.source, resolutionStage: 'effect' })) {
                 return false;
             }
         }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -143,6 +143,7 @@ const Effects = {
     },
     setStrength: function(value) {
         return {
+            gameAction: card => card.getType() === 'character' && card.getStrength() > value ? 'decreaseStrength' : 'increaseStrength',
             apply: function(card) {
                 card.strengthSet = value;
             },

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -188,8 +188,9 @@ describe('Daenerys Targaryen (TFM)', function() {
                 this.player1.clickPrompt('Done');
             });
 
-            it('should set her strength to 1', function() {
-                expect(this.dany.getStrength()).toBe(1);
+            it('should not set her strength to 1', function() {
+                // Ruling: http://www.cardgamedb.com/forums/index.php?/topic/39646-ruling-daenerys-targaryen-tfm-strangler/
+                expect(this.dany.getStrength()).toBe(3);
             });
         });
     });


### PR DESCRIPTION
Setting a card value to a lower value than it currently has should be
considered "reducing" the value, not just when manually subtracting from
the value. Thus, Daenerys (TFM) should be immune to the strength setting
effect applied by Strangler.

Ruling: http://www.cardgamedb.com/forums/index.php?/topic/39646-ruling-daenerys-targaryen-tfm-strangler/