### PR TITLE
Disable challenge buttons for invalid challenges

### DIFF
--- a/server/game/ChallengeTypes.js
+++ b/server/game/ChallengeTypes.js
@@ -1,0 +1,16 @@
+class ChallengeTypes {
+    static asButtons(propertiesOrFunc) {
+        return ChallengeTypes.all.map(type => {
+            let resolvedProperties = typeof propertiesOrFunc === 'function' ? propertiesOrFunc(type.value) : propertiesOrFunc;
+            return Object.assign({ text: type.text, arg: type.value }, resolvedProperties);
+        });
+    }
+}
+
+ChallengeTypes.all = [
+    { text: 'Military', value: 'military' },
+    { text: 'Intrigue', value: 'intrigue' },
+    { text: 'Power', value: 'power' }
+];
+
+module.exports = ChallengeTypes;

--- a/server/game/cards/01-Core/CalmOverWesteros.js
+++ b/server/game/cards/01-Core/CalmOverWesteros.js
@@ -1,4 +1,5 @@
 const PlotCard = require('../../plotcard.js');
+const ChallengeTypes = require('../../ChallengeTypes');
 
 class CalmOverWesteros extends PlotCard {
     setupCardAbilities() {
@@ -7,11 +8,7 @@ class CalmOverWesteros extends PlotCard {
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Select a challenge type',
-                        buttons: [
-                            { text: 'Military', method: 'setChallengeType', arg: 'military' },
-                            { text: 'Intrigue', method: 'setChallengeType', arg: 'intrigue' },
-                            { text: 'Power', method: 'setChallengeType', arg: 'power' }
-                        ]
+                        buttons: ChallengeTypes.asButtons({ method: 'setChallengeType' })
                     },
                     source: this
                 });

--- a/server/game/cards/01-Core/OlennasInformant.js
+++ b/server/game/cards/01-Core/OlennasInformant.js
@@ -1,4 +1,5 @@
 const DrawCard = require('../../drawcard.js');
+const ChallengeTypes = require('../../ChallengeTypes');
 
 class OlennasInformant extends DrawCard {
     setupCardAbilities() {
@@ -10,11 +11,7 @@ class OlennasInformant extends DrawCard {
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Name a challenge type',
-                        buttons: [
-                            { text: 'Military', method: 'challengeSelected', arg: 'military' },
-                            { text: 'Intrigue', method: 'challengeSelected', arg: 'intrigue' },
-                            { text: 'Power', method: 'challengeSelected', arg: 'power' }
-                        ]
+                        buttons: ChallengeTypes.asButtons({ method: 'challengeSelected' })
                     },
                     source: this
                 });

--- a/server/game/cards/01-Core/UnbowedUnbentUnbroken.js
+++ b/server/game/cards/01-Core/UnbowedUnbentUnbroken.js
@@ -1,4 +1,5 @@
 const DrawCard = require('../../drawcard.js');
+const ChallengeTypes = require('../../ChallengeTypes');
 
 class UnbowedUnbentUnbroken extends DrawCard {
     setupCardAbilities(ability) {
@@ -13,12 +14,9 @@ class UnbowedUnbentUnbroken extends DrawCard {
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Select a challenge type',
-                        buttons: [
-                            { text: 'Military', method: 'trigger', arg: 'military' },
-                            { text: 'Intrigue', method: 'trigger', arg: 'intrigue' },
-                            { text: 'Power', method: 'trigger', arg: 'power' },
+                        buttons: ChallengeTypes.asButtons({ method: 'trigger' }).concat([
                             { text: 'Cancel', method: 'cancel' }
-                        ]
+                        ])
                     },
                     source: this
                 });

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -2,6 +2,7 @@ const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
 const Challenge = require('../challenge.js');
 const ChallengeFlow = require('./challenge/challengeflow.js');
+const ChallengeTypes = require('../ChallengeTypes');
 const ActionWindow = require('./actionwindow.js');
 
 class ChallengePhase extends Phase {
@@ -24,17 +25,11 @@ class ChallengePhase extends Phase {
 
         this.game.queueStep(new ActionWindow(this.game, 'Before challenge', 'challengeBegin'));
 
-        const ChallengeTypes = ['Military', 'Intrigue', 'Power'];
-
         let currentPlayer = this.remainingPlayers[0];
-        let buttons = ChallengeTypes.map(challengeType => {
-            return {
-                text: challengeType,
-                method: 'chooseChallengeType',
-                arg: challengeType.toLowerCase(),
-                disabled: () => !this.allowChallengeType(currentPlayer, challengeType.toLowerCase())
-            };
-        });
+        let buttons = ChallengeTypes.asButtons(challengeType => ({
+            method: 'chooseChallengeType',
+            disabled: () => !this.allowChallengeType(currentPlayer, challengeType)
+        }));
 
         this.game.promptWithMenu(currentPlayer, this, {
             activePrompt: {

--- a/server/game/gamesteps/iconprompt.js
+++ b/server/game/gamesteps/iconprompt.js
@@ -1,6 +1,5 @@
-const _ = require('underscore');
-
 const BaseStep = require('./basestep');
+const ChallengeTypes = require('../ChallengeTypes');
 
 class IconPrompt extends BaseStep {
     constructor(game, player, card, callback) {
@@ -12,16 +11,10 @@ class IconPrompt extends BaseStep {
     }
 
     continue() {
-        let icons = ['Military', 'Intrigue', 'Power'];
-
-        let buttons = _.map(icons, icon => {
-            return { text: icon, method: 'iconSelected', arg: icon.toLowerCase() };
-        });
-
         this.game.promptWithMenu(this.player, this, {
             activePrompt: {
                 menuTitle: 'Select an icon',
-                buttons: buttons
+                buttons: ChallengeTypes.asButtons({ method: 'iconSelected' })
             },
             source: this.card
         });

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -82,9 +82,18 @@ class PlayerPromptState {
             selectOrder: this.selectOrder,
             menuTitle: this.menuTitle,
             promptTitle: this.promptTitle,
-            buttons: this.buttons,
+            buttons: this.buttons.map(button => this.getButtonState(button)),
             controls: this.controls
         };
+    }
+
+    getButtonState(button) {
+        if(button.disabled) {
+            let disabled = typeof button.disabled === 'function' ? button.disabled() : button.disabled;
+            return Object.assign({}, button, { disabled: !!disabled });
+        }
+
+        return button;
     }
 }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -31,13 +31,18 @@ class PlayerInteractionWrapper {
     }
 
     formatPrompt() {
-        var prompt = this.currentPrompt();
+        let prompt = this.currentPrompt();
 
         if(!prompt) {
             return 'no prompt active';
         }
 
-        return prompt.menuTitle + '\n' + _.map(prompt.buttons, button => '[ ' + button.text + ' ]').join('\n');
+        let buttons = prompt.buttons.map(button => {
+            let text = button.disabled ? button.text + ' (Disabled)' : button.text;
+            return `[${text}]`;
+        });
+
+        return prompt.menuTitle + '\n' + buttons.join('\n');
     }
 
     findCardByName(name, location = 'any') {
@@ -97,10 +102,14 @@ class PlayerInteractionWrapper {
 
     clickPrompt(text) {
         let currentPrompt = this.player.currentPrompt();
-        let promptButton = _.find(currentPrompt.buttons, button => button.text.toLowerCase() === text.toLowerCase());
+        let promptButton = currentPrompt.buttons.find(button => button.text.toLowerCase() === text.toLowerCase());
 
         if(!promptButton) {
             throw new Error(`Couldn't click on "${text}" for ${this.player.name}. Current prompt is:\n${this.formatPrompt()}`);
+        }
+
+        if(promptButton.disabled) {
+            throw new Error(`Couldn't click on "${text}" for ${this.player.name} because it is disabled. Current prompt is:\n${this.formatPrompt()}`);
         }
 
         this.game.menuButton(this.player.name, promptButton.arg, promptButton.method);

--- a/test/server/cards/01-Core/AGameOfThrones.spec.js
+++ b/test/server/cards/01-Core/AGameOfThrones.spec.js
@@ -27,17 +27,11 @@ describe('A Game Of Thrones', function() {
 
             describe('when the player has not won an intrigue challenge', function() {
                 it('should not allow military challenges to be declared', function() {
-                    this.player1.clickPrompt('Military');
-
-                    expect(this.player1).not.toHavePrompt('Select challenge attackers');
-                    expect(this.player1).toHavePromptButton('Military');
+                    expect(this.player1).toHaveDisabledPromptButton('Military');
                 });
 
                 it('should not allow power challenges to be declared', function() {
-                    this.player1.clickPrompt('Power');
-
-                    expect(this.player1).not.toHavePrompt('Select challenge attackers');
-                    expect(this.player1).toHavePromptButton('Power');
+                    expect(this.player1).toHaveDisabledPromptButton('Power');
                 });
             });
 
@@ -48,17 +42,11 @@ describe('A Game Of Thrones', function() {
                 });
 
                 it('should allow military challenges to be declared', function() {
-                    this.player1.clickPrompt('Military');
-
-                    expect(this.player1).toHavePrompt('Select challenge attackers');
-                    expect(this.player1).not.toHavePromptButton('Military');
+                    expect(this.player1).toHavePromptButton('Military');
                 });
 
                 it('should allow power challenges to be declared', function() {
-                    this.player1.clickPrompt('Power');
-
-                    expect(this.player1).toHavePrompt('Select challenge attackers');
-                    expect(this.player1).not.toHavePromptButton('Power');
+                    expect(this.player1).toHavePromptButton('Power');
                 });
             });
         });

--- a/test/server/cards/02.2-TRtW/BrothelMadame.spec.js
+++ b/test/server/cards/02.2-TRtW/BrothelMadame.spec.js
@@ -30,9 +30,7 @@ describe('Brothel Madame', function() {
             });
 
             it('should not allow the opponent to initiate military challenges', function() {
-                this.player2.clickPrompt('Military');
-
-                expect(this.player2).toHavePromptButton('Military');
+                expect(this.player2).toHaveDisabledPromptButton('Military');
             });
         });
 

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -38,7 +38,7 @@ describe('challenges phase', function() {
         describe('when a side has higher strength but no participating characters', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('thenightswatch', [
-                    'Sneak Attack',
+                    'A Noble Cause',
                     'Steward at the Wall', 'The Haunted Forest', 'The Haunted Forest', 'The Shadow Tower'
                 ]);
                 this.player1.selectDeck(deck);
@@ -74,7 +74,7 @@ describe('challenges phase', function() {
 
             it('should complete the challenge', function() {
                 expect(this.player1).toHavePromptButton('Military');
-                expect(this.player1).toHavePromptButton('Intrigue');
+                expect(this.player1).toHaveDisabledPromptButton('Intrigue');
                 expect(this.player1).toHavePromptButton('Power');
             });
         });


### PR DESCRIPTION
If a player cannot initiate another challenge of a certain type (met their limit for that type of challenge already, restricted by something like Game of Thrones, etc), the button for that challenge type will be disabled.

![screen shot 2018-06-19 at 4 02 58 pm](https://user-images.githubusercontent.com/145077/41628671-7618cf3c-73da-11e8-93b2-9a5c0ba8e484.png)

Using the `/reset-challenges-count` command will live-update an existing challenge prompt.