### PR TITLE
Convert challenge effects from bool to counted

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -140,7 +140,7 @@ class Challenge {
 
     calculateStrengthFor(cards) {
         return _.reduce(cards, (sum, card) => {
-            if(card.challengeOptions.doesNotContributeStrength) {
+            if(card.challengeOptions.contains('doesNotContributeStrength')) {
                 return sum;
             }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -32,14 +32,7 @@ class DrawCard extends BaseCard {
         this.inDanger = false;
         this.wasAmbush = false;
         this.saved = false;
-        this.challengeOptions = {
-            doesNotContributeStrength: false,
-            doesNotKneelAs: {
-                attacker: false,
-                defender: false
-            },
-            mustBeDeclaredAsDefender: false
-        };
+        this.challengeOptions = new ReferenceCountedSetProperty();
         this.stealthLimit = 1;
         this.minCost = 0;
         this.eventPlacementLocation = 'discard pile';
@@ -392,8 +385,8 @@ class DrawCard extends BaseCard {
             this.canParticipateInChallenge() &&
             this.location === 'play area' &&
             !this.stealth &&
-            (!this.kneeled || this.challengeOptions.canBeDeclaredWhileKneeling) &&
-            (this.hasIcon(challengeType) || this.challengeOptions.canBeDeclaredWithoutIcon)
+            (!this.kneeled || this.challengeOptions.contains('canBeDeclaredWhileKneeling')) &&
+            (this.hasIcon(challengeType) || this.challengeOptions.contains('canBeDeclaredWithoutIcon'))
         );
     }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -36,6 +36,19 @@ function losesAllAspectEffect(aspect) {
     };
 }
 
+function challengeOptionEffect(key) {
+    return function() {
+        return {
+            apply: function(card) {
+                card.challengeOptions.add(key);
+            },
+            unapply: function(card) {
+                card.challengeOptions.remove(key);
+            }
+        };
+    };
+}
+
 const Effects = {
     setSetupGold: function(value) {
         return {
@@ -60,26 +73,8 @@ const Effects = {
     cannotBeDeclaredAsAttacker: cannotEffect('declareAsAttacker'),
     cannotBeDeclaredAsDefender: cannotEffect('declareAsDefender'),
     cannotParticipate: cannotEffect('participateInChallenge'),
-    doesNotKneelAsAttacker: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.doesNotKneelAs.attacker = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.doesNotKneelAs.attacker = false;
-            }
-        };
-    },
-    doesNotKneelAsDefender: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.doesNotKneelAs.defender = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.doesNotKneelAs.defender = false;
-            }
-        };
-    },
+    doesNotKneelAsAttacker: challengeOptionEffect('doesNotKneelAsAttacker'),
+    doesNotKneelAsDefender: challengeOptionEffect('doesNotKneelAsDefender'),
     consideredToBeAttacking: function() {
         return {
             apply: function(card, context) {
@@ -97,36 +92,9 @@ const Effects = {
             }
         };
     },
-    canBeDeclaredWithoutIcon: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.canBeDeclaredWithoutIcon = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.canBeDeclaredWithoutIcon = false;
-            }
-        };
-    },
-    canBeDeclaredWhileKneeling: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.canBeDeclaredWhileKneeling = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.canBeDeclaredWhileKneeling = false;
-            }
-        };
-    },
-    mustBeDeclaredAsDefender: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.mustBeDeclaredAsDefender = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.mustBeDeclaredAsDefender = false;
-            }
-        };
-    },
+    canBeDeclaredWithoutIcon: challengeOptionEffect('canBeDeclaredWithoutIcon'),
+    canBeDeclaredWhileKneeling: challengeOptionEffect('canBeDeclaredWhileKneeling'),
+    mustBeDeclaredAsDefender: challengeOptionEffect('mustBeDeclaredAsDefender'),
     restrictAttachmentsTo: function(trait) {
         return Effects.addKeyword(`No attachments except <i>${trait}</i>`);
     },
@@ -321,16 +289,7 @@ const Effects = {
         let negatedCalculate = (card, context) => -(calculate(card, context) || 0);
         return Effects.dynamicStrength(negatedCalculate, 'decreaseStrength');
     },
-    doesNotContributeStrength: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.doesNotContributeStrength = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.doesNotContributeStrength = false;
-            }
-        };
-    },
+    doesNotContributeStrength: challengeOptionEffect('doesNotContributeStrength'),
     doesNotReturnUnspentGold: function() {
         return {
             apply: function(player) {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -74,7 +74,7 @@ class ChallengeFlow extends BaseStep {
         this.challenge.addAttackers(attackers);
 
         _.each(attackers, card => {
-            if(!card.kneeled && !card.challengeOptions.doesNotKneelAs['attacker']) {
+            if(!card.kneeled && !card.challengeOptions.contains('doesNotKneelAsAttacker')) {
                 this.game.applyGameAction('kneel', card, card => {
                     card.kneeled = true;
                     this.attackersToKneel.push(card);
@@ -214,7 +214,7 @@ class ChallengeFlow extends BaseStep {
         this.challenge.addDefenders(defenders);
 
         _.each(defenders, card => {
-            if(!card.kneeled && !card.challengeOptions.doesNotKneelAs['defender']) {
+            if(!card.kneeled && !card.challengeOptions.contains('doesNotKneelAsDefender')) {
                 this.game.applyGameAction('kneel', card, card => {
                     card.kneeled = true;
                     defendersToKneel.push(card);

--- a/test/server/effects/doesNotKneelAsAttacker.spec.js
+++ b/test/server/effects/doesNotKneelAsAttacker.spec.js
@@ -1,25 +1,23 @@
 describe('doesNotKneelAsAttacker', function() {
     integration(function() {
-        beforeEach(function() {
-            const deck = this.buildDeck('stark', [
-                'A Noble Cause',
-                'Ser Jaime Lannister (Core)'
-            ]);
-            this.player1.selectDeck(deck);
-            this.player2.selectDeck(deck);
-            this.startGame();
-            this.keepStartingHands();
-
-            this.character = this.player1.findCardByName('Ser Jaime Lannister');
-            this.player1.clickCard(this.character);
-
-            this.completeSetup();
-            this.selectFirstPlayer(this.player1);
-            this.completeMarshalPhase();
-        });
-
         describe('when the character is declared as an attacker', function() {
             beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Ser Jaime Lannister (Core)'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Ser Jaime Lannister');
+                this.player1.clickCard(this.character);
+
+                this.completeSetup();
+                this.selectFirstPlayer(this.player1);
+                this.completeMarshalPhase();
+
                 this.player1.clickPrompt('Military');
                 this.player1.clickCard(this.character);
                 this.player1.clickPrompt('Done');
@@ -27,6 +25,51 @@ describe('doesNotKneelAsAttacker', function() {
 
             it('should not kneel the character', function() {
                 expect(this.game.currentChallenge.isAttacking(this.character));
+                expect(this.character.kneeled).toBe(false);
+            });
+        });
+
+        describe('when there are multiple does-not-kneel effects in play', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'The Blackfish', 'The Wolf King'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('The Blackfish');
+                this.player1.clickCard(this.character);
+                this.player1.clickCard('The Wolf King', 'hand');
+                this.completeSetup();
+
+                // Setup attachments
+                this.player1.clickCard('The Wolf King', 'play area');
+                this.player1.clickCard(this.character);
+
+                this.selectFirstPlayer(this.player1);
+                this.completeMarshalPhase();
+
+                // Set 4 power on Blackfish so he receives the does-not-kneel effect
+                this.character.power = 4;
+
+                // Both the Wolf King and Blackfish effects should keep him standing
+                this.unopposedChallenge(this.player1, 'Military', this.character);
+                this.player1.clickPrompt('Pass');
+                this.player1.clickPrompt('Continue');
+
+                expect(this.character.kneeled).toBe(false);
+
+                // Initiate a non-military challenge
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should not reset the original effect', function() {
+                // Blackfish should still be standing from his own effect
                 expect(this.character.kneeled).toBe(false);
             });
         });


### PR DESCRIPTION
Previously, challenge-related effects such as "does not kneel as
attacker / defender" were implemented by setting and unsetting booleans.
This lead to bugs where if the same card received multiple copies of the
effect (e.g. attaching The Wolf King to The Blackfish at 4 power), when
one of the effects was unset it would erase the other effect.

Now these effects are tracked using a reference-counted set similar to
traits and keywords, to ensure that removing one effect won't remove all
of them at once.

Fixes #2037 