### PR TITLE
Track controller changes by card source

### DIFF
--- a/server/game/TitlePool.js
+++ b/server/game/TitlePool.js
@@ -47,7 +47,7 @@ class TitlePool {
             return;
         }
 
-        card.controller = player;
+        card.takeControl(player, this);
         card.moveTo('title');
         card.applyPersistentEffects();
         player.title = card;
@@ -58,7 +58,7 @@ class TitlePool {
             return;
         }
 
-        card.controller = null;
+        card.revertControl(this);
         card.moveTo('title pool');
         player.title = null;
     }

--- a/server/game/cards/02.5-COW/PullingTheStrings.js
+++ b/server/game/cards/02.5-COW/PullingTheStrings.js
@@ -29,7 +29,7 @@ class PullingTheStrings extends PlotCard {
         this.resolving = true;
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', player, this, card);
-        card.controller = player;
+        card.takeControl(player, this);
 
         let whenRevealed = card.getWhenRevealedAbility();
         if(whenRevealed) {
@@ -38,7 +38,7 @@ class PullingTheStrings extends PlotCard {
             this.game.resolveAbility(whenRevealed, context);
         }
         this.game.queueSimpleStep(() => {
-            card.controller = card.owner;
+            card.revertControl(this);
 
             this.resolving = false;
         });

--- a/server/game/cards/04.1-AtSK/VaryssRiddle.js
+++ b/server/game/cards/04.1-AtSK/VaryssRiddle.js
@@ -43,7 +43,7 @@ class VaryssRiddle extends PlotCard {
 
     resolveWhenRevealed(plot) {
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, plot);
-        plot.controller = this.controller;
+        plot.takeControl(this.controller, this);
         this.resolving = true;
 
         let whenRevealed = plot.getWhenRevealedAbility();
@@ -54,7 +54,7 @@ class VaryssRiddle extends PlotCard {
         }
         this.game.queueSimpleStep(() => {
             this.resolving = false;
-            plot.controller = plot.owner;
+            plot.revertControl(this);
         });
     }
 }

--- a/server/game/cards/04.6-TC/TyrionsChain.js
+++ b/server/game/cards/04.6-TC/TyrionsChain.js
@@ -51,7 +51,7 @@ class TyrionsChain extends DrawCard {
         this.resolving = true;
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, warPlot);
-        warPlot.controller = this.controller;
+        warPlot.takeControl(this.controller, this);
 
         let whenRevealed = warPlot.getWhenRevealedAbility();
         if(whenRevealed) {
@@ -60,7 +60,7 @@ class TyrionsChain extends DrawCard {
             this.game.resolveAbility(whenRevealed, context);
         }
         this.game.queueSimpleStep(() => {
-            warPlot.controller = warPlot.owner;
+            warPlot.revertControl(this);
             this.resolving = false;
         });
         return true;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -50,7 +50,7 @@ class DrawCard extends BaseCard {
 
         clone.attachments = this.attachments.map(attachment => attachment.createSnapshot());
         clone.blanks = this.blanks.clone();
-        clone.controller = this.controller;
+        clone.controllerStack = [...this.controllerStack];
         clone.dupes = this.dupes.map(dupe => dupe.createSnapshot());
         clone.factions = Object.assign({}, this.factions);
         clone.icons = this.icons.clone();

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -685,14 +685,11 @@ const Effects = {
         return {
             apply: function(card, context) {
                 let finalController = typeof newController === 'function' ? newController() : newController;
-                context.takeControl = context.takeControl || {};
-                context.takeControl[card.uuid] = { originalController: card.controller };
-                context.game.takeControl(finalController, card);
+                context.game.takeControl(finalController, card, context.source);
                 context.game.addMessage('{0} uses {1} to take control of {2}', context.source.controller, context.source, card);
             },
             unapply: function(card, context) {
-                context.game.takeControl(context.takeControl[card.uuid].originalController, card);
-                delete context.takeControl[card.uuid];
+                context.game.revertControl(card, context.source);
             }
         };
     },

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -916,7 +916,7 @@ class Game extends EventEmitter {
         });
     }
 
-    takeControl(player, card) {
+    takeControl(player, card, source = null) {
         var oldController = card.controller;
         var newController = player;
 
@@ -934,7 +934,7 @@ class Game extends EventEmitter {
 
         this.applyGameAction('takeControl', card, card => {
             oldController.removeCardFromPile(card);
-            card.controller = newController;
+            card.takeControl(newController, source);
             newController.cardsInPlay.push(card);
 
             if(card.location !== 'play area') {
@@ -946,6 +946,17 @@ class Game extends EventEmitter {
 
             this.raiseEvent('onCardTakenControl', { card: card });
         });
+    }
+
+    revertControl(card, source) {
+        if(card.location !== 'play area') {
+            return;
+        }
+
+        card.controller.removeCardFromPile(card);
+        card.revertControl(source);
+        card.controller.cardsInPlay.push(card);
+        this.raiseEvent('onCardTakenControl', { card: card });
     }
 
     applyGameAction(actionType, cards, func, options = {}) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -647,7 +647,7 @@ class Player extends Spectator {
             card.facedown = this.game.currentPhase === 'setup';
             card.new = true;
             this.moveCard(card, 'play area', { isDupe: !!dupeCard });
-            card.controller = this;
+            card.takeControl(this);
             card.kneeled = playingType !== 'setup' && !!card.entersPlayKneeled || !!options.kneeled;
             card.wasAmbush = (playingType === 'ambush');
 
@@ -806,7 +806,7 @@ class Player extends Spectator {
         }
 
         attachment.moveTo('play area', card);
-        attachment.controller = controller;
+        attachment.takeControl(controller);
         card.attachments.push(attachment);
 
         this.game.queueSimpleStep(() => {
@@ -1150,7 +1150,7 @@ class Player extends Spectator {
     removeCardFromPile(card) {
         if(card.controller !== this) {
             card.controller.removeCardFromPile(card);
-            card.controller = card.owner;
+            card.takeControl(card.owner);
             return;
         }
 

--- a/test/server/card/basecard.takeControl.spec.js
+++ b/test/server/card/basecard.takeControl.spec.js
@@ -1,0 +1,66 @@
+const BaseCard = require('../../../server/game/basecard');
+
+describe('BaseCard', function () {
+    describe('takeControl()', function() {
+        beforeEach(function() {
+            this.owner = { owner: 1 };
+            this.newController = { controller: 1 };
+            this.source = { source: 1 };
+
+            this.card = new BaseCard(this.owner, {});
+        });
+
+        describe('when taking sourced control', function() {
+            beforeEach(function() {
+                this.card.takeControl(this.newController, this.source);
+            });
+
+            it('should update the controller', function() {
+                expect(this.card.controller).toBe(this.newController);
+            });
+
+            it('should handle losing control after another take control', function() {
+                // Revert the earlier control
+                this.card.takeControl(this.owner, { source: 2});
+                this.card.revertControl(this.source);
+
+                expect(this.card.controller).toBe(this.owner);
+            });
+        });
+
+        describe('when taking permanent control as the non-owner', function() {
+            beforeEach(function() {
+                this.card.takeControl(this.newController);
+            });
+
+            it('should update the controller', function() {
+                expect(this.card.controller).toBe(this.newController);
+            });
+
+            it('should clear any other take control effects', function() {
+                this.card.takeControl(this.newController, this.source);
+                this.card.takeControl(this.newController);
+                this.card.revertControl();
+
+                expect(this.card.controller).toBe(this.owner);
+            });
+        });
+
+        describe('when taking permanent control as the owner', function() {
+            beforeEach(function() {
+                this.card.takeControl(this.newController, this.source);
+                this.card.takeControl(this.owner);
+            });
+
+            it('should update the controller', function() {
+                expect(this.card.controller).toBe(this.owner);
+            });
+
+            it('should clear any other take control effects', function() {
+                this.card.revertControl();
+
+                expect(this.card.controller).toBe(this.owner);
+            });
+        });
+    });
+});

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -706,5 +706,47 @@ describe('take control', function() {
                 expect(this.player2Object.discardPile).toContain(this.character);
             });
         });
+
+        describe('competing take control', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('greyjoy', [
+                    'A Noble Cause',
+                    'Sea Bitch', 'Nagga\'s Ribs'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.location = this.player2.findCardByName('Nagga\'s Ribs', 'hand');
+
+                this.player1.clickCard('Sea Bitch', 'hand');
+                this.player2.clickCard('Sea Bitch', 'hand');
+                this.player2.clickCard(this.location);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                // Steal the location
+                this.player1.clickMenu('Sea Bitch', 'Take control of location');
+                this.player1.clickCard(this.location);
+
+                expect(this.location).toBeControlledBy(this.player1);
+
+                // Steal it back
+                this.player2.clickMenu('Sea Bitch', 'Take control of location');
+                this.player2.clickCard(this.location);
+
+                expect(this.location).toBeControlledBy(this.player2);
+
+                // Finish phase, allow effects to expire
+                this.completeMarshalPhase();
+            });
+
+            it('should revert control properly', function() {
+                expect(this.location).toBeControlledBy(this.player2);
+            });
+        });
     });
 });

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -12,7 +12,7 @@ describe('Player', function() {
 
         this.gameSpy.queueSimpleStep.and.callFake(func => func());
 
-        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isBestow', 'isUnique', 'applyPersistentEffects', 'moveTo']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isBestow', 'isUnique', 'applyPersistentEffects', 'moveTo', 'takeControl']);
         this.cardSpy.controller = this.player;
         this.cardSpy.owner = this.player;
         this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
@@ -295,7 +295,7 @@ describe('Player', function() {
             });
 
             it('should transfer control to the player', function () {
-                expect(this.cardSpy.controller).toBe(this.player);
+                expect(this.cardSpy.takeControl).toHaveBeenCalledWith(this.player);
             });
         });
     });


### PR DESCRIPTION
In order to properly revert control back to the most recent control
effect, take control effects are now tracked on a stack.

Lasting effects that take control pass along the source card so that
when they expire, just their controller can be reverted. This prevents
newer controllers from being overwritten when older effects are expired.

Permanent, source-less take control simply clears the stack and adds the
new controller directly.

Fixes #1904 
