### PR TITLE
Use ability's player instead of controller

### DIFF
--- a/server/game/cards/01-Core/ThrowingAxe.js
+++ b/server/game/cards/01-Core/ThrowingAxe.js
@@ -15,7 +15,7 @@ class ThrowingAxe extends DrawCard {
             },
             handler: context => {
                 context.target.controller.killCharacter(context.target);
-                this.game.addMessage('{0} sacrifices {1} to kill {2}', this.controller, this, context.target);
+                this.game.addMessage('{0} sacrifices {1} to kill {2}', context.player, this, context.target);
             }
         });
     }

--- a/server/game/cards/02.5-COW/StinkingDrunk.js
+++ b/server/game/cards/02.5-COW/StinkingDrunk.js
@@ -9,7 +9,7 @@ class StinkingDrunk extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
-                this.game.addMessage('{0} sacrifices {1} to kneel {2}', this.controller, this, context.event.card);
+                this.game.addMessage('{0} sacrifices {1} to kneel {2}', context.player, this, context.event.card);
                 context.event.card.controller.kneelCard(context.event.card);
             }
         });

--- a/server/game/cards/02.5-COW/WinterfellCrypt.js
+++ b/server/game/cards/02.5-COW/WinterfellCrypt.js
@@ -19,7 +19,7 @@ class WinterfellCrypt extends DrawCard {
                     effect: ability.effects.shuffleIntoDeckIfStillInPlay()
                 }));
 
-                this.game.addMessage('{0} sacrifices {1} to choose {2}', this.controller, this, context.target);
+                this.game.addMessage('{0} sacrifices {1} to choose {2}', context.player, this, context.target);
             }
         });
     }

--- a/server/game/cards/03-WotN/JoryCassel.js
+++ b/server/game/cards/03-WotN/JoryCassel.js
@@ -25,7 +25,7 @@ class JoryCassel extends DrawCard {
                     message += ' and have it gain 1 power';
                 }
 
-                this.game.addMessage(message, this.controller, this, toKill);
+                this.game.addMessage(message, context.player, this, toKill);
             }
         });
     }

--- a/server/game/cards/03-WotN/Needle.js
+++ b/server/game/cards/03-WotN/Needle.js
@@ -13,7 +13,7 @@ class Needle extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
-                this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', this.controller, this, context.event.card);
+                this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', context.player, this, context.event.card);
                 context.replaceHandler(() => {
                     context.event.cardStateWhenSacrificed = context.event.card.createSnapshot();
                     this.controller.returnCardToHand(context.event.card, false);

--- a/server/game/cards/03-WotN/RickonStark.js
+++ b/server/game/cards/03-WotN/RickonStark.js
@@ -11,7 +11,7 @@ class RickonStark extends DrawCard {
             handler: context => {
                 context.event.cancel();
 
-                this.game.addMessage('{0} sacrifices {1} to cancel {2}', this.controller, this, context.event.source);
+                this.game.addMessage('{0} sacrifices {1} to cancel {2}', context.player, this, context.event.source);
             }
         });
     }

--- a/server/game/cards/03-WotN/WinterfellHeartTree.js
+++ b/server/game/cards/03-WotN/WinterfellHeartTree.js
@@ -8,16 +8,16 @@ class WinterfellHeartTree extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             target: {
-                cardCondition: card => card.controller === this.controller && card.isFaction('stark')
+                cardCondition: (card, context) => card.controller === context.player && card.isFaction('stark')
             },
             handler: context => {
                 this.untilEndOfPhase(ability => ({
                     match: context.target,
-                    effect: ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'plot')
+                    effect: ability.effects.immuneTo(card => card.controller !== context.player && card.getType() === 'plot')
                 }));
 
                 this.game.addMessage('{0} sacrifices {1} to grant {2} immunity from opponents\' plot effects until the end of the phase',
-                    this.controller, this, context.target);
+                    context.player, this, context.target);
             }
         });
     }

--- a/server/game/cards/04.1-AtSK/CaptainsDaughter.js
+++ b/server/game/cards/04.1-AtSK/CaptainsDaughter.js
@@ -14,7 +14,7 @@ class CaptainsDaughter extends DrawCard {
             handler: context => {
                 context.event.card.owner.moveCard(context.event.card, 'draw deck');
                 this.game.addMessage('{0} sacrifices {1} and kneels their faction card to move {2} to the top of {3}\'s deck',
-                    this.controller, this, context.event.card, context.event.card.owner);
+                    context.player, this, context.event.card, context.event.card.owner);
             }
         });
     }

--- a/server/game/cards/04.5-GoH/Craster.js
+++ b/server/game/cards/04.5-GoH/Craster.js
@@ -17,12 +17,12 @@ class Craster extends DrawCard {
             title: 'Sacrifice to resurrect',
             cost: ability.costs.sacrificeSelf(),
             condition: () => this.tracker.anyKilled(),
-            handler: () => {
+            handler: context => {
                 let characters = this.tracker.killedThisPhase.filter(card => card.location === 'dead pile');
                 _.each(characters, character => {
                     character.owner.putIntoPlay(character);
                 });
-                this.game.addMessage('{0} sacrifices {1} to put into play each character killed this phase', this.controller, this);
+                this.game.addMessage('{0} sacrifices {1} to put into play each character killed this phase', context.player, this);
             }
         });
     }

--- a/server/game/cards/04.5-GoH/Harrenhal.js
+++ b/server/game/cards/04.5-GoH/Harrenhal.js
@@ -13,7 +13,7 @@ class Harrenhal extends DrawCard {
             handler: context => {
                 context.event.card.controller.killCharacter(context.event.card);
                 this.game.addMessage('{0} sacrifices {1} and kneels their faction card to kill {2}',
-                    this.controller, this, context.event.card);
+                    context.player, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/04.5-GoH/RooseBolton.js
+++ b/server/game/cards/04.5-GoH/RooseBolton.js
@@ -22,7 +22,7 @@ class RooseBolton extends DrawCard {
             },
             handler: context => {
                 this.game.killCharacters(context.target);
-                this.game.addMessage('{0} sacrifices {1} to kill {2}', this.controller, this, context.target);
+                this.game.addMessage('{0} sacrifices {1} to kill {2}', context.player, this, context.target);
             }
         });
     }

--- a/server/game/cards/06.2-GtR/ScorchingDeserts.js
+++ b/server/game/cards/06.2-GtR/ScorchingDeserts.js
@@ -15,7 +15,7 @@ class ScorchingDeserts extends DrawCard {
             handler: context => {
                 this.game.currentChallenge.removeFromChallenge(context.event.card);
                 this.game.addMessage('{0} kneels and sacrifices {1} to remove {2} from the challenge',
-                    this.controller, this, context.event.card);
+                    context.player, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -10,7 +10,7 @@ class SpearsOfTheMerlingKing extends DrawCard {
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
                 this.game.addMessage('{0} sacrifices {1} to return {2} to their hand',
-                    this.controller, this, context.event.card);
+                    context.player, this, context.event.card);
                 context.replaceHandler(() => {
                     context.event.cardStateWhenKilled = context.event.card.createSnapshot();
                     this.controller.moveCard(context.event.card, 'hand');

--- a/server/game/cards/06.4-TRW/ImprovedFortifications.js
+++ b/server/game/cards/06.4-TRW/ImprovedFortifications.js
@@ -11,7 +11,7 @@ class ImprovedFortifications extends DrawCard {
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
                 context.event.cancel();
-                this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, this.parent);
+                this.game.addMessage('{0} sacrifices {1} to save {2}', context.player, this, this.parent);
             }
         });
     }

--- a/server/game/cards/07-WotW/JeynePoole.js
+++ b/server/game/cards/07-WotW/JeynePoole.js
@@ -7,9 +7,9 @@ class JeynePoole extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.sacrificeSelf(),
             target: {
-                cardCondition: card => (
+                cardCondition: (card, context) => (
                     card.location === 'discard pile' &&
-                    card.controller === this.controller &&
+                    card.controller === context.player &&
                     card.hasTrait('Lady') &&
                     card.getType() === 'character')
             },

--- a/server/game/cards/08.1-TAK/Ashemark.js
+++ b/server/game/cards/08.1-TAK/Ashemark.js
@@ -21,7 +21,7 @@ class Ashemark extends DrawCard {
                 });
 
                 this.game.addMessage('{0} kneels and sacrifices {1} to return each character with printed cost {2} or less to its owner\'s hand',
-                    this.controller, this, context.cardStateWhenInitiated.tokens.gold);
+                    context.player, this, context.cardStateWhenInitiated.tokens.gold);
             }
         });
     }

--- a/server/game/cards/08.1-TAK/DreadfortMaester.js
+++ b/server/game/cards/08.1-TAK/DreadfortMaester.js
@@ -7,14 +7,14 @@ class DreadfortMaester extends DrawCard {
                 onChallengeInitiated: event => event.challenge.attackingPlayer === this.controller && ['military', 'intrigue'].includes(event.challenge.challengeType)
             },
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
+            handler: context => {
                 this.untilEndOfChallenge(ability => ({
-                    match: card => card === this.controller.activePlot,
+                    match: card => card === context.player.activePlot,
                     effect: ability.effects.modifyClaim(1)
                 }));
 
                 this.game.addMessage('{0} sacrifices {1} to raise the claim value on their revealed plot card by 1 until the end of the challenge',
-                    this.controller, this);
+                    context.player, this);
             }
         });
     }

--- a/server/game/cards/08.1-TAK/Oathkeeper.js
+++ b/server/game/cards/08.1-TAK/Oathkeeper.js
@@ -14,8 +14,8 @@ class Oathkeeper extends DrawCard {
                     event.challenge.isParticipating(this.parent)
             },
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                this.game.promptForDeckSearch(this.controller, {
+            handler: context => {
+                this.game.promptForDeckSearch(context.player, {
                     activePromptTitle: 'Select a card',
                     cardCondition: card => !card.isFaction('tyrell') && card.getType() === 'character',
                     onSelect: (player, card) => this.cardSelected(player, card),

--- a/server/game/cards/09-HoT/LionsTooth.js
+++ b/server/game/cards/09-HoT/LionsTooth.js
@@ -17,7 +17,7 @@ class LionsTooth extends DrawCard {
                 cardCondition: card => card.getType() === 'character' && card.getPrintedCost() <= 3 && this.game.currentChallenge.isParticipating(card)
             },
             handler: context => {
-                this.game.addMessage('{0} sacrifices {1} to return {2} to its owner\'s hand', this.controller, this, context.target);
+                this.game.addMessage('{0} sacrifices {1} to return {2} to its owner\'s hand', context.player, this, context.target);
                 context.target.owner.returnCardToHand(context.target);
             }
         });


### PR DESCRIPTION
Cards that sacrifice themselves as cost need to refer to
`context.player` instead of `this.controller` because if they were
controlled by an opponent, the controller reverts back to its owner
after the sacrifice completes and before targeting / handler for the
ability executes.

Fixes #1790 