### PR TITLE
Fix Bridge of Dream + Rains interaction

### DIFF
--- a/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
+++ b/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
@@ -12,7 +12,7 @@ class TheCrowIsATricksyBird extends DrawCard {
                 this.game.addMessage('{0} plays {1} and kneels their faction card to look at {2}\'s plot deck',
                     context.player, this, context.opponent);
 
-                let validPlots = context.opponent.plotDeck.filter(plot => !plot.notConsideredToBeInPlotDeck);
+                let validPlots = context.opponent.getPlots();
                 let buttons = validPlots.map(card => {
                     return { method: 'cardSelected', card: card, mapCard: true };
                 });

--- a/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
+++ b/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
@@ -15,7 +15,7 @@ class BeneathTheBridgeOfDream extends DrawCard {
                 }
                 // Delay picking the plot until the async recycle above resolves
                 this.game.queueSimpleStep(() => {
-                    let plot = sample(this.controller.plotDeck);
+                    let plot = sample(this.controller.getPlots());
                     this.untilEndOfPhase(ability => ({
                         targetType: 'player',
                         targetController: 'current',

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -207,6 +207,10 @@ class Player extends Spectator {
         return this.plotDiscard.length + this.usedPlotsModifier;
     }
 
+    getPlots() {
+        return this.plotDeck.filter(plot => !plot.notConsideredToBeInPlotDeck);
+    }
+
     addGoldSource(source) {
         this.goldSources.unshift(source);
     }


### PR DESCRIPTION
Beneath the Bridge of Dream should only randomly select non-Scheme plots
in a Rains deck because the Scheme plots are not considered part of the
plot deck during the plot phase.

Fixes #2064 