### PR TITLE
Differentiate kneel/sacrifice *any* costs by whether 0 is allowed

### DIFF
--- a/server/game/cards/08.4-FotOG/Nymeria.js
+++ b/server/game/cards/08.4-FotOG/Nymeria.js
@@ -7,7 +7,7 @@ class Nymeria extends DrawCard {
             condition: () => this.isStarkCardParticipatingInChallenge(),
             cost: [
                 ability.costs.kneelSelf(),
-                ability.costs.kneelAny(card => card.hasTrait('Direwolf') && card.getType() === 'character' && card !== this)
+                ability.costs.kneelAny(card => card.hasTrait('Direwolf') && card.getType() === 'character' && card !== this, true)
             ],
             handler: context => {
                 let direwolvesToAdd = context.getCostValuesFor('kneel');

--- a/server/game/cards/11.2-TMoW/SteelRain.js
+++ b/server/game/cards/11.2-TMoW/SteelRain.js
@@ -4,7 +4,7 @@ class SteelRain extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Search deck for GJ locations',
-            cost: ability.costs.sacrificeAny(card => card.isFaction('greyjoy') && card.getType() === 'location'),
+            cost: ability.costs.sacrificeAny(card => card.isFaction('greyjoy') && card.getType() === 'location', false),
             handler: context => {
                 for(let costCard of context.costs.sacrifice) {
                     this.game.promptForDeckSearch(context.player, {

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -51,7 +51,7 @@ const Costs = {
      * Cost that requires kneeling any number of cards that match the
      * passed condition predicate function.
      */
-    kneelAny: (condition) => CostBuilders.kneel.selectAny(condition),
+    kneelAny: (condition, zeroAllowed) => CostBuilders.kneel.selectAny(condition, zeroAllowed),
     /**
      * Cost that will sacrifice the card that initiated the ability.
      */
@@ -65,7 +65,7 @@ const Costs = {
      * Cost that requires sacrificing any number of cards that match the
      * passed condition predicate function.
      */
-    sacrificeAny: (condition) => CostBuilders.sacrifice.selectAny(condition),
+    sacrificeAny: (condition, zeroAllowed) => CostBuilders.sacrifice.selectAny(condition, zeroAllowed),
     /**
      * Cost that will kill the card that initiated the ability.
      */

--- a/server/game/costs/CostBuilder.js
+++ b/server/game/costs/CostBuilder.js
@@ -58,12 +58,13 @@ class CostBuilder {
     }
 
     /**
-     * Returns a cost that asks the player to select any number of cards (including 0) matching the passed condition.
+     * Returns a cost that asks the player to select any number of cards matching the passed condition.
      * @param {function} condition Function that takes a card and ability context and returns whether to allow the player to select it.
+     * @param {boolean} zeroAllowed Boolean denoting whether 0 is a valid amount of the cost to be paid.
      */
-    selectAny(condition = () => true) {
+    selectAny(condition = () => true, zeroAllowed = true) {
         return new SelectCardCost(this.action, {
-            mode: 'optional',
+            mode: zeroAllowed ? 'optional' : 'unlimited',
             activePromptTitle: this.titles.selectAny,
             cardCondition: condition
         });


### PR DESCRIPTION
Fixes a bug where "Steel Rain" could be played without sacrificing any locations.