### PR TITLE
Check for unserializable data in integration tests

### DIFF
--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -7,6 +7,7 @@ const https = require('https');
 const fs = require('fs');
 
 const config = require('./nodeconfig.js');
+const { detectBinary } = require('../util');
 const logger = require('../log.js');
 const ZmqSocket = require('./zmqsocket.js');
 const Game = require('../game/game.js');
@@ -105,7 +106,7 @@ class GameServer {
         let debugData = {};
 
         if(e.message.includes('Maximum call stack')) {
-            debugData.badSerializaton = this.detectBinary(gameState);
+            debugData.badSerializaton = detectBinary(gameState);
         } else {
             debugData.game = gameState;
             debugData.game.players = undefined;
@@ -123,32 +124,6 @@ class GameServer {
         if(game) {
             game.addMessage('A Server error has occured processing your game state, apologies.  Your game may now be in an inconsistent state, or you may be able to continue.  The error has been logged.');
         }
-    }
-
-    detectBinary(state, path = '', results = []) {
-        const allowedTypes = ['Array', 'Boolean', 'Date', 'Number', 'Object', 'String'];
-
-        if(!state) {
-            return results;
-        }
-
-        let type = state.constructor.name;
-
-        if(!allowedTypes.includes(type)) {
-            results.push({ path: path, type: type });
-        }
-
-        if(type === 'Object') {
-            for(let key in state) {
-                this.detectBinary(state[key], `${path}.${key}`, results);
-            }
-        } else if(type === 'Array') {
-            for(let i = 0; i < state.length; ++i) {
-                this.detectBinary(state[i], `${path}[${i}]`, results);
-            }
-        }
-
-        return results;
     }
 
     clearStaleFinishedGames() {

--- a/server/util.js
+++ b/server/util.js
@@ -22,7 +22,34 @@ function wrapAsync(fn) {
     };
 }
 
+function detectBinary(state, path = '', results = []) {
+    const allowedTypes = ['Array', 'Boolean', 'Date', 'Number', 'Object', 'String'];
+
+    if(!state) {
+        return results;
+    }
+
+    let type = state.constructor.name;
+
+    if(!allowedTypes.includes(type)) {
+        results.push({ path: path, type: type });
+    }
+
+    if(type === 'Object') {
+        for(let key in state) {
+            detectBinary(state[key], `${path}.${key}`, results);
+        }
+    } else if(type === 'Array') {
+        for(let i = 0; i < state.length; ++i) {
+            detectBinary(state[i], `${path}[${i}]`, results);
+        }
+    }
+
+    return results;
+}
+
 module.exports = {
+    detectBinary: detectBinary,
     escapeRegex: escapeRegex,
     httpRequest: httpRequest,
     wrapAsync: wrapAsync

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -34,6 +34,7 @@ class GameFlowWrapper {
             players: this.generatePlayerDetails(options.numOfPlayers || (options.isMelee ? 3 : 2))
         };
         this.game = new Game(details, { router: gameRouter, titleCardData: titleCardData });
+        this.game.started = true;
 
         this.allPlayers = this.game.getPlayers().map(player => new PlayerInteractionWrapper(this.game, player));
     }

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -2,6 +2,7 @@ const _ = require('underscore');
 const uuid = require('uuid');
 
 const { matchCardByNameAndPack } = require('./cardutil.js');
+const { detectBinary } = require('../../server/util');
 
 class PlayerInteractionWrapper {
     constructor(game, player) {
@@ -114,6 +115,7 @@ class PlayerInteractionWrapper {
 
         this.game.menuButton(this.player.name, promptButton.arg, promptButton.method);
         this.game.continue();
+        this.checkUnserializableGameState();
     }
 
     clickCard(card, location = 'any') {
@@ -127,6 +129,7 @@ class PlayerInteractionWrapper {
 
         this.game.cardClicked(this.player.name, card.uuid);
         this.game.continue();
+        this.checkUnserializableGameState();
     }
 
     clickMenu(card, menuText) {
@@ -142,6 +145,7 @@ class PlayerInteractionWrapper {
 
         this.game.menuItemClick(this.player.name, card.uuid, items[0]);
         this.game.continue();
+        this.checkUnserializableGameState();
     }
 
     triggerAbility(cardOrCardName) {
@@ -177,6 +181,7 @@ class PlayerInteractionWrapper {
     dragCard(card, targetLocation) {
         this.game.drop(this.player.name, card.uuid, card.location, targetLocation);
         this.game.continue();
+        this.checkUnserializableGameState();
     }
 
     togglePromptedActionWindow(window, value) {
@@ -194,6 +199,15 @@ class PlayerInteractionWrapper {
 
     mockShuffle(func) {
         this.player.shuffleArray = func;
+    }
+
+    checkUnserializableGameState() {
+        let state = this.game.getState(this.player.name);
+        let results = detectBinary(state);
+
+        if(results.length !== 0) {
+            throw new Error('Unable to serialize game state back to client:\n' + JSON.stringify(results));
+        }
     }
 }
 


### PR DESCRIPTION
Since integration tests do not run an actual game server + socket.io,
the tests would not detect changes that added unserializable data to
either game messages or as properties on player or card state. Now the
integration tests check that there is no unserializable data in the game
state that would be sent to the client after every player input in the
tests.