### PR TITLE
Don't change attachment controller after moving with Aryas Gift

### DIFF
--- a/server/game/cards/03-WotN/AryasGift.js
+++ b/server/game/cards/03-WotN/AryasGift.js
@@ -5,28 +5,29 @@ class AryasGift extends DrawCard {
         this.action({
             title: 'Move attachment',
             target: {
+                type: 'select',
                 activePromptTitle: 'Select an attachment',
-                cardCondition: card => card.getType && card.getType() === 'attachment' && card.parent &&
-                    card.parent.isFaction('stark') && card.parent.controller === this.controller
+                cardCondition: card => card.location === 'play area' && card.getType() === 'attachment' && card.parent &&
+                                       card.parent.isFaction('stark') && card.parent.getType() === 'character' && 
+                                       card.parent.controller === this.controller
             },
             handler: context => {
                 let attachment = context.target;
-                let oldOwner = attachment.parent;
+                let oldParent = attachment.parent;
 
                 this.game.promptForSelect(this.controller, {
                     cardCondition: card => card.getType() === 'character' && card.controller === this.controller &&
-                        card !== oldOwner && this.controller.canAttach(attachment, card) && card.location === 'play area',
-                    onSelect: (player, card) => this.moveAttachment(player, card, attachment, oldOwner)
+                        card !== oldParent && this.controller.canAttach(attachment, card) && card.location === 'play area',
+                    onSelect: (player, card) => this.moveAttachment(player, card, attachment, oldParent)
                 });
 
             }
         });
     }
 
-    moveAttachment(player, newOwner, attachment, oldOwner) {
-        player.attach(player, attachment, newOwner);
-        this.game.addMessage('{0} moves {1} from {2} to {3}', player, attachment, oldOwner, newOwner);
-
+    moveAttachment(player, newParent, attachment, oldParent) {
+        player.attach(attachment.controller, attachment, newParent);
+        this.game.addMessage('{0} plays {1} to move {2} from {3} to {4}', player, this, attachment, oldParent, newParent);
         return true;
     }
 }


### PR DESCRIPTION
Fixes a bug where, after having moved an opponent's attachment with Aryas Gift, the opponent was unable to use that attachment to trigger Trading with Qohor.