### PR TITLE
Limit Qohor to search different cards by name

### DIFF
--- a/server/game/cards/11.2-TMoW/TradingWithQohor.js
+++ b/server/game/cards/11.2-TMoW/TradingWithQohor.js
@@ -17,7 +17,8 @@ class TradingWithQohor extends AgendaCard {
             handler: context => {
                 this.game.promptForDeckSearch(context.player, {
                     activePromptTitle: 'Select a card',
-                    cardType: 'attachment',
+                    cardCondition: card => card.getType() === 'attachment' && card.getPrintedCost() <= context.costs.sacrifice.getPrintedCost() &&
+                                           card.name !== context.costs.sacrifice.name,
                     onSelect: (player, card) => this.cardSelected(player, card, context.costs.sacrifice),
                     onCancel: player => this.doneSelecting(player, context.costs.sacrifice),
                     source: this


### PR DESCRIPTION
Also make sure only attachments with equal or lower printed cost can be searched.