### PR TITLE
Turn on effects for Alliance agendas

### DIFF
--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -47,14 +47,12 @@ class SetupPhase extends Phase {
     }
 
     turnOnEffects() {
-        for(const player of this.game.getPlayers()) {
-            if(player.agenda) {
-                player.agenda.applyPersistentEffects();
-            }
-        }
-
         for(const card of this.game.allCards) {
             card.applyAnyLocationPersistentEffects();
+
+            if(card.getType() === 'agenda') {
+                card.applyPersistentEffects();
+            }
         }
     }
 

--- a/test/server/cards/11.2-TMoW/TradingWithQohor.spec.js
+++ b/test/server/cards/11.2-TMoW/TradingWithQohor.spec.js
@@ -1,38 +1,66 @@
 describe('Trading With Qohor', function() {
     integration(function() {
         describe('vs Alliance', function() {
-            beforeEach(function() {
-                const deck = this.buildDeck('targaryen', [
-                    'Alliance', 'Banner of the Kraken', 'Trading With Qohor',
-                    'A Noble Cause',
-                    'Hedge Knight', 'Little Bird', 'Noble Lineage'
-                ]);
-                this.player1.selectDeck(deck);
-                this.player2.selectDeck(deck);
-                this.startGame();
-                this.keepStartingHands();
+            describe('when the player controls an attachment', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('targaryen', [
+                        'Alliance', 'Banner of the Kraken', 'Trading With Qohor',
+                        'A Noble Cause',
+                        'Hedge Knight', 'Little Bird', 'Noble Lineage'
+                    ]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
 
-                this.character = this.player1.findCardByName('Hedge Knight');
-                this.origAttachment = this.player1.findCardByName('Little Bird');
+                    this.character = this.player1.findCardByName('Hedge Knight');
+                    this.origAttachment = this.player1.findCardByName('Little Bird');
 
-                this.player1.clickCard(this.character);
-                this.player1.clickCard(this.origAttachment);
+                    this.player1.clickCard(this.character);
+                    this.player1.clickCard(this.origAttachment);
 
-                this.completeSetup();
+                    this.completeSetup();
 
-                this.player1.clickCard(this.origAttachment);
-                this.player1.clickCard(this.character);
+                    this.player1.clickCard(this.origAttachment);
+                    this.player1.clickCard(this.character);
 
-                this.selectFirstPlayer(this.player1);
+                    this.selectFirstPlayer(this.player1);
 
-                this.completeMarshalPhase();
+                    this.completeMarshalPhase();
+                });
 
-                this.unopposedChallenge(this.player1, 'Intrigue', this.character);
-                this.player1.clickPrompt('Apply Claim');
+                it('should allow Trading with Qohor to trigger', function() {
+                    this.unopposedChallenge(this.player1, 'Intrigue', this.character);
+                    this.player1.clickPrompt('Apply Claim');
+
+                    expect(this.player1).toAllowAbilityTrigger('Trading With Qohor');
+                });
+
+                it('should not grant the opponent additional gold', function() {
+                    expect(this.player2Object.gold).toBe(5);
+                });
             });
 
-            it('should allow Trading with Qohor to trigger', function() {
-                expect(this.player1).toAllowAbilityTrigger('Trading With Qohor');
+            describe('when the player does not control an attachment', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('targaryen', [
+                        'Alliance', 'Banner of the Kraken', 'Trading With Qohor',
+                        'A Noble Cause',
+                        'Hedge Knight'
+                    ]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.completeSetup();
+                    this.selectFirstPlayer(this.player1);
+                    this.completeMarshalPhase();
+                });
+
+                it('should grant the opponent additional gold', function() {
+                    expect(this.player2Object.gold).toBe(6);
+                });
             });
         });
     });


### PR DESCRIPTION
Previously, only the agenda in the 'agenda' location was having its
effects activated. This lead to Trading with Qohor not granting the gold
bonus to opponents when it was bannered using the Alliance agenda. Now
all agenda cards have their effects activated during the setup phase.

Fixes #2102 