### PR TITLE
Track which targets have effects applied

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -105,14 +105,9 @@ class EffectEngine {
     }
 
     recalculateTargetingChange(card) {
-        _.each(this.effects, effect => {
-            if(effect.duration === 'persistent' && effect.hasTarget(card) && !effect.isValidTarget(card)) {
-                effect.removeTarget(card);
-            }
-            effect.addTargets([card]);
-        });
-
-        this.addTargetForPersistentEffects(card, 'play area');
+        for(let effect of this.effects) {
+            effect.reapply([card]);
+        }
     }
 
     addTargetForPersistentEffects(card, targetLocation) {

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -23,7 +23,7 @@ describe('Effect', function() {
         this.sourceSpy = jasmine.createSpyObj('source', ['getType', 'isAnyBlank']);
         this.properties = {
             match: jasmine.createSpy('match'),
-            duration: 'persistent',
+            duration: 'untilEndOfPhase',
             effect: {
                 apply: jasmine.createSpy('apply'),
                 unapply: jasmine.createSpy('unapply')
@@ -144,9 +144,9 @@ describe('Effect', function() {
                     this.matchingCard.allowGameAction.and.returnValue(false);
                 });
 
-                it('should reject the target', function() {
+                it('should not add the target to the applied target list', function() {
                     this.effect.addTargets([this.matchingCard]);
-                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                    expect(this.effect.appliedTargets).not.toContain(this.matchingCard);
                 });
             });
 
@@ -428,7 +428,9 @@ describe('Effect', function() {
         describe('when the effect is active', function() {
             beforeEach(function() {
                 this.effect.active = true;
-                this.effect.targets = [this.target];
+                this.effect.addTargets([this.target]);
+
+                this.properties.effect.apply.calls.reset();
             });
 
             describe('and is set to inactive', function() {
@@ -522,8 +524,8 @@ describe('Effect', function() {
 
     describe('cancel()', function() {
         beforeEach(function() {
-            this.target = {};
-            this.effect.targets = [this.target];
+            this.target = createTarget({ target: 1, location: 'play area' });
+            this.effect.addTargets([this.target]);
             this.effect.cancel();
         });
 
@@ -540,8 +542,10 @@ describe('Effect', function() {
         beforeEach(function() {
             this.target = createTarget({ target: 1, location: 'play area' });
             this.newTarget = createTarget({ target: 2, location: 'play area' });
-            this.effect.targets = [this.target];
+            this.effect.addTargets([this.target]);
             this.newTargets = [this.target, this.newTarget];
+
+            this.properties.effect.apply.calls.reset();
         });
 
         describe('when the effect is neither state dependent nor conditional', function() {
@@ -557,8 +561,8 @@ describe('Effect', function() {
                     this.effect.reapply(this.newTargets);
                 });
 
-                it('should not unapply the effect from existing targets', function() {
-                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                it('should unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
                 });
 
                 it('should not apply the effect for new or existing targets', function() {
@@ -596,8 +600,8 @@ describe('Effect', function() {
                     this.effect.reapply(this.newTargets);
                 });
 
-                it('should not unapply the effect from existing targets', function() {
-                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                it('should unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
                 });
 
                 it('should not apply the effect for new or existing targets', function() {
@@ -666,8 +670,8 @@ describe('Effect', function() {
                     this.effect.reapply(this.newTargets);
                 });
 
-                it('should not unapply the effect from existing targets', function() {
-                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                it('should unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
                 });
 
                 it('should not apply the effect from existing targets', function() {

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -18,7 +18,7 @@ describe('EffectEngine', function() {
         this.gameSpy.queueSimpleStep.and.callFake(func => func());
         this.gameSpy.allCards = [this.handCard, this.playAreaCard, this.discardedCard, this.drawCard, this.deadCard, this.activePlot, this.plotCard, this.revealedPlot, this.agendaCard, this.factionCard];
 
-        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive']);
+        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive', 'updateImmunityStatus']);
         this.effectSpy.isInActiveLocation.and.returnValue(true);
         this.effectSpy.targetLocation = 'play area';
 

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -77,6 +77,118 @@ describe('effects', function() {
                     expect(this.dany.location).toBe('dead pile');
                 });
             });
+
+            describe('when gaining immunity after a lasting effect is applied', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('targaryen', [
+                        'Trading with the Pentoshi',
+                        'Maester Caleotte', 'Maester Aemon (Core)', 'Benjen Stark', 'Dragonglass Dagger'
+                    ]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.intrigueChar = this.player1.findCardByName('Maester Aemon', 'hand');
+                    this.benjen = this.player1.findCardByName('Benjen Stark', 'hand');
+                    this.dagger = this.player1.findCardByName('Dragonglass Dagger', 'hand');
+                    this.caleotte = this.player2.findCardByName('Maester Caleotte', 'hand');
+
+                    this.player1.clickCard(this.intrigueChar);
+                    this.player1.clickCard(this.benjen);
+                    this.player2.clickCard(this.caleotte);
+
+                    this.completeSetup();
+                    this.selectFirstPlayer(this.player1);
+                    this.selectPlotOrder(this.player1);
+                    this.completeMarshalPhase();
+
+                    // Lose the first challenge
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard(this.intrigueChar);
+                    this.player1.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.player2.clickCard(this.caleotte);
+                    this.player2.clickPrompt('Done');
+                    this.skipActionWindow();
+
+                    // Trigger Caleotte and remove an icon from Benjen
+                    this.player2.triggerAbility(this.caleotte);
+                    this.player2.clickCard(this.benjen);
+                    this.player2.clickPrompt('Military');
+
+                    this.player1.clickPrompt('Apply Claim');
+
+                    // Get Benjen participating in a challenge
+                    this.player1.clickPrompt('Power');
+                    this.player1.clickCard(this.benjen);
+                    this.player1.clickPrompt('Done');
+
+                    // Manually drag the dagger into play
+                    this.player1.dragCard(this.dagger, 'play area');
+                    this.player1.clickCard(this.benjen);
+                });
+
+                it('should not remove the previously applied effect', function() {
+                    expect(this.benjen.hasIcon('Military')).toBe(false);
+                });
+            });
+
+            describe('when a card leaves and re-enters play', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('targaryen', [
+                        'Trading with the Pentoshi',
+                        'Daenerys Targaryen (TFM)', 'A Dragon Is No Slave', 'Viserion (Core)', 'Fire and Blood'
+                    ]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.character = this.player2.findCardByName('Viserion', 'hand');
+
+                    this.player1.clickCard('Daenerys Targaryen', 'hand');
+                    this.player2.clickCard(this.character);
+
+                    this.completeSetup();
+                    this.selectFirstPlayer(this.player2);
+                    this.selectPlotOrder(this.player1);
+                    this.completeMarshalPhase();
+
+                    this.player2.clickPrompt('Power');
+                    this.player2.clickCard(this.character);
+                    this.player2.clickPrompt('Done');
+
+                    // Kill Viserion
+                    this.player1.clickCard('A Dragon Is No Slave', 'hand');
+                    this.player1.clickCard(this.character);
+                    this.player1.triggerAbility('Daenerys Targaryen');
+                    this.player1.clickCard(this.character);
+
+                    // Bring Viserion back into play
+                    this.player2.clickCard('Fire and Blood', 'hand');
+                    this.player2.clickCard(this.character);
+                    this.player2.clickPrompt('Yes');
+
+                    this.player2.clickPrompt('Pass');
+                    this.player1.clickPrompt('Pass');
+                    this.player1.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    // Declare Viserion in a challenge to force a recalculation
+                    // of effects
+                    this.player2.clickPrompt('Military');
+                    this.player2.clickCard(this.character);
+                    this.player2.clickPrompt('Done');
+                });
+
+                it('should not re-apply the previously applied effect', function() {
+                    // Viserion should remain in play and not immediately killed
+                    // by the previous burn effect
+                    expect(this.character.location).toBe('play area');
+                });
+            });
         });
 
         describe('when blanking / unblanking a dynamically calculated conditional effect', function() {


### PR DESCRIPTION
Previously, if a target for an effect had immunity to that effect, it
simply wasn't added as a target. In order to handle cases where immunity
wears off after the effect is already applied, it will now be added as a
target but not have the effect applied to it.

Additionally, gaining immunity after a lasting effect has already been
applied will no longer unapply the effect, per RRG rules.

Fixes #2098 