### PR TITLE
Ensure first player order for reserve prompt

### DIFF
--- a/server/game/gamesteps/taxation/DiscardToReservePrompt.js
+++ b/server/game/gamesteps/taxation/DiscardToReservePrompt.js
@@ -1,6 +1,4 @@
-const _ = require('underscore');
-
-const BaseStep = require('../basestep.js');
+const BaseStep = require('../basestep');
 
 class DiscardToReservePrompt extends BaseStep {
     constructor(game) {
@@ -9,16 +7,18 @@ class DiscardToReservePrompt extends BaseStep {
     }
 
     continue() {
-        this.remainingPlayers = _.reject(this.remainingPlayers, player => player.isBelowReserve());
+        while(this.remainingPlayers.length !== 0) {
+            let currentPlayer = this.remainingPlayers.shift();
 
-        if(_.isEmpty(this.remainingPlayers)) {
-            this.game.raiseEvent('onReserveChecked');
-            return true;
+            if(currentPlayer.isBelowReserve()) {
+                this.game.addMessage('{0} is already below their reserve value', currentPlayer);
+            } else {
+                this.promptPlayerToDiscard(currentPlayer);
+                return false;
+            }
         }
 
-        this.promptPlayerToDiscard(this.remainingPlayers[0]);
-
-        return false;
+        this.game.raiseEvent('onReserveChecked');
     }
 
     promptPlayerToDiscard(currentPlayer) {
@@ -40,9 +40,6 @@ class DiscardToReservePrompt extends BaseStep {
         cards = cards.reverse();
         player.discardCards(cards, false, () => {
             this.game.addMessage('{0} discards {1} to meet reserve', player, cards);
-            if(player.isBelowReserve()) {
-                this.remainingPlayers = this.remainingPlayers.slice(1);
-            }
         });
         return true;
     }

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -1,7 +1,7 @@
 const _ = require('underscore');
 const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
-const DiscardToReservePrompt = require('./taxation/discardtoreserveprompt.js');
+const DiscardToReservePrompt = require('./taxation/DiscardToReservePrompt');
 const ActionWindow = require('./actionwindow.js');
 
 class TaxationPhase extends Phase {
@@ -9,7 +9,7 @@ class TaxationPhase extends Phase {
         super(game, 'taxation');
         this.initialise([
             new SimpleStep(game, () => this.returnGold()),
-            new DiscardToReservePrompt(game),
+            () => new DiscardToReservePrompt(game),
             new SimpleStep(game, () => this.returnTitleCards()),
             new ActionWindow(game, 'After reserve check', 'taxation'),
             new SimpleStep(game, () => this.roundEnded())


### PR DESCRIPTION
Previously, the prompt to discard down to reserve was being created at
the beginning of each round. Because of this, the `remainingPlayers`
array was always in first player order for the previous round, which may
not match the first player order for the current round after plots are
revealed.

Now the prompt is created on demand when the proper step in the pipeline
has been reached.

Additionally, a message has been added when a player does not have to
discard to meet reserve to make it more clear for both players and
spectators on what's happening.