### PR TITLE
Fix mustBeDeclaredAsDefender effect

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -129,7 +129,7 @@ class ChallengeFlow extends BaseStep {
         this.forcedDefenders = this.challenge.defendingPlayer.filterCardsInPlay(card => {
             return card.getType() === 'character' &&
                 card.canDeclareAsDefender(this.challenge.challengeType) &&
-                card.challengeOptions.mustBeDeclaredAsDefender;
+                card.challengeOptions.contains('mustBeDeclaredAsDefender');
         });
 
         let defenderMaximum = this.challenge.defendingPlayer.defenderLimits.getMax();


### PR DESCRIPTION
Fixes a bug where this effect was executed incorrectly after challengeOptions was converted to a reference counted set property.