### PR TITLE
Force boolean on card loyalty check

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -377,7 +377,7 @@ class BaseCard {
     }
 
     isLoyal() {
-        return this.cardData.loyal;
+        return !!this.cardData.loyal;
     }
 
     applyAnyLocationPersistentEffects() {


### PR DESCRIPTION
The carddata does not include loyalty data for neutral cards anymore, which caused a bug where Turncloak could not be attached to neutral characters as the attachment check was trying to match undefined to false.

Fixes #2122.