### PR TITLE
Move targetType from effect usage to definition

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -236,12 +236,18 @@ this.persistentEffect({
 
 #### Player modifying effects
 
-Certain cards provide bonuses or restrictions on the player itself instead of on any specific cards. These can be implemented setting the `targetType` to `'player'` and using the appropriate effect.
+Certain cards provide bonuses or restrictions on the player itself instead of on any specific cards. Such effects can be implemented setting the `targetType` to `'player'`.
+
+```javascript
+mayInitiateAdditionalChallenge: function(challengeType) {
+    targetType: 'player',
+    // ...
+}
+```
 
 ```javascript
 // You may initiate an additional  challenge during the challenges phase.
 this.persistentEffect({
-    targetType: 'player',
     targetController: 'current',
     effect: ability.effects.mayInitiateAdditionalChallenge('military')
 });
@@ -266,7 +272,6 @@ To apply an effect to last until the end of the current phase, use `untilEndOfPh
 ```javascript
 // Until the end of the phase, the current player can initiate an additional power challenge.
 this.untilEndOfPhase(ability => ({
-    targetType: 'player',
     targetController: 'current',
     effect: ability.effects.mayInitiateAdditionalChallenge('power')
 }));

--- a/server/game/cards/00-VDS/HouseBannerman.js
+++ b/server/game/cards/00-VDS/HouseBannerman.js
@@ -12,7 +12,6 @@ class HouseBannerman extends DrawCard {
                     this.controller, this, this.controller.getFaction());
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         1,

--- a/server/game/cards/00-VDS/ThePowerOfWealth.js
+++ b/server/game/cards/00-VDS/ThePowerOfWealth.js
@@ -11,7 +11,6 @@ class ThePowerOfWealth extends AgendaCard {
 
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceFirstMarshalledOrPlayedCardCostEachRound(1, card => card.isFaction(this.controller.getFaction()))
         });

--- a/server/game/cards/00-VDS/UnitingTheSevenKingdoms.js
+++ b/server/game/cards/00-VDS/UnitingTheSevenKingdoms.js
@@ -3,7 +3,6 @@ const AgendaCard = require('../../agendacard.js');
 class UnitingTheSevenKingdoms extends AgendaCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.increaseCost({
                 playingTypes: ['marshal', 'play'],

--- a/server/game/cards/01-Core/AGameOfThrones.js
+++ b/server/game/cards/01-Core/AGameOfThrones.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class AGameOfThrones extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             match: player => player.getNumberOfChallengesWon('intrigue') < 1,
             effect: [

--- a/server/game/cards/01-Core/ANobleCause.js
+++ b/server/game/cards/01-Core/ANobleCause.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class ANobleCause extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceFirstMarshalledCardCostEachRound(2, card => card.hasTrait('Lord') || card.hasTrait('Lady'))
         });

--- a/server/game/cards/01-Core/AStormOfSwords.js
+++ b/server/game/cards/01-Core/AStormOfSwords.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class AStormOfSwords extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.mayInitiateAdditionalChallenge('military')
         });

--- a/server/game/cards/01-Core/CasterlyRock.js
+++ b/server/game/cards/01-Core/CasterlyRock.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class CasterlyRock extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.mayInitiateAdditionalChallenge('intrigue')
         });

--- a/server/game/cards/01-Core/CatelynStark.js
+++ b/server/game/cards/01-Core/CatelynStark.js
@@ -4,7 +4,6 @@ class CatelynStark extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.isParticipating(),
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.cannotTriggerCardAbilities()
         });

--- a/server/game/cards/01-Core/Fealty.js
+++ b/server/game/cards/01-Core/Fealty.js
@@ -8,7 +8,6 @@ class Fealty extends AgendaCard {
             handler: () => {
                 this.game.addMessage('{0} uses {1} to kneel their faction card and reduce the cost of the next loyal card by 1', this.controller, this);
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledOrPlayedCardCost(1, card => card.isLoyal())
                 }));

--- a/server/game/cards/01-Core/JoustingContest.js
+++ b/server/game/cards/01-Core/JoustingContest.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class JoustingContest extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             effect: [
                 ability.effects.setAttackerMaximum(1),

--- a/server/game/cards/01-Core/KhalDrogo.js
+++ b/server/game/cards/01-Core/KhalDrogo.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class KhalDrogo extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.mayInitiateAdditionalChallenge('military')
         });

--- a/server/game/cards/01-Core/MarchingOrders.js
+++ b/server/game/cards/01-Core/MarchingOrders.js
@@ -3,11 +3,9 @@ const PlotCard = require('../../plotcard.js');
 class MarchingOrders extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.cannotMarshal(card => card.getType() === 'location' || card.getType() === 'attachment')
         });
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.cannotPlay(card => card.getType() === 'event')
         });
     }

--- a/server/game/cards/01-Core/OlennasInformant.js
+++ b/server/game/cards/01-Core/OlennasInformant.js
@@ -21,7 +21,6 @@ class OlennasInformant extends DrawCard {
 
     challengeSelected(player, challenge) {
         this.untilEndOfPhase(ability => ({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.mayInitiateAdditionalChallenge(challenge)
         }));

--- a/server/game/cards/01-Core/PaxterRedwyne.js
+++ b/server/game/cards/01-Core/PaxterRedwyne.js
@@ -6,7 +6,6 @@ class PaxterRedwyne extends DrawCard {
             gold: 1
         });
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceFirstPlayedCardCostEachRound(1, card => card.getType() === 'event')
         });

--- a/server/game/cards/01-Core/SneakAttack.js
+++ b/server/game/cards/01-Core/SneakAttack.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class SneakAttack extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.setMaxChallenge(1)
         });

--- a/server/game/cards/01-Core/StannisBaratheon.js
+++ b/server/game/cards/01-Core/StannisBaratheon.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class StannisBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.cannotStandMoreThan(2, card => card.getType() === 'character')
         });

--- a/server/game/cards/01-Core/Taxation.js
+++ b/server/game/cards/01-Core/Taxation.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class Taxation extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.modifyMaxLimited(1)
         });
     }

--- a/server/game/cards/01-Core/TheKingsroad.js
+++ b/server/game/cards/01-Core/TheKingsroad.js
@@ -22,7 +22,6 @@ class TheKingsroad extends DrawCard {
                 let currentController = context.player;
                 this.game.addMessage('{0} kneels and sacrifices {1} to reduce the cost of the next character by 3', currentController, this);
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'any',
                     match: player => player === currentController,
                     effect: ability.effects.reduceNextMarshalledCardCost(3, card => card.getType() === 'character')

--- a/server/game/cards/01-Core/TheKnightOfFlowers.js
+++ b/server/game/cards/01-Core/TheKnightOfFlowers.js
@@ -5,7 +5,6 @@ class TheKnightOfFlowers extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.isDuringChallenge({ attackingAlone: this }),
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.setDefenderMaximum(1)
         });

--- a/server/game/cards/01-Core/TheRedKeep.js
+++ b/server/game/cards/01-Core/TheRedKeep.js
@@ -9,7 +9,6 @@ class TheRedKeep extends DrawCard {
                 this.game.currentChallenge.challengeType === 'power' &&
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller) &&
                 this.controller.canDraw(),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.contributeChallengeStrength(2)
         });

--- a/server/game/cards/01-Core/TheSwordInTheDarkness.js
+++ b/server/game/cards/01-Core/TheSwordInTheDarkness.js
@@ -15,7 +15,6 @@ class TheSwordInTheDarkness extends DrawCard {
                 this.game.addMessage('{0} plays {1} to prevent {2} from initiating any more challenges this round', this.controller, this, opponent);
 
                 this.untilEndOfRound(ability => ({
-                    targetType: 'player',
                     targetController: opponent,
                     effect: ability.effects.cannotInitiateChallengeAgainst(this.controller)
                 }));

--- a/server/game/cards/01-Core/UnbowedUnbentUnbroken.js
+++ b/server/game/cards/01-Core/UnbowedUnbentUnbroken.js
@@ -26,7 +26,6 @@ class UnbowedUnbentUnbroken extends DrawCard {
 
     trigger(player, challengeType) {
         this.untilEndOfPhase(ability => ({
-            targetType: 'player',
             targetController: this.challengeWinner,
             effect: ability.effects.cannotInitiateChallengeType(challengeType)
         }));

--- a/server/game/cards/02.1-TtB/RenlyBaratheon.js
+++ b/server/game/cards/02.1-TtB/RenlyBaratheon.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class RenlyBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceFirstMarshalledCardCostEachRound(1, card => (
                 card.getType() === 'character' &&

--- a/server/game/cards/02.1-TtB/TheLongPlan.js
+++ b/server/game/cards/02.1-TtB/TheLongPlan.js
@@ -12,7 +12,6 @@ class TheLongPlan extends PlotCard {
             }
         });
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.doesNotReturnUnspentGold()
         });
     }

--- a/server/game/cards/02.2-TRtW/BrandonsGift.js
+++ b/server/game/cards/02.2-TRtW/BrandonsGift.js
@@ -14,7 +14,6 @@ class BrandonsGift extends DrawCard {
             limit: ability.limit.perPhase(3),
             handler: () => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(1, card => card.isFaction('thenightswatch'))
                 }));

--- a/server/game/cards/02.2-TRtW/BrothelMadame.js
+++ b/server/game/cards/02.2-TRtW/BrothelMadame.js
@@ -27,7 +27,6 @@ class BrothelMadame extends DrawCard {
                 this.hasPaymentMessageBeenPrinted = false;
 
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: context.opponent,
                     condition: () => !this.tracker.hasPaid(context.opponent, this.controller),
                     effect: ability.effects.cannotInitiateChallengeType('military', opponent => opponent === this.controller)

--- a/server/game/cards/02.2-TRtW/InTheNameOfYourKing.js
+++ b/server/game/cards/02.2-TRtW/InTheNameOfYourKing.js
@@ -9,7 +9,6 @@ class InTheNameOfYourKing extends DrawCard {
             handler: () => {
                 this.game.currentChallenge.cancelChallenge();
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.cannotInitiateChallengeType('military')
                 }));

--- a/server/game/cards/02.3-TKP/TheSilverSteed.js
+++ b/server/game/cards/02.3-TKP/TheSilverSteed.js
@@ -22,7 +22,6 @@ class TheSilverSteed extends DrawCard {
                 this.controller.sacrificeCard(this);
 
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.mayInitiateAdditionalChallenge('power')
                 }));

--- a/server/game/cards/02.4-NMG/DothrakiOutriders.js
+++ b/server/game/cards/02.4-NMG/DothrakiOutriders.js
@@ -4,7 +4,6 @@ class DothrakiOutriders extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('marshal', () => this.getNumberOfDothraki())
         });

--- a/server/game/cards/02.4-NMG/ForTheWatch.js
+++ b/server/game/cards/02.4-NMG/ForTheWatch.js
@@ -7,7 +7,6 @@ class ForTheWatch extends PlotCard {
                 this.game.isDuringChallenge({ defendingPlayer: this.controller }) &&
                 this.numOfChallengesInitiatedAgainst() <= 1
             ),
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.cannotWinChallenge()
         });

--- a/server/game/cards/02.4-NMG/WraithsInTheirMidst.js
+++ b/server/game/cards/02.4-NMG/WraithsInTheirMidst.js
@@ -8,7 +8,6 @@ class WraithsInTheirMidst extends PlotCard {
             effect: ability.effects.modifyReserve(-2)
         });
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.setMinReserve(2)
         });

--- a/server/game/cards/02.5-COW/Famine.js
+++ b/server/game/cards/02.5-COW/Famine.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class Famine extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.increaseCost({
                 playingTypes: 'marshal',

--- a/server/game/cards/02.6-TS/CityWatch.js
+++ b/server/game/cards/02.6-TS/CityWatch.js
@@ -6,7 +6,6 @@ class CityWatch extends DrawCard {
         this.persistentEffect({
             location: 'any',
             condition: () => this.hasMorePowerThanAnOpponent(),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('ambush', 2)
         });

--- a/server/game/cards/02.6-TS/SwornBrother.js
+++ b/server/game/cards/02.6-TS/SwornBrother.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class SwornBrother extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceFirstMarshalledCardCostEachRound(1, card => card.getType() === 'location')
         });

--- a/server/game/cards/03-WotN/HouseTullySepton.js
+++ b/server/game/cards/03-WotN/HouseTullySepton.js
@@ -9,7 +9,6 @@ class HouseTullySepton extends DrawCard {
             cost: ability.costs.discardPower(1, card => card.getType() === 'character'),
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         2,
                         card => (card.hasTrait('House Tully') || card.hasTrait('The Seven')) && card.getType() === 'character'

--- a/server/game/cards/03-WotN/ManceRayder.js
+++ b/server/game/cards/03-WotN/ManceRayder.js
@@ -11,7 +11,6 @@ class ManceRayder extends DrawCard {
         });
         this.persistentEffect({
             condition: () => _.any(this.game.getPlayers(), player => player.activePlot && player.activePlot.hasTrait('Winter')),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceAmbushCardCost(1, card => card.hasTrait('Wildling'))
         });

--- a/server/game/cards/03-WotN/TourneyGrounds.js
+++ b/server/game/cards/03-WotN/TourneyGrounds.js
@@ -9,7 +9,6 @@ class TourneyGrounds extends DrawCard {
             handler: context => {
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextPlayedCardCost(1, card => card.getType() === 'event')
                 }));

--- a/server/game/cards/03-WotN/Winterfell.js
+++ b/server/game/cards/03-WotN/Winterfell.js
@@ -14,7 +14,6 @@ class Winterfell extends DrawCard {
             handler: () => {
                 this.controller.kneelCard(this);
                 this.untilEndOfChallenge(ability => ({
-                    targetType: 'player',
                     targetController: 'any',
                     match: player => !player.activePlot.hasTrait('winter'),
                     effect: ability.effects.cannotTriggerCardAbilities()

--- a/server/game/cards/04.2-CtA/DonellaHornwood.js
+++ b/server/game/cards/04.2-CtA/DonellaHornwood.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class DonellaHornwood extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceFirstMarshalledOrPlayedCardCostEachRound(1, card => card.isLoyal())
         });

--- a/server/game/cards/04.3-FFH/HotPie.js
+++ b/server/game/cards/04.3-FFH/HotPie.js
@@ -8,7 +8,6 @@ class HotPie extends DrawCard {
             cost: ability.costs.kneel(card => card.hasTrait('Companion') && card.getType() === 'character'),
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         1,
                         card => card.isUnique() && card.getType() === 'character'

--- a/server/game/cards/04.3-FFH/NightGathers.js
+++ b/server/game/cards/04.3-FFH/NightGathers.js
@@ -9,7 +9,6 @@ class NightGathers extends DrawCard {
             handler: context => {
                 this.game.addMessage('{0} plays {1} to allow cards from {2}\'s discard pile to be marshaled', this.controller, this, context.opponent);
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.canMarshal(card =>
                         card.controller === context.opponent &&

--- a/server/game/cards/04.3-FFH/Spearmaiden.js
+++ b/server/game/cards/04.3-FFH/Spearmaiden.js
@@ -28,7 +28,6 @@ class Spearmaiden extends DrawCard {
         this.game.addMessage('{0} uses {1} to force {2} to be chosen for claim, if able', this.controller, this, context.target);
 
         this.untilEndOfChallenge(ability => ({
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.mustChooseAsClaim(context.target)
         }));

--- a/server/game/cards/04.4-TIMC/TheHauntedForest.js
+++ b/server/game/cards/04.4-TIMC/TheHauntedForest.js
@@ -7,7 +7,6 @@ class TheHauntedForest extends DrawCard {
                 !this.kneeled &&
                 this.game.isDuringChallenge({ defendingPlayer: this.controller })
             ),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.contributeChallengeStrength(1)
         });

--- a/server/game/cards/04.6-TC/NorthernRefugee.js
+++ b/server/game/cards/04.6-TC/NorthernRefugee.js
@@ -5,7 +5,6 @@ class NorthernRefugee extends DrawCard {
         this.persistentEffect({
             location: 'any',
             condition: () => this.game.anyPlotHasTrait('Winter'),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('marshal', 1)
         });

--- a/server/game/cards/04.6-TC/RelentlessAssault.js
+++ b/server/game/cards/04.6-TC/RelentlessAssault.js
@@ -14,7 +14,6 @@ class RelentlessAssault extends DrawCard {
             handler: context => {
                 let type = this.game.currentChallenge.challengeType;
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.mayInitiateAdditionalChallenge(type)
                 }));

--- a/server/game/cards/05-LoCR/ALannisterAlwaysPaysHisDebts.js
+++ b/server/game/cards/05-LoCR/ALannisterAlwaysPaysHisDebts.js
@@ -9,7 +9,6 @@ class ALannisterAlwaysPaysHisDebts extends DrawCard {
             phase: 'challenge',
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: [
                         ability.effects.mayInitiateAdditionalChallenge('military', opponent => opponent === context.opponent),

--- a/server/game/cards/05-LoCR/DevoutFreerider.js
+++ b/server/game/cards/05-LoCR/DevoutFreerider.js
@@ -4,7 +4,6 @@ class DevoutFreerider extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'challenge',
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.cannotGainGold()
         });

--- a/server/game/cards/05-LoCR/EarlyFrost.js
+++ b/server/game/cards/05-LoCR/EarlyFrost.js
@@ -4,7 +4,6 @@ class EarlyFrost extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'draw',
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.modifyDrawPhaseCards(-1)
         });

--- a/server/game/cards/05-LoCR/LittleFingersMeddling.js
+++ b/server/game/cards/05-LoCR/LittleFingersMeddling.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class LittleFingersMeddling extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceCost({
                 playingTypes: 'play',

--- a/server/game/cards/05-LoCR/OceanRoad.js
+++ b/server/game/cards/05-LoCR/OceanRoad.js
@@ -12,7 +12,6 @@ class OceanRoad extends DrawCard {
                     this.controller, this);
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         1,

--- a/server/game/cards/05-LoCR/TimeOfPlenty.js
+++ b/server/game/cards/05-LoCR/TimeOfPlenty.js
@@ -4,7 +4,6 @@ class TimeOfPlenty extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'draw',
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.modifyDrawPhaseCards(1)
         });

--- a/server/game/cards/05-LoCR/TommenBaratheon.js
+++ b/server/game/cards/05-LoCR/TommenBaratheon.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class TommenBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             match: player => player.hand.length === 0,
             effect: ability.effects.cannotGainChallengeBonus()

--- a/server/game/cards/06.1-AMAF/BarringTheGates.js
+++ b/server/game/cards/06.1-AMAF/BarringTheGates.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class BarringTheGates extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.cannotPutIntoPlay((card, playingType) => card.getType() === 'character' && playingType !== 'marshal')
         });

--- a/server/game/cards/06.1-AMAF/Ricasso.js
+++ b/server/game/cards/06.1-AMAF/Ricasso.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class Ricasso extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.dynamicUsedPlots(() => this.tokens['gold'])
         });

--- a/server/game/cards/06.2-GtR/GreatHall.js
+++ b/server/game/cards/06.2-GtR/GreatHall.js
@@ -12,7 +12,6 @@ class GreatHall extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to reduce the cost of the next unique character by 1 (by 2 if it has cost of 6 or more)', context.player, this);
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         amount,

--- a/server/game/cards/06.2-GtR/TheAnnalsOfCastleBlack.js
+++ b/server/game/cards/06.2-GtR/TheAnnalsOfCastleBlack.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class TheAnnalsOfCastleBlack extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.canPlayFromOwn('discard pile')
         });

--- a/server/game/cards/06.3-TFoA/ElinorTyrell.js
+++ b/server/game/cards/06.3-TFoA/ElinorTyrell.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class ElinorTyrell extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.modifyMaxLimited(1)
         });
     }

--- a/server/game/cards/06.3-TFoA/SilverHairNet.js
+++ b/server/game/cards/06.3-TFoA/SilverHairNet.js
@@ -10,7 +10,6 @@ class SilverHairNet extends DrawCard {
 
         this.persistentEffect({
             condition: () => this.parent && this.parent.isParticipating(),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceCost({
                 playingTypes: 'play',

--- a/server/game/cards/06.5-OR/OlennasMachinations.js
+++ b/server/game/cards/06.5-OR/OlennasMachinations.js
@@ -7,7 +7,6 @@ class OlennasMachinations extends DrawCard {
             title: 'Raise power challenge limit',
             handler: () => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.mayInitiateAdditionalChallenge('power')
                 }));

--- a/server/game/cards/06.5-OR/PassingTheBlackGate.js
+++ b/server/game/cards/06.5-OR/PassingTheBlackGate.js
@@ -8,7 +8,6 @@ class PassingTheBlackGate extends DrawCard {
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.reduceCost({
                         playingTypes: 'marshal',
                         amount: 1,

--- a/server/game/cards/06.5-OR/TheIronBankWillHaveItsDue.js
+++ b/server/game/cards/06.5-OR/TheIronBankWillHaveItsDue.js
@@ -15,7 +15,6 @@ class TheIronBankWillHaveItsDue extends DrawCard {
                 gold = this.game.addGold(this.controller, gold);
 
                 this.untilEndOfRound(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.cannotMarshalOrPutIntoPlayByTitle(returnedCard.name)
                 }));
 

--- a/server/game/cards/07-WotW/BuilderAtTheWall.js
+++ b/server/game/cards/07-WotW/BuilderAtTheWall.js
@@ -12,7 +12,6 @@ class BuilderAtTheWall extends DrawCard {
                     this.controller, this, 'thenightswatch');
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         1,

--- a/server/game/cards/07-WotW/GrizzledMiner.js
+++ b/server/game/cards/07-WotW/GrizzledMiner.js
@@ -5,7 +5,6 @@ class GrizzledMiner extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            targetType: 'player',
             targetController: 'current',
             effect: [
                 ability.effects.reduceSelfCost('marshal', () => this.getDiscount()),

--- a/server/game/cards/07-WotW/Retaliation.js
+++ b/server/game/cards/07-WotW/Retaliation.js
@@ -6,7 +6,6 @@ class Retaliation extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => _.size(this.game.getPlayers()) > 1,
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.canSelectAsFirstPlayer(player => player !== this.controller)
         });

--- a/server/game/cards/08.1-TAK/BloodyArakh.js
+++ b/server/game/cards/08.1-TAK/BloodyArakh.js
@@ -13,7 +13,6 @@ class BloodyArakh extends DrawCard {
                 context.player.sacrificeCard(this);
 
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.mayInitiateAdditionalChallenge('military')
                 }));
 

--- a/server/game/cards/08.1-TAK/TheWaterGardens.js
+++ b/server/game/cards/08.1-TAK/TheWaterGardens.js
@@ -10,7 +10,6 @@ class TheWaterGardens extends DrawCard {
             handler: context => {
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     effect: ability.effects.reduceNextMarshalledPlayedOrAmbushedCardCost(
                         context.player.getNumberOfUsedPlots(),
                         card => card.getType() !== 'character'

--- a/server/game/cards/08.2-JtO/BrightwaterKnight.js
+++ b/server/game/cards/08.2-JtO/BrightwaterKnight.js
@@ -9,7 +9,6 @@ class BrightWaterKnight extends DrawCard {
             cost: ability.costs.discardGold(),
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         2,
                         card => card.getType() === 'character' && card.hasTrait('Knight')

--- a/server/game/cards/08.2-JtO/SailingTheSummerSea.js
+++ b/server/game/cards/08.2-JtO/SailingTheSummerSea.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class SailingTheSummerSea extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             effect: [
                 ability.effects.mayInitiateAdditionalChallenge('power'),
                 ability.effects.cannotInitiateChallengeType('military'),

--- a/server/game/cards/08.2-JtO/TheHouseWithTheRedDoor.js
+++ b/server/game/cards/08.2-JtO/TheHouseWithTheRedDoor.js
@@ -42,7 +42,6 @@ class TheHouseWithTheRedDoor extends AgendaCard {
 
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.setSetupGold(4)
         });
     }

--- a/server/game/cards/08.2-JtO/TrisBotley.js
+++ b/server/game/cards/08.2-JtO/TrisBotley.js
@@ -16,7 +16,6 @@ class TrisBotley extends DrawCard {
                     until: {
                         onCardLeftPlay: event => event.card === this
                     },
-                    targetType: 'player',
                     targetController: context.target.owner,
                     effect: [
                         ability.effects.cannotMarshal(card => card.code === context.target.code),

--- a/server/game/cards/08.3-Km/TheWitheringCold.js
+++ b/server/game/cards/08.3-Km/TheWitheringCold.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class TheWitheringCold extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'game',
             effect: ability.effects.skipPhase('standing')
         });
     }

--- a/server/game/cards/08.4-FotOG/TheKingInTheNorth.js
+++ b/server/game/cards/08.4-FotOG/TheKingInTheNorth.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class TheKingInTheNorth extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             match: player => !player.anyCardsInPlay(card => card.getType() === 'character' && card.hasTrait('King')),
             effect: ability.effects.cannotTriggerCardAbilities(card => ['character', 'location', 'attachment'].includes(card.getType()))

--- a/server/game/cards/08.5-TFM/HighgardenRefugee.js
+++ b/server/game/cards/08.5-TFM/HighgardenRefugee.js
@@ -5,7 +5,6 @@ class HighgardenRefugee extends DrawCard {
         this.persistentEffect({
             location: 'any',
             condition: () => this.game.anyPlotHasTrait('Summer'),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('marshal', 1)
         });

--- a/server/game/cards/08.5-TFM/TarleTheThriceDrowned.js
+++ b/server/game/cards/08.5-TFM/TarleTheThriceDrowned.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class TarleTheThriceDrowned extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.canMarshal(card =>
                 card.controller === this.controller &&

--- a/server/game/cards/08.5-TFM/TheHighSparrow.js
+++ b/server/game/cards/08.5-TFM/TheHighSparrow.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class TheHighSparrow extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             effect: [
                 ability.effects.setMaxGoldGain(7),

--- a/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
+++ b/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
@@ -33,7 +33,6 @@ class TheCrowIsATricksyBird extends DrawCard {
             until: {
                 onCardEntersPlay: event => event.card.getType() === 'plot' && event.card.controller === this.context.opponent
             },
-            targetType: player,
             match: this.context.opponent,
             effect: ability.effects.mustRevealPlot(card)
         }));

--- a/server/game/cards/08.6-SAT/TheSevenPointedStar.js
+++ b/server/game/cards/08.6-SAT/TheSevenPointedStar.js
@@ -15,7 +15,6 @@ class TheSevenPointedStar extends DrawCard {
                 this.game.addMessage('{0} uses {1} and kneels {2} to reduce the cost of the next The Seven character by 2', currentController, this, context.costs.kneel);
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     match: player => player === currentController,
                     effect: ability.effects.reduceNextMarshalledCardCost(2, card => card.hasTrait('The Seven'))

--- a/server/game/cards/09-HoT/Besieged.js
+++ b/server/game/cards/09-HoT/Besieged.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class Besieged extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'any',
             effect: ability.effects.setDefenderMinimum(1)
         });

--- a/server/game/cards/09-HoT/EmissaryOfTheHightower.js
+++ b/server/game/cards/09-HoT/EmissaryOfTheHightower.js
@@ -13,7 +13,6 @@ class EmissaryOfTheHightower extends DrawCard {
             handler: context => {
                 this.game.addMessage('{0} uses {1} to allow {2} to be played as if it were in their hand', this.controller, this, context.target);
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.canPlay(context.target)
                 }));

--- a/server/game/cards/09-HoT/HighgardenHonorGuard.js
+++ b/server/game/cards/09-HoT/HighgardenHonorGuard.js
@@ -4,7 +4,6 @@ class HighgardenHonorGuard extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('ambush', () => this.getNumberOfReachLocations())
         });

--- a/server/game/cards/09-HoT/TheBastardOfGodsgrace.js
+++ b/server/game/cards/09-HoT/TheBastardOfGodsgrace.js
@@ -8,7 +8,6 @@ class TheBastardOfGodsgrace extends DrawCard {
             cost: ability.costs.discardPowerFromSelf(),
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     effect: ability.effects.reduceNextAmbushedOrPlayedCardCost(2)
                 }));
 

--- a/server/game/cards/09-HoT/TheSpidersWeb.js
+++ b/server/game/cards/09-HoT/TheSpidersWeb.js
@@ -10,7 +10,6 @@ class TheSpidersWeb extends PlotCard {
             handler: () => {
                 this.game.addMessage('{0} uses {1} to be able to initiate an additional {2} challenge with claim raised by 1', this.controller, this, 'intrigue');
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.mayInitiateAdditionalChallenge('intrigue')
                 }));

--- a/server/game/cards/09-HoT/TourneyLance.js
+++ b/server/game/cards/09-HoT/TourneyLance.js
@@ -10,7 +10,6 @@ class TourneyLance extends DrawCard {
 
         this.persistentEffect({
             condition: () => this.parent && this.game.isDuringChallenge({ attackingAlone: this.parent }),
-            targetType: 'player',
             targetController: 'opponent',
             effect: ability.effects.setDefenderMaximum(1)
         });

--- a/server/game/cards/10-SoD/AreoHotah.js
+++ b/server/game/cards/10-SoD/AreoHotah.js
@@ -4,7 +4,6 @@ class AreoHotah extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('ambush', () => this.controller.getNumberOfUsedPlots())
         });

--- a/server/game/cards/10-SoD/HouseDayneEscort.js
+++ b/server/game/cards/10-SoD/HouseDayneEscort.js
@@ -5,7 +5,6 @@ class HouseDayneEscort extends DrawCard {
         this.persistentEffect({
             location: 'any',
             condition: () => this.location === 'discard pile' && this.controller.getNumberOfUsedPlots() >= 3,
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.canMarshal(card => card === this && card.location === 'discard pile')
         });

--- a/server/game/cards/10-SoD/MaesterKedry.js
+++ b/server/game/cards/10-SoD/MaesterKedry.js
@@ -7,7 +7,6 @@ class MaesterKedry extends DrawCard {
             cost: ability.costs.kneelSelf(),
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextPlayedCardCost(2)
                 }));

--- a/server/game/cards/10-SoD/PeaceAndProsperity.js
+++ b/server/game/cards/10-SoD/PeaceAndProsperity.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class PeaceAndProsperity extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: [
                 ability.effects.reduceFirstMarshalledCardCostEachRound(3, card => card.getType() === 'character'),

--- a/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
+++ b/server/game/cards/11.1-TSC/BeneathTheBridgeOfDream.js
@@ -17,7 +17,6 @@ class BeneathTheBridgeOfDream extends DrawCard {
                 this.game.queueSimpleStep(() => {
                     let plot = sample(this.controller.getPlots());
                     this.untilEndOfPhase(ability => ({
-                        targetType: 'player',
                         targetController: 'current',
                         effect: ability.effects.mustRevealPlot(plot)
                     }));

--- a/server/game/cards/11.1-TSC/TheShadowCity.js
+++ b/server/game/cards/11.1-TSC/TheShadowCity.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard');
 class TheShadowCity extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceCost({
                 playingTypes: 'marshalIntoShadows',

--- a/server/game/cards/11.2-TMoW/HizdahrZoLoraq.js
+++ b/server/game/cards/11.2-TMoW/HizdahrZoLoraq.js
@@ -8,7 +8,6 @@ class HizdahrZoLoraq extends DrawCard {
             limit: ability.limit.perPhase(1),
             handler: context => {
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledAmbushedOrOutOfShadowsCardCost(3)
                 }));

--- a/server/game/cards/11.2-TMoW/MarchOnWinterfell.js
+++ b/server/game/cards/11.2-TMoW/MarchOnWinterfell.js
@@ -9,7 +9,6 @@ class MarchOnWinterfell extends DrawCard {
                 this.game.currentChallenge.cancelChallenge();
 
                 this.untilEndOfPhase(ability => ({
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.mayInitiateAdditionalChallenge('power')
                 }));

--- a/server/game/cards/11.2-TMoW/Meereen.js
+++ b/server/game/cards/11.2-TMoW/Meereen.js
@@ -12,7 +12,6 @@ class Meereen extends DrawCard {
                         onCardLeftPlay: event => event.card === this,
                         onPhaseEnded: () => true
                     },
-                    targetType: 'player',
                     effect: ability.effects.removeCardsFromHand()
                 }));
 

--- a/server/game/cards/11.2-TMoW/TychoNestoris.js
+++ b/server/game/cards/11.2-TMoW/TychoNestoris.js
@@ -7,7 +7,6 @@ class TychoNestoris extends DrawCard {
         });
 
         this.persistentEffect({
-            targetType: 'player',
             effect: ability.effects.cannotWinGame()
         });
 

--- a/server/game/cards/11.6-DitD/Varys.js
+++ b/server/game/cards/11.6-DitD/Varys.js
@@ -4,7 +4,6 @@ class Varys extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('outOfShadows', () => this.game.getPlayers().reduce((acc, player) => acc + player.shadows.filter(card => card !== this).length,0))
         });

--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -19,7 +19,6 @@ class FactionCostReducer extends DrawCard {
                     this.controller, this, this.faction, this.reduceBy);
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(this.reduceBy, card => card.isFaction(this.faction))
                 }));
@@ -47,7 +46,6 @@ class FactionCharacterCostReducer extends DrawCard {
                     this.controller, this, this.faction, this.reduceBy);
                 this.untilEndOfPhase(ability => ({
                     condition: () => !context.abilityDeactivated,
-                    targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(
                         this.reduceBy,

--- a/server/game/cards/titles/HandOfTheKing.js
+++ b/server/game/cards/titles/HandOfTheKing.js
@@ -5,7 +5,6 @@ class HandOfTheKing extends TitleCard {
         this.supports('Master of Laws');
         this.rivals('Master of Coin', 'Master of Ships');
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.mayInitiateAdditionalChallenge('power', opponent => this.allowOpponent(opponent))
         });
@@ -15,7 +14,6 @@ class HandOfTheKing extends TitleCard {
                 this.game.currentChallenge.challengeType === 'power' &&
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.contributeChallengeStrength(1)
         });

--- a/server/game/cards/titles/MasterOfLaws.js
+++ b/server/game/cards/titles/MasterOfLaws.js
@@ -6,7 +6,6 @@ class MasterOfLaws extends TitleCard {
         this.rivals('Master of Whispers', 'Master of Ships');
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'draw',
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.modifyDrawPhaseCards(1)
         });

--- a/server/game/cards/titles/MasterOfShips.js
+++ b/server/game/cards/titles/MasterOfShips.js
@@ -20,7 +20,6 @@ class MasterOfShips extends TitleCard {
                 this.game.currentChallenge.challengeType === 'military' &&
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.contributeChallengeStrength(1)
         });

--- a/server/game/cards/titles/MasterOfWhispers.js
+++ b/server/game/cards/titles/MasterOfWhispers.js
@@ -5,7 +5,6 @@ class MasterOfWhispers extends TitleCard {
         this.supports('Hand of the King');
         this.rivals('Master of Laws', 'Master of Coin');
         this.persistentEffect({
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.applyClaimToMultipleOpponents('intrigue')
         });
@@ -15,7 +14,6 @@ class MasterOfWhispers extends TitleCard {
                 this.game.currentChallenge.challengeType === 'intrigue' &&
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
-            targetType: 'player',
             targetController: 'current',
             effect: ability.effects.contributeChallengeStrength(1)
         });

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -24,8 +24,6 @@ const PlayAreaLocations = ['play area', 'active plot'];
  *                    than Winter plots").
  * targetController - string that determines which player's cards are targeted.
  *                    Can be 'current' (default), 'opponent' or 'any'.
- * targetType       - string that determines whether cards or players are the
- *                    target for the effect. Can be 'card' (default) or 'player'
  * targetLocation   - string that determines the location of cards that can be
  *                    applied by the effect. Can be 'play area' (default) or
  *                    'hand'.
@@ -45,7 +43,7 @@ class Effect {
         this.condition = properties.condition || (() => true);
         this.location = properties.location || 'play area';
         this.targetController = properties.targetController || 'current';
-        this.targetType = properties.targetType || 'card';
+        this.targetType = properties.effect.targetType || 'card';
         this.targetLocation = properties.targetLocation || 'play area';
         this.effect = this.buildEffect(properties.effect);
         this.gameAction = this.effect.gameAction || 'genericEffect';

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -292,6 +292,7 @@ const Effects = {
     doesNotContributeStrength: challengeOptionEffect('doesNotContributeStrength'),
     doesNotReturnUnspentGold: function() {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.doesNotReturnUnspentGold = true;
             },
@@ -659,6 +660,7 @@ const Effects = {
     },
     cannotPutIntoPlay: function(restriction) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.playCardRestrictions.push(restriction);
             },
@@ -679,6 +681,7 @@ const Effects = {
     cannotGainPower: cannotEffect('gainPower'),
     cannotGainGold: function() {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.maxGoldGain.setMax(0);
             },
@@ -690,6 +693,7 @@ const Effects = {
     cannotTarget: cannotEffect('target'),
     setMaxGoldGain: function(max) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.maxGoldGain.setMax(max);
             },
@@ -700,6 +704,7 @@ const Effects = {
     },
     setMaxCardDraw: function(max) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.maxCardDraw.setMax(max);
             },
@@ -710,6 +715,7 @@ const Effects = {
     },
     cannotGainChallengeBonus: function() {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.cannotGainChallengeBonus = true;
             },
@@ -720,6 +726,7 @@ const Effects = {
     },
     cannotWinGame: function() {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.cannotWinGame = true;
             },
@@ -731,6 +738,7 @@ const Effects = {
     },
     cannotTriggerCardAbilities: function(restriction = () => true) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.triggerRestrictions.push(restriction);
             },
@@ -741,6 +749,7 @@ const Effects = {
     },
     modifyDrawPhaseCards: function(value) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.drawPhaseCards += value;
             },
@@ -751,6 +760,7 @@ const Effects = {
     },
     modifyMaxLimited: function(amount) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.maxLimited += amount;
             },
@@ -762,6 +772,7 @@ const Effects = {
     mayInitiateAdditionalChallenge: function(challengeType, opponentFunc) {
         let allowedChallenge = new AllowedChallenge(challengeType, opponentFunc);
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.addAllowedChallenge(allowedChallenge);
             },
@@ -776,6 +787,7 @@ const Effects = {
     cannotInitiateChallengeType(challengeType, opponentCondition = () => true) {
         let restriction = new ChallengeRestriction(challengeType, opponentCondition);
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.addChallengeRestriction(restriction);
             },
@@ -801,6 +813,7 @@ const Effects = {
     },
     setMaxChallenge: function(max) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.setMaxChallenge(max);
             },
@@ -811,6 +824,7 @@ const Effects = {
     },
     setMinReserve: function(min) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 context.setMinReserve = context.setMinReserve || {};
                 context.setMinReserve[player.name] = player.minReserve;
@@ -824,6 +838,7 @@ const Effects = {
     },
     setMinCost: function(value) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 context.source.minCost = value;
             },
@@ -834,6 +849,7 @@ const Effects = {
     },
     contributeChallengeStrength: function(value) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 let challenge = context.game.currentChallenge;
                 if(!challenge) {
@@ -864,6 +880,7 @@ const Effects = {
     },
     setAttackerMaximum: function(value) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.attackerLimits.setMax(value);
             },
@@ -874,6 +891,7 @@ const Effects = {
     },
     setDefenderMinimum: function(value) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.defenderLimits.setMin(value);
             },
@@ -884,6 +902,7 @@ const Effects = {
     },
     setDefenderMaximum: function(value) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.defenderLimits.setMax(value);
             },
@@ -894,6 +913,7 @@ const Effects = {
     },
     cannotWinChallenge: function() {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.cannotWinChallenge = true;
             },
@@ -904,6 +924,7 @@ const Effects = {
     },
     canPlay: function(card) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 let playableLocation = new PlayableLocation('play', c => c === card);
                 context.canPlay = context.canPlay || {};
@@ -919,6 +940,7 @@ const Effects = {
     canMarshal: function(predicate) {
         let playableLocation = new PlayableLocation('marshal', predicate);
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.playableLocations.push(playableLocation);
             },
@@ -929,6 +951,7 @@ const Effects = {
     },
     canPlayFromOwn: function(location) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 let playableLocation = new PlayableLocation('play', card => card.controller === player && card.location === location);
                 context.canPlayFromOwn = context.canPlayFromOwn || {};
@@ -943,6 +966,7 @@ const Effects = {
     },
     canSelectAsFirstPlayer: function(condition) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.firstPlayerSelectCondition = condition;
             },
@@ -954,6 +978,7 @@ const Effects = {
     cannotStandMoreThan: function(max, match) {
         let restriction = { max: max, match: match };
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.standPhaseRestrictions.push(restriction);
             },
@@ -964,6 +989,7 @@ const Effects = {
     },
     reduceCost: function(properties) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 context.reducers = context.reducers || [];
                 var reducer = new CostReducer(context.game, context.source, properties);
@@ -979,6 +1005,7 @@ const Effects = {
     },
     reduceSelfCost: function(playingTypes, amount) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 context.reducers = context.reducers || [];
                 let reducer = new CostReducer(context.game, context.source, {
@@ -1052,6 +1079,7 @@ const Effects = {
     },
     dynamicUsedPlots: function(calculate) {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 context.dynamicUsedPlots = context.dynamicUsedPlots || {};
                 context.dynamicUsedPlots[player.name] = calculate(player, context) || 0;
@@ -1072,6 +1100,7 @@ const Effects = {
     },
     mustChooseAsClaim: function(card) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.mustChooseAsClaim.push(card);
             },
@@ -1082,6 +1111,7 @@ const Effects = {
     },
     skipPhase: function(name) {
         return {
+            targetType: 'game',
             apply: function(game) {
                 game.skipPhase[name] = true;
             },
@@ -1102,6 +1132,7 @@ const Effects = {
     },
     mustRevealPlot: function(card) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.mustRevealPlot = card;
             },
@@ -1112,6 +1143,7 @@ const Effects = {
     },
     applyClaimToMultipleOpponents: function(claimType) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.multipleOpponentClaim.push(claimType);
             },
@@ -1123,6 +1155,7 @@ const Effects = {
     //Meereen only effect
     removeCardsFromHand: function() {
         return {
+            targetType: 'player',
             apply: function(player, context) {
                 for(let card of player.hand) {
                     player.removeCardFromPile(card);


### PR DESCRIPTION
Previously, targetType needed to be specified for each usage of an
effect. However, since each effect could only target either a card or
player but not both, this led to repetition for the same effect.