### PR TITLE
Remove unused title property from reactions/interrupts

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -672,18 +672,6 @@ this.reaction({
 });
 ```
 
-#### Changing the title of the reaction / interrupt button
-
-By default, players will see for all triggered abilities come in the form of buttons with the name of the card. In certain scenarios, you may want to override that title. This can be done by passing a `title` method which will take the ability `context` object (allowing access to the event and its parameters) and which should return the string to be added after the card name in ability prompts.
-
-```javascript
-this.interrupt({
-    // ...
-    title: context => 'Do something',
-    // Results in a prompt button: Iron Mines - Do something
-});
-```
-
 #### Limiting the number of uses
 
 Some abilities have text limiting the number of times they may be used in a given period. You can pass an optional `limit` property using one of the duration-specific ability limiters.

--- a/server/game/cards/06.2-GtR/ScorchingDeserts.js
+++ b/server/game/cards/06.2-GtR/ScorchingDeserts.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class ScorchingDeserts extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
-            title: context => context.event.card.name,
             when: {
                 onDeclaredAsAttacker: event => event.card.getNumberOfIcons() < 2 && event.card.controller !== this.controller,
                 onDeclaredAsDefender: event => event.card.getNumberOfIcons() < 2 && event.card.controller !== this.controller

--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class SpearsOfTheMerlingKing extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
-            title: context => context.event.card.name,
             when: {
                 onCharacterKilled: event => event.card.controller === this.controller
             },

--- a/server/game/cards/07-WotW/MaryaSeaworth.js
+++ b/server/game/cards/07-WotW/MaryaSeaworth.js
@@ -3,7 +3,6 @@ const DrawCard = require('../../drawcard.js');
 class MaryaSeaworth extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
-            title: context => 'Kneel ' + context.event.target.name,
             when: {
                 onBypassedByStealth: () => true
             },

--- a/server/game/cards/09-HoT/WardensOfTheSouth.js
+++ b/server/game/cards/09-HoT/WardensOfTheSouth.js
@@ -3,7 +3,6 @@ const PlotCard = require('../../plotcard.js');
 class WardensOfTheSouth extends PlotCard {
     setupCardAbilities() {
         this.reaction({
-            title: context => context.event.card.name,
             when: {
                 onDeclaredAsAttacker: event => event.card.controller === this.controller && event.card.isFaction('tyrell'),
                 onDeclaredAsDefender: event => event.card.controller === this.controller && event.card.isFaction('tyrell')


### PR DESCRIPTION
Since reactions/interrupts are triggered by clicking cards instead of buttons, this property serves no function anymore.