### PR TITLE
Add triggered ability window title for onCardEntersPlay event

### DIFF
--- a/server/game/gamesteps/TriggeredAbilityWindowTitles.js
+++ b/server/game/gamesteps/TriggeredAbilityWindowTitles.js
@@ -1,5 +1,6 @@
 const EventToTitleFunc = {
     onCardAbilityInitiated: event => `the effects of ${event.source.name}`,
+    onCardEntersPlay: event => `${event.card.name} entering play`,
     onCardPowerGained: event => `${event.card.name} gaining power`,
     onCardPowerMoved: event => `power moved from ${event.source.name} to ${event.target.name}`,
     onClaimApplied: () => 'to claim effects being applied',


### PR DESCRIPTION
* This makes it clearer which card is triggering for example Harrenhal (GoH).
* Fixes #2129.

![schermafbeelding 2018-07-25 om 01 48 38](https://user-images.githubusercontent.com/23409205/43172024-69327b30-8fad-11e8-908d-59bc2e0bed3c.png)