### PR TITLE
Allow simultaneous discard across multiple players

### DIFF
--- a/server/game/cards/01-Core/MarchedToTheWall.js
+++ b/server/game/cards/01-Core/MarchedToTheWall.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../plotcard.js');
 
 class MarchedToTheWall extends PlotCard {
@@ -26,10 +24,8 @@ class MarchedToTheWall extends PlotCard {
     }
 
     doDiscard() {
-        _.each(this.selections, selection => {
-            let player = selection.player;
-            player.discardCard(selection.card, false);
-        });
+        let cards = this.selections.map(selection => selection.card);
+        this.game.discardFromPlay(cards, { allowSave: false });
     }
 
     proceedToNextStep() {

--- a/server/game/cards/01-Core/Varys.js
+++ b/server/game/cards/01-Core/Varys.js
@@ -1,21 +1,15 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../drawcard.js');
 
 class Varys extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onPhaseEnded: event => event.phase === 'dominance'
+                onPhaseEnded: event => event.phase === 'dominance' && this.game.anyCardsInPlay(card => card.getType() === 'character' && card !== this)
             },
             cost: ability.costs.removeSelfFromGame(),
             handler: () => {
-                _.each(this.game.getPlayers(), player => {
-                    let characters = player.filterCardsInPlay(card => card.getType() === 'character');
-                    _.each(characters, card => {
-                        player.discardCard(card);
-                    });
-                });
+                let characters = this.game.filterCardsInPlay(card => card.getType() === 'character');
+                this.game.discardFromPlay(characters);
 
                 this.game.addMessage('{0} removes {1} from the game to discard all characters',
                     this.controller, this);

--- a/server/game/cards/02.2-TRtW/PoliticalDisaster.js
+++ b/server/game/cards/02.2-TRtW/PoliticalDisaster.js
@@ -30,18 +30,19 @@ class PoliticalDisaster extends PlotCard {
     }
 
     doDiscard() {
-        _.each(this.selections, selection => {
+        let toDiscard = [];
+        for(let selection of this.selections) {
             let player = selection.player;
-            let toDiscard = _.difference(player.filterCardsInPlay(card => card.getType() === 'location'), selection.cards);
+            let remainingLocations = _.difference(player.filterCardsInPlay(card => card.getType() === 'location'), selection.cards);
 
-            _.each(toDiscard, card => {
-                player.discardCard(card);
-            });
+            toDiscard = toDiscard.concat(remainingLocations);
 
-            if(!_.isEmpty(toDiscard)) {
-                this.game.addMessage('{0} discards {1} for {2}', player, toDiscard, this);
+            if(remainingLocations.length !== 0) {
+                this.game.addMessage('{0} discards {1} for {2}', player, remainingLocations, this);
             }
-        });
+        }
+
+        this.game.discardFromPlay(toDiscard);
 
         this.selections = [];
     }

--- a/server/game/cards/09-HoT/NothingBurnsLikeTheCold.js
+++ b/server/game/cards/09-HoT/NothingBurnsLikeTheCold.js
@@ -88,14 +88,15 @@ class NothingBurnsLikeTheCold extends PlotCard {
     }
 
     doDiscard() {
+        let cards = this.selections.reduce((cards, selection) => cards.concat(selection.cards), []);
         for(let selection of this.selections) {
             let player = selection.player;
 
             if(selection.cards.length !== 0) {
                 this.game.addMessage('{0} discards {1} for {2}', player, selection.cards, this);
-                player.discardCards(selection.cards, false);
             }
         }
+        this.game.discardFromPlay(cards, { allowSave: false });
 
         this.selections = [];
     }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -937,6 +937,19 @@ class Game extends EventEmitter {
         this.raiseEvent('onCardSaved', { card: card });
     }
 
+    discardFromPlay(cards, options = { allowSave: true }, callback = () => true) {
+        let inPlayCards = cards.filter(card => card.location === 'play area');
+        if(inPlayCards.length === 0) {
+            return;
+        }
+
+        // The player object used is irrelevant - it shouldn't be referenced by
+        // any abilities that respond to cards being discarded from play. This
+        // should be a temporary workaround until better support is added for
+        // simultaneous resolution of events.
+        inPlayCards[0].owner.discardCards(inPlayCards, options.allowSave, callback, options);
+    }
+
     killCharacters(cards, options = {}) {
         options = Object.assign({ allowSave: true, isBurn: false }, options);
         this.queueStep(new KillCharacters(this, cards, options));

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -965,7 +965,7 @@ class Player extends Spectator {
                 handler: () => true,
                 perCardEventName: 'onCardDiscarded',
                 perCardHandler: event => {
-                    this.moveCard(event.card, 'discard pile');
+                    event.card.controller.moveCard(event.card, 'discard pile');
                 },
                 postHandler: event => {
                     callback(event.cards);

--- a/test/server/cards/01-Core/Varys.spec.js
+++ b/test/server/cards/01-Core/Varys.spec.js
@@ -1,0 +1,40 @@
+describe('Varys (Core)', function() {
+    integration(function() {
+        describe('simultaneous discard', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Varys (Core)', 'Arya Stark (TFM)', 'Sansa Stark (Core)', 'Sansa Stark (Core)'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.player1.clickCard('Varys', 'hand');
+
+                // Explicitly set up a duped Sansa after Arya. If Varys' ability
+                // causes Arya to leave play before Sansa instead of
+                // simultaneously, the 'cannot be saved' effect will wear off
+                // prematurely and Sansa will be saved by her dupe.
+                [this.sansa, this.dupe] = this.player2.filterCardsByName('Sansa Stark', 'hand');
+                this.player2.clickCard('Arya Stark', 'hand');
+                this.player2.clickCard(this.sansa);
+                this.player2.clickCard(this.dupe);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                this.player1.triggerAbility('Varys');
+            });
+
+            it('should cause all cards to be discarded simultaneously', function() {
+                expect(this.sansa.location).toBe('discard pile');
+            });
+        });
+    });
+});

--- a/test/server/player/discardcards.spec.js
+++ b/test/server/player/discardcards.spec.js
@@ -6,6 +6,7 @@ describe('Player', function() {
         let spy = jasmine.createSpyObj('card', ['moveTo', 'removeDuplicate']);
         spy.num = num;
         spy.location = 'loc';
+        spy.controller = jasmine.createSpyObj('player', ['moveCard']);
         return spy;
     }
 
@@ -23,7 +24,6 @@ describe('Player', function() {
         });
 
         this.player = new Player('1', { username: 'Test 1', settings: {} }, true, this.gameSpy);
-        spyOn(this.player, 'moveCard');
 
         this.callbackSpy = jasmine.createSpy('callback');
 
@@ -67,7 +67,7 @@ describe('Player', function() {
                 });
 
                 it('should move the card to the discard pile', function() {
-                    expect(this.player.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
+                    expect(this.card1.controller.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
                 });
             });
 


### PR DESCRIPTION
Previously, abilities that discarded cards from play controlled by
multiple players were implemented using for loops to either discard each
card individually, or discard each set of cards per player. Because it
was done sequentially, this could lead to bugs where a card leaving play
earlier than the others could change the outcome of the discard (e.g. if
TFM Arya leaves play before other characters with potential saves).

Now all cards are grouped into a single bundle and discarded at once.
This can only be applied to cards that are in play currently - cards
discarded simultaneously from hand (Bastard Daughter) or deck
(Greensight) still need individual events in order to properly trigger
cards like LoCR Tywin. Another solution will be needed for such
abilities.

Fixes #2128 