### PR TITLE
Centralize how card visibility is handled

### DIFF
--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -17,9 +17,6 @@ class BaseCardSelector {
      * the game action checked for immunity purposes on potential target cards.
      * @param {boolean} properties.singleController
      * indicates that all cards selected must belong to the same controller.
-     * @param {boolean} properties.revealTargets
-     * indicates that all selectable facedown cards are flipped faceup for
-     * the selecting player.
      * @param {boolean} properties.isCardEffect
      * indicates whether the selector is part of a card effect and thus should
      * check for card immunity
@@ -29,7 +26,6 @@ class BaseCardSelector {
         this.cardType = properties.cardType;
         this.gameAction = properties.gameAction;
         this.singleController = properties.singleController;
-        this.revealTargets = properties.revealTargets;
         this.isCardEffect = properties.isCardEffect;
 
         if(!Array.isArray(properties.cardType)) {
@@ -157,18 +153,6 @@ class BaseCardSelector {
         }
 
         return card.controller === selectedCards[0].controller;
-    }
-
-    /**
-     * Flips the specified (facedown) card faceup to the selecting player if the
-     * revealTargets flag is set.
-     * @param {BaseCard} card
-     * @param {Player} player
-     */
-    showFacedownTargetTo(card, player) {
-        if(this.revealTargets && card.getType() !== 'plot') {
-            card.showFacedownTargetTo(player);
-        }
     }
 }
 

--- a/server/game/CardVisibility.js
+++ b/server/game/CardVisibility.js
@@ -1,0 +1,50 @@
+const OpenInformationLocations = [
+    'active plot',
+    'agenda',
+    'dead pile',
+    'discard pile',
+    'faction',
+    'out of game',
+    'play area',
+    'revealed plots',
+    'title'
+];
+
+class CardVisibility {
+    constructor(game) {
+        this.game = game;
+        this.rules = [
+            (card) => this.isPublicRule(card),
+            (card, player) => this.isControllerRule(card, player),
+            (card, player) => this.isSpectatorRule(card, player)
+        ];
+    }
+
+    isVisible(card, player) {
+        return this.rules.some(rule => rule(card, player));
+    }
+
+    addRule(rule) {
+        this.rules.push(rule);
+    }
+
+    removeRule(rule) {
+        this.rules = this.rules.filter(r => r !== rule);
+    }
+
+    isPublicRule(card) {
+        return OpenInformationLocations.includes(card.location) && !card.facedown;
+    }
+
+    isControllerRule(card, player) {
+        return card.controller === player && (card.location !== 'draw deck' || player.showDeck);
+    }
+
+    isSpectatorRule(card, player) {
+        return this.game.showHand &&
+               this.game.isSpectator(player) &&
+               ['hand', 'shadows'].includes(card.location);
+    }
+}
+
+module.exports = CardVisibility;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -643,10 +643,8 @@ class BaseCard {
         };
     }
 
-    getSummary(activePlayer, hideWhenFaceup) {
-        let isActivePlayer = activePlayer === this.controller;
-
-        if(!isActivePlayer && (this.facedown || hideWhenFaceup)) {
+    getSummary(activePlayer) {
+        if(!this.game.isCardVisible(this, activePlayer)) {
             return { facedown: true, uuid: this.uuid };
         }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -20,7 +20,6 @@ class DrawCard extends BaseCard {
             this.icons.add(icon);
         }
 
-        this.revealWhenHiddenTo = undefined;
         this.power = 0;
         this.burnValue = 0;
         this.strengthModifier = 0;
@@ -443,39 +442,26 @@ class DrawCard extends BaseCard {
         this.saved = false;
     }
 
-    showFacedownTargetTo(player) {
-        this.revealWhenHiddenTo = player.name;
-    }
-
-    hideFacedownTarget() {
-        this.revealWhenHiddenTo = undefined;
-    }
-
-    getSummary(activePlayer, hideWhenFaceup) {
-        if(this.revealWhenHiddenTo === activePlayer.name) {
-            hideWhenFaceup = false;
-        }
-
-        let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);
+    getSummary(activePlayer) {
+        let baseSummary = super.getSummary(activePlayer);
 
         let publicSummary = {
             attached: !!this.parent,
             attachments: this.attachments.map(attachment => {
-                return attachment.getSummary(activePlayer, hideWhenFaceup);
+                return attachment.getSummary(activePlayer);
             }),
             childCards: this.childCards.map(card => {
-                return card.getSummary(activePlayer, hideWhenFaceup);
+                return card.getSummary(activePlayer);
             }),
             dupes: this.dupes.map(dupe => {
                 if(dupe.dupes.length !== 0) {
                     throw new Error('A dupe should not have dupes! ' + dupe.name);
                 }
 
-                return dupe.getSummary(activePlayer, hideWhenFaceup);
+                return dupe.getSummary(activePlayer);
             }),
             kneeled: this.kneeled,
-            power: this.power,
-            revealWhenHiddenTo: this.revealWhenHiddenTo
+            power: this.power
         };
 
         if(baseSummary.facedown) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -37,6 +37,7 @@ const GroupedCardEvent = require('./GroupedCardEvent.js');
 const SimultaneousEvents = require('./SimultaneousEvents');
 const ChooseGoldSourceAmounts = require('./gamesteps/ChooseGoldSourceAmounts.js');
 const DropCommand = require('./ServerCommands/DropCommand');
+const CardVisibility = require('./CardVisibility');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -77,6 +78,7 @@ class Game extends EventEmitter {
         this.packData = options.packData || [];
         this.restrictedListData = options.restrictedListData || [];
         this.skipPhase = {};
+        this.cardVisibility = new CardVisibility(this);
 
         _.each(details.players, player => {
             this.playersAndSpectators[player.user.username] = new Player(player.id, player.user, this.owner === player.user.username, this);
@@ -175,6 +177,10 @@ class Game extends EventEmitter {
 
     getOpponents(player) {
         return this.getPlayers().filter(p => p !== player);
+    }
+
+    isCardVisible(card, player) {
+        return this.cardVisibility.isVisible(card, player);
     }
 
     anyCardsInPlay(predicate) {

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -59,6 +59,8 @@ class SelectCardPrompt extends UiPrompt {
         _.defaults(this.properties, this.defaultProperties());
         this.selector = properties.selector || CardSelector.for(properties);
         this.selectedCards = [];
+        this.revealTargets = properties.revealTargets;
+        this.revealFunc = null;
         this.savePreviouslySelectedCards();
     }
 
@@ -88,8 +90,13 @@ class SelectCardPrompt extends UiPrompt {
         let selectableCards = this.game.allCards.filter(card => {
             return this.checkCardCondition(card);
         });
-        _.each(selectableCards, card => this.selector.showFacedownTargetTo(card, this.choosingPlayer));
+
         this.choosingPlayer.setSelectableCards(selectableCards);
+
+        if(this.revealTargets && !this.revealFunc) {
+            this.revealFunc = (card, player) => player === this.choosingPlayer && player.getSelectableCards().includes(card);
+            this.game.cardVisibility.addRule(this.revealFunc);
+        }
     }
 
     activeCondition(player) {
@@ -217,6 +224,11 @@ class SelectCardPrompt extends UiPrompt {
 
         // Restore previous selections.
         this.choosingPlayer.setSelectedCards(this.previouslySelectedCards);
+
+        if(this.revealTargets && this.revealFunc) {
+            this.game.cardVisibility.removeRule(this.revealFunc);
+            this.revealFunc = null;
+        }
     }
 }
 

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -230,6 +230,12 @@ class SelectCardPrompt extends UiPrompt {
             this.revealFunc = null;
         }
     }
+
+    cancelStep() {
+        // Explicitly complete the prompt and thus clear player selections if
+        // the prompt is cancelled.
+        this.complete();
+    }
 }
 
 module.exports = SelectCardPrompt;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1191,9 +1191,9 @@ class Player extends Spectator {
         this.promptState.clearSelectableCards();
     }
 
-    getSummaryForCardList(list, activePlayer, hideWhenFaceup) {
+    getSummaryForCardList(list, activePlayer) {
         return list.map(card => {
-            return card.getSummary(activePlayer, hideWhenFaceup);
+            return card.getSummary(activePlayer);
         });
     }
 
@@ -1226,10 +1226,6 @@ class Player extends Spectator {
         };
     }
 
-    showHandtoSpectators(player) {
-        return this.game.isSpectator(player) && this.game.showHand;
-    }
-
     disableTimerForRound() {
         this.noTimer = true;
         this.resetTimerAtEndOfRound = true;
@@ -1249,7 +1245,7 @@ class Player extends Spectator {
         // Rains
         if(this.agenda && this.agenda.code === '05045') {
             for(const plot of this.plotDeck) {
-                let plotSummary = plot.getSummary(activePlayer, true);
+                let plotSummary = plot.getSummary(activePlayer);
                 if(plot.hasTrait('scheme')) {
                     plotSummary.group = 'Scheme';
                 } else {
@@ -1259,7 +1255,7 @@ class Player extends Spectator {
                 plots.push(plotSummary);
             }
         } else {
-            plots = this.getSummaryForCardList(this.plotDeck, activePlayer, true);
+            plots = this.getSummaryForCardList(this.plotDeck, activePlayer);
         }
 
         let state = {
@@ -1268,14 +1264,14 @@ class Player extends Spectator {
             cardPiles: {
                 bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
                 cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
-                conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer, true),
+                conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer),
                 deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
                 discardPile: this.getSummaryForCardList(fullDiscardPile, activePlayer).reverse(),
-                hand: this.getSummaryForCardList(this.hand, activePlayer, !this.showHandtoSpectators(activePlayer)),
-                outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer, false),
+                hand: this.getSummaryForCardList(this.hand, activePlayer),
+                outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer),
                 plotDeck: plots,
                 plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
-                shadows: this.getSummaryForCardList(this.shadows, activePlayer, !this.showHandtoSpectators(activePlayer))
+                shadows: this.getSummaryForCardList(this.shadows, activePlayer)
             },
             disconnected: this.disconnected,
             faction: this.faction.getSummary(activePlayer),

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -26,11 +26,6 @@ class PlayerPromptState {
     }
 
     clearSelectableCards() {
-        for(let card of this.selectableCards) {
-            if(['attachment', 'character', 'event', 'location'].includes(card.getType())) {
-                card.hideFacedownTarget();
-            }
-        }
         this.selectableCards = [];
     }
 

--- a/test/server/CardVisibility.spec.js
+++ b/test/server/CardVisibility.spec.js
@@ -1,0 +1,116 @@
+const CardVisibility = require ('../../server/game/CardVisibility');
+
+describe('CardVisibility', function() {
+    beforeEach(function() {
+        this.spectator = { specator: true };
+        this.controller = { controller: true };
+        this.opponent = { opponent: true };
+        this.card = { location: 'play area', facedown: false, controller: this.controller };
+        this.gameSpy = jasmine.createSpyObj('game', ['isSpectator']);
+        this.gameSpy.isSpectator.and.callFake(p => p === this.specator);
+
+        this.visibility = new CardVisibility(this.gameSpy);
+    });
+
+    describe('isVisible()', function() {
+        describe('when the card face up', function() {
+            beforeEach(function() {
+                this.card.facedown = false;
+            });
+
+            describe('and it is in a open information location', function() {
+                beforeEach(function() {
+                    this.card.location = 'discard pile';
+                });
+
+                it('should return true for the controller', function() {
+                    expect(this.visibility.isVisible(this.card, this.controller)).toBe(true);
+                });
+
+                it('should return true for the opponent', function() {
+                    expect(this.visibility.isVisible(this.card, this.opponent)).toBe(true);
+                });
+
+                it('should return true for spectators', function() {
+                    expect(this.visibility.isVisible(this.card, this.specator)).toBe(true);
+                });
+            });
+
+            describe('and it is in a hidden information location', function() {
+                beforeEach(function() {
+                    this.card.location = 'hand';
+                });
+
+                it('should return true for the controller', function() {
+                    expect(this.visibility.isVisible(this.card, this.controller)).toBe(true);
+                });
+
+                it('should return false for the opponent', function() {
+                    expect(this.visibility.isVisible(this.card, this.opponent)).toBe(false);
+                });
+
+                it('should return false for spectators', function() {
+                    expect(this.visibility.isVisible(this.card, this.specator)).toBe(false);
+                });
+
+                describe('when showHand is on', function() {
+                    beforeEach(function() {
+                        this.gameSpy.showHand = true;
+                    });
+
+                    it('should still return false for the opponent', function() {
+                        expect(this.visibility.isVisible(this.card, this.opponent)).toBe(false);
+                    });
+
+                    it('should return true for spectators', function() {
+                        expect(this.visibility.isVisible(this.card, this.specator)).toBe(true);
+                    });
+                });
+            });
+
+            describe('and it is in the draw deck', function() {
+                beforeEach(function() {
+                    this.card.location = 'draw deck';
+                });
+
+                it('should return false for the controller', function() {
+                    expect(this.visibility.isVisible(this.card, this.controller)).toBe(false);
+                });
+
+                it('should return true for the controller if showDeck is on', function() {
+                    this.controller.showDeck = true;
+
+                    expect(this.visibility.isVisible(this.card, this.controller)).toBe(true);
+                });
+            });
+        });
+
+        describe('when the card is face down', function() {
+            beforeEach(function() {
+                this.card.facedown = true;
+                this.card.location = 'play area';
+            });
+
+            it('should return true for the controller', function() {
+                expect(this.visibility.isVisible(this.card, this.controller)).toBe(true);
+            });
+
+            it('should return false for the opponent', function() {
+                expect(this.visibility.isVisible(this.card, this.opponent)).toBe(false);
+            });
+
+            it('should return false for spectators', function() {
+                expect(this.visibility.isVisible(this.card, this.specator)).toBe(false);
+            });
+        });
+    });
+
+    describe('addRule()', function() {
+        it('should allow otherwise disallowed cards to be visible', function() {
+            this.card.location = 'plot deck';
+            this.visibility.addRule((card, player) => player === this.opponent);
+
+            expect(this.visibility.isVisible(this.card, this.opponent)).toBe(true);
+        });
+    });
+});

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -5,7 +5,7 @@ describe('BaseCard', function () {
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1', faction: 'neutral' };
         this.limitedCard = { code: '1234', text: 'Limited.', faction: 'neutral' };
         this.nonLimitedCard = { code: '2222', text: 'Stealth.', faction: 'neutral' };
-        this.game = jasmine.createSpyObj('game', ['raiseEvent']);
+        this.game = jasmine.createSpyObj('game', ['isCardVisible', 'raiseEvent']);
         this.owner = jasmine.createSpyObj('owner', ['getCardSelectionState']);
         this.owner.getCardSelectionState.and.returnValue({});
         this.owner.game = this.game;
@@ -50,8 +50,9 @@ describe('BaseCard', function () {
     });
 
     describe('getSummary', function() {
-        describe('when is active player', function() {
+        describe('when is visible to the active player', function() {
             beforeEach(function () {
+                this.game.isCardVisible.and.returnValue(true);
                 this.summary = this.card.getSummary(this.owner);
             });
 
@@ -85,41 +86,26 @@ describe('BaseCard', function () {
             });
         });
 
-        describe('when is not active player', function() {
+        describe('when is not visible to active player', function() {
             beforeEach(function () {
+                this.game.isCardVisible.and.returnValue(false);
                 this.anotherPlayer = jasmine.createSpyObj('owner', ['getCardSelectionState']);
                 this.anotherPlayer.getCardSelectionState.and.returnValue({});
                 this.summary = this.card.getSummary(this.anotherPlayer);
             });
 
             describe('and card is faceup', function() {
-                describe('and hiding facedown cards', function() {
-                    beforeEach(function() {
-                        this.summary = this.card.getSummary(this.anotherPlayer, true);
-                    });
-
-                    it('should return no card data', function () {
-                        expect(this.summary.name).toBeUndefined();
-                        expect(this.summary.code).toBeUndefined();
-                    });
-
-                    it('should return facedown', function() {
-                        expect(this.summary.facedown).toBe(true);
-                    });
-
-                    it('should return the uuid', function() {
-                        expect(this.summary.uuid).not.toBeUndefined();
-                    });
+                it('should return no card data', function () {
+                    expect(this.summary.name).toBeUndefined();
+                    expect(this.summary.code).toBeUndefined();
                 });
 
-                it('should return card data', function () {
-                    expect(this.summary.uuid).toEqual(this.card.uuid);
-                    expect(this.summary.name).toEqual(this.testCard.label);
-                    expect(this.summary.code).toEqual(this.testCard.code);
+                it('should return the uuid', function() {
+                    expect(this.summary.uuid).not.toBeUndefined();
                 });
 
-                it('should not return facedown', function() {
-                    expect(this.summary.facedown).toBe(false);
+                it('should return facedown', function() {
+                    expect(this.summary.facedown).toBe(true);
                 });
             });
 

--- a/test/server/card/drawcard.getsummary.spec.js
+++ b/test/server/card/drawcard.getsummary.spec.js
@@ -1,4 +1,4 @@
-const DrawCard = require('../../../server/game/drawcard.js');
+const DrawCard = require('../../../server/game/drawcard');
 
 describe('DrawCard', function () {
     function createPlayerSpy(name) {
@@ -8,8 +8,11 @@ describe('DrawCard', function () {
     }
 
     beforeEach(function () {
+        this.gameSpy = jasmine.createSpyObj('game', ['isCardVisible']);
+        this.gameSpy.isCardVisible.and.returnValue(true);
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1', faction: 'neutral' };
         this.card = new DrawCard({}, this.testCard);
+        this.card.game = this.gameSpy;
         this.activePlayer = createPlayerSpy('player1');
         this.card.owner = this.activePlayer;
     });
@@ -39,11 +42,12 @@ describe('DrawCard', function () {
             });
         });
 
-        describe('when a card is facedown', function() {
+        describe('when a card is not visible', function() {
             beforeEach(function() {
                 this.testCard.strength = 5;
                 let anotherPlayer = createPlayerSpy('player2');
-                this.summary = this.card.getSummary(anotherPlayer, true);
+                this.gameSpy.isCardVisible.and.returnValue(false);
+                this.summary = this.card.getSummary(anotherPlayer);
             });
 
             it('should not include baseStrength', function() {


### PR DESCRIPTION
Previously, the logic about who could see which cards was spread across
multiple classes - Player class controlled the visibility of cards
within individual piles, the Card classes controlled it via properties
passed into their getSummary methods, and logic for revealed in-hand
cards appeared in multiple spots related to card selection prompts.

By centralizing it, the overall logic should be more clear.
Additionally, adding the ability to add new visibility rules should make
it easier to implement upcoming cards like Stolen Message, which reveal
cards publicly instead of only to a specific player.