### PR TITLE
Setup gold effect should be applied to players

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -65,6 +65,7 @@ function dominanceOptionEffect(key) {
 const Effects = {
     setSetupGold: function(value) {
         return {
+            targetType: 'player',
             apply: function(player) {
                 player.setupGold = value;
             },


### PR DESCRIPTION
Fixes an issue where House with the Red Door was giving players 8 gold
during setup instead of 4 gold like it should.