### PR TITLE
Handle choosing no cards w/ Growing Ambition

### DIFF
--- a/server/game/cards/11.3-SoKL/GrowingAmbition.js
+++ b/server/game/cards/11.3-SoKL/GrowingAmbition.js
@@ -8,6 +8,8 @@ class GrowingAmbition extends DrawCard {
             cost: ability.costs.payXGold(() => 1, () => this.controller.drawDeck.length),
             chooseOpponent: true,
             handler: context => {
+                this.chosenCards = [];
+
                 this.game.promptForDeckSearch(this.controller, {
                     numToSelect: context.xValue,
                     onSelect: (player, card) => this.cardSelected(player, card),
@@ -28,6 +30,11 @@ class GrowingAmbition extends DrawCard {
     }
 
     returnCards(context) {
+        if(this.chosenCards.length === 0) {
+            this.game.addMessage('{0} plays {1} to search their deck, but chooses no cards.', context.player, this);
+            return;
+        }
+
         this.game.addMessage('{0} plays {1} to choose {2}, search their deck and place {3} in their discard pile',
             context.player, this, context.opponent, this.chosenCards);
 


### PR DESCRIPTION
Growing Ambition requires the player pay at least 1 gold for X. However,
if the player does not choose their card in the deck search prompt, the
ability would crash.

Fixes THRONETEKI-2A6