### PR TITLE
Add getPlayActions to base card class

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -274,6 +274,10 @@ class BaseCard {
         return value === '-' ? 0 : value;
     }
 
+    getPlayActions() {
+        return [];
+    }
+
     get controller() {
         if(this.controllerStack.length === 0) {
             return this.owner;


### PR DESCRIPTION
Previously, it was assumed that the Player.playCard method would only be
called with draw card objects. However, as we've generalized click
behavior it can now be reached with both plot and agenda card objects,
which was crashing. Adding a default implementation in BaseCard that
returns no possible play actions prevents this crash.

Fixes THRONETEKI-2A3