### PR TITLE
Limit out-of-shadows action to controlling player

### DIFF
--- a/server/game/PlayActions/OutOfShadowsAction.js
+++ b/server/game/PlayActions/OutOfShadowsAction.js
@@ -19,7 +19,7 @@ class OutOfShadowsAction extends BaseAbility {
     meetsRequirements(context) {
         return (
             context.source.isShadow() &&
-            context.source.location === 'shadows' &&
+            context.player.isCardInPlayableLocation(context.source, 'outOfShadows') &&
             context.player.canPutIntoPlay(context.source, 'outOfShadows') &&
             context.source.getType() !== 'event'
         );

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -84,7 +84,7 @@ class Player extends Spectator {
 
     createDefaultPlayableLocations() {
         let playFromHand = ['marshal', 'play', 'ambush'].map(playingType => new PlayableLocation(playingType, card => card.controller === this && card.location === 'hand'));
-        let playFromShadows = ['play'].map(playingType => new PlayableLocation(playingType, card => card.controller === this && card.location === 'shadows'));
+        let playFromShadows = ['outOfShadows', 'play'].map(playingType => new PlayableLocation(playingType, card => card.controller === this && card.location === 'shadows'));
         return playFromHand.concat(playFromShadows);
     }
 

--- a/test/server/integration/ShadowKeyword.spec.js
+++ b/test/server/integration/ShadowKeyword.spec.js
@@ -159,6 +159,30 @@ describe('Shadow keyword', function() {
                     expect(this.player1).toAllowAbilityTrigger('Bowels of Casterly Rock');
                 });
             });
+
+            describe('as an opponent\'s shadow character', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.character);
+                    this.player1.clickPrompt('Setup in shadows');
+                    this.completeSetup();
+                    this.player1.selectPlot('Trading with the Pentoshi');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.completeMarshalPhase();
+
+                    // Complete Player 1 marshalling
+                    this.player1.clickPrompt('Done');
+
+                    // Attempt to bring Player 1's character out of shadows
+                    this.player2.clickCard(this.character);
+                });
+
+                it('should not put the card into play', function() {
+                    expect(this.character.location).not.toBe('play area');
+                    expect(this.character).not.toBeControlledBy(this.player2);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Recently, card IDs were added to the data for facedown cards in order to
support cards like Hired Assassin and Valyrian's Crew. However, this
revealed an existing bug where a player could bring out opponent's cards
from shadow under their own control. It simply never could occur before
because the client was not sent the IDs for in-shadow cards.

Now, the out-of-shadows action uses the same "playable location"
mechanism that is used for marshalling, ambushing, and playing in-hand
cards, preventing opponents from using them by default. The playable
location mechanism should also automatically support any cards in the
future that do allow you to bring opponent cards out-of-shadow (similar
to Night Gathers allowing marshalling from opponent discard pile).

Fixes #2171 