### PR TITLE
Fix duplicate visibility

### DIFF
--- a/server/game/CardVisibility.js
+++ b/server/game/CardVisibility.js
@@ -4,6 +4,7 @@ const OpenInformationLocations = [
     'being played',
     'dead pile',
     'discard pile',
+    'duplicate',
     'faction',
     'out of game',
     'play area',


### PR DESCRIPTION
If a duplicate is not facedown, an opponent should be able to see the
card used.