### PR TITLE
Hizdahr zo Loraq reduces marshalling into shadow

### DIFF
--- a/server/game/costreducer.js
+++ b/server/game/costreducer.js
@@ -8,10 +8,24 @@ class CostReducer {
         this.limit = properties.limit;
         this.match = properties.match || (() => true);
         this.amount = properties.amount || 1;
-        this.playingTypes = _.isArray(properties.playingTypes) ? properties.playingTypes : [properties.playingTypes];
+        this.playingTypes = this.buildPlayingTypes(properties);
         if(this.limit) {
             this.limit.registerEvents(game);
         }
+    }
+
+    buildPlayingTypes(properties) {
+        let playingTypes = Array.isArray(properties.playingTypes) ? properties.playingTypes : [properties.playingTypes];
+
+        // Reducers that reduce marshalling any card with no characteristic
+        // requirements should also reduce marshalling any card into shadows.
+        // See the following ruling on Hizdahr zo Loraq:
+        // http://www.cardgamedb.com/forums/index.php?/topic/39948-ruling-hizdahr-zo-loraq/
+        if(!properties.match && playingTypes.includes('marshal')) {
+            return playingTypes.concat('marshalIntoShadows');
+        }
+
+        return playingTypes;
     }
 
     canReduce(playingType, card) {


### PR DESCRIPTION
Reducers such as Hizdahr zo Loraq that have no characteristic
requirement for the reduction (e.g. being a certain faction, being a
character, etc) should also reduce any card marshalled into shadows.

http://www.cardgamedb.com/forums/index.php?/topic/39948-ruling-hizdahr-zo-loraq/