### PR TITLE
Fix crash + language on Growing Ambition

### DIFF
--- a/server/game/cards/11.3-SoKL/GrowingAmbition.js
+++ b/server/game/cards/11.3-SoKL/GrowingAmbition.js
@@ -41,7 +41,7 @@ class GrowingAmbition extends DrawCard {
     }
 
     selfCancelSearch(context) {
-        this.game.addMessage('{0} play {1} to search their deck, but chooses no cards', context.player, this);
+        this.game.addMessage('{0} plays {1} to search their deck, but chooses no cards', context.player, this);
     }
 
     opponentSelectCards(player, cards) {


### PR DESCRIPTION
Cleans up language of the prompt for Growing Ambition after converting
it to a card select prompt, as well as adding messages for cancellation
cases and removing the call to a cleanup method that was removed.

Fixes THRONETEKI-2AJ