### PR TITLE
Allow dupes when card abilities prevented

### DIFF
--- a/server/game/PlayActions/MarshalCardAction.js
+++ b/server/game/PlayActions/MarshalCardAction.js
@@ -4,6 +4,7 @@ const Costs = require('../costs');
 class MarshalCardAction extends BaseAbility {
     constructor() {
         super({
+            abilitySourceType: 'game',
             cost: [
                 Costs.payReduceableGoldCost('marshal'),
                 Costs.playLimited()
@@ -52,10 +53,6 @@ class MarshalCardAction extends BaseAbility {
         let hand = params.originalLocation === 'hand' ? 'hand' : 'other';
         let current = params.originalController === params.player ? 'current' : 'opponent';
         return messages[`${params.type}.${hand}.${current}`] || messages['card.hand.current'];
-    }
-
-    isCardAbility() {
-        return false;
     }
 }
 

--- a/server/game/PlayActions/MarshalIntoShadowsAction.js
+++ b/server/game/PlayActions/MarshalIntoShadowsAction.js
@@ -4,6 +4,7 @@ const Costs = require('../costs');
 class MarshalIntoShadowsAction extends BaseAbility {
     constructor() {
         super({
+            abilitySourceType: 'game',
             cost: [
                 Costs.payReduceableGoldCost('marshalIntoShadows')
             ]
@@ -37,10 +38,6 @@ class MarshalIntoShadowsAction extends BaseAbility {
             context.game.addMessage('{0} marshals a card into shadows costing {1} gold', context.player, context.costs.gold);
             context.player.putIntoShadows(context.source);
         });
-    }
-
-    isCardAbility() {
-        return false;
     }
 }
 

--- a/server/game/PlayActions/SetupCardAction.js
+++ b/server/game/PlayActions/SetupCardAction.js
@@ -4,16 +4,13 @@ const Costs = require('../costs');
 class SetupCardAction extends BaseAbility {
     constructor() {
         super({
+            abilitySourceType: 'game',
             cost: [
                 Costs.payPrintedGoldCost(),
                 Costs.playLimited()
             ]
         });
         this.title = 'Setup';
-    }
-
-    isCardAbility() {
-        return false;
     }
 
     meetsRequirements(context) {

--- a/server/game/PlayActions/SetupInShadowsAction.js
+++ b/server/game/PlayActions/SetupInShadowsAction.js
@@ -4,15 +4,12 @@ const Costs = require('../costs');
 class SetupInShadowsAction extends BaseAbility {
     constructor() {
         super({
+            abilitySourceType: 'game',
             cost: [
                 Costs.payGold(2)
             ]
         });
         this.title = 'Setup in shadows';
-    }
-
-    isCardAbility() {
-        return false;
     }
 
     meetsRequirements(context) {

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -27,6 +27,7 @@ class BaseAbility {
         this.limit = properties.limit;
         this.cannotBeCanceled = !!properties.cannotBeCanceled;
         this.chooseOpponentFunc = properties.chooseOpponent;
+        this.abilitySourceType = properties.abilitySourceType || 'card';
     }
 
     buildCost(cost) {
@@ -212,7 +213,7 @@ class BaseAbility {
     }
 
     isCardAbility() {
-        return true;
+        return this.abilitySourceType === 'card';
     }
 
     isTriggeredAbility() {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -102,7 +102,7 @@ class CardAction extends BaseAbility {
             return false;
         }
 
-        if(!context.player.canTrigger(this.card)) {
+        if(this.isCardAbility() && !context.player.canTrigger(this.card)) {
             return false;
         }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -69,6 +69,7 @@ class DrawCard extends BaseCard {
         let dupeCondition = event => event.card === this.parent && this.parent.canBeSaved() && event.allowSave && this.controller.promptDupes;
 
         this.interrupt({
+            abilitySourceType: 'game',
             canCancel: true,
             cannotBeCanceled: true,
             location: 'duplicate',

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -78,7 +78,7 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
-        if(!this.isForcedAbility() && context.player && !context.player.canTrigger(this.card)) {
+        if(this.isCardAbility() && !this.isForcedAbility() && context.player && !context.player.canTrigger(this.card)) {
             return false;
         }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -200,6 +200,10 @@ class PlayerInteractionWrapper {
         this.player.keywordSettings[setting] = value;
     }
 
+    toggleManualDupes(value) {
+        this.player.promptDupes = value;
+    }
+
     reconnect() {
         let newSocket = { id: uuid.v1() };
         this.game.reconnect(newSocket, this.player.name);

--- a/test/server/integration/Duplicates.spec.js
+++ b/test/server/integration/Duplicates.spec.js
@@ -1,0 +1,47 @@
+describe('Duplicates', function() {
+    integration(function() {
+        describe('manual dupes', function() {
+            beforeEach(function() {
+                this.player1.toggleManualDupes(true);
+                this.player2.toggleManualDupes(true);
+            });
+
+            describe('when abilities cannot be triggered and a duped character would be killed', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', [
+                        'The King in the North',
+                        'Hedge Knight', 'Arya Stark (Core)', 'Arya Stark (Core)'
+                    ]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.player1.clickCard('Hedge Knight', 'hand');
+
+                    [this.character, this.dupe] = this.player2.filterCardsByName('Arya Stark', 'hand');
+                    this.player2.clickCard(this.character);
+                    this.player2.clickCard(this.dupe);
+
+                    this.completeSetup();
+                    this.selectFirstPlayer(this.player1);
+                    this.completeMarshalPhase();
+
+                    this.unopposedChallenge(this.player1, 'Military', 'Hedge Knight');
+                    this.player1.clickPrompt('Apply Claim');
+
+                    this.player2.clickCard(this.character);
+
+                    expect(this.player2).toAllowAbilityTrigger(this.dupe);
+
+                    this.player2.clickCard(this.dupe);
+                });
+
+                it('should allow the dupe to be used', function() {
+                    expect(this.character.location).toBe('play area');
+                    expect(this.dupe.location).toBe('discard pile');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Using a dupe to save is considered a "game ability" instead of a "card
ability." Since manual dupes are set up as using the ability system,
they were improperly considered a "card ability" when cards like
Winterfell, Core Catelyn, or King in the North were in play.

Now, abilities can be defined as a game ability and thus skip the checks
involved with effects preventing card abilities.