### PR TITLE
Allow ability messages defined outside of handler

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -316,6 +316,35 @@ class SealOfTheHand extends DrawCard {
 }
 ```
 
+#### Ability messages
+
+The `message` property can be used to add a message to the game log outside of the `handler` function. By separating the message from the handler that executes the ability, messages can be added to the game log prior to prompting to cancel abilities (e.g. Treachery, Hand's Judgment, etc).
+
+The `message` property should be a function that takes an ability context object and returns an array with the message string as the first item in the array, followed by any arguments for the message:
+
+```javascript
+this.action({
+    // ...
+    message: context => ['{0} kneels {1} to stand {2}', context.player, this, this.parent],
+    handler: () => {
+        // ...
+    }
+});
+```
+
+It can also output the message directly using the game object without returning a message format:
+```javascript
+this.action({
+    // ...
+    message: context => {
+        this.game.addMessage('{0} kneels {1} to stand {2}', context.player, this, this.parent);
+    },
+    handler: () => {
+        // ...
+    }
+});
+```
+
 #### Checking ability restrictions
 
 Card abilities can only be triggered if they have the potential to modify game state (outside of paying costs). To ensure that the action's play restrictions are met, pass a `condition` function that returns `true` when the restrictions are met, and `false` otherwise. If the condition returns `false`, the action will not be executed and costs will not be paid.

--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -320,25 +320,39 @@ class SealOfTheHand extends DrawCard {
 
 The `message` property can be used to add a message to the game log outside of the `handler` function. By separating the message from the handler that executes the ability, messages can be added to the game log prior to prompting to cancel abilities (e.g. Treachery, Hand's Judgment, etc).
 
-The `message` property should be a function that takes an ability context object and returns an array with the message string as the first item in the array, followed by any arguments for the message:
+The `message` property can be just a string if there are no additional arguments. `{player}` will be replaced with the player initiating the ability, `{source}` will be replaced with the card associated with the ability, and `{target}` will be replaced with the target for the ability (if any):
 
 ```javascript
 this.action({
     // ...
-    message: context => ['{0} kneels {1} to stand {2}', context.player, this, this.parent],
+    message: '{player} kneels {source} to stand {target}',
     handler: () => {
         // ...
     }
 });
 ```
 
-It can also output the message directly using the game object without returning a message format:
+When you have additional parameters needed for the message, the `message` property can be an object with a `format` sub-property for the message format, and an `args` sub-property for the additional arguments. The keys of the `args` sub-property correspond to the replacement name, and the values correspond to a function that takes the `context` object and returns the appropriate argument value:
 ```javascript
 this.action({
     // ...
-    message: context => {
-        this.game.addMessage('{0} kneels {1} to stand {2}', context.player, this, this.parent);
+    message: {
+        format: '{player} uses {source} to put {target} into play from {targetOwner}\'s discard pile.',
+        args: {
+            targetOwner: context => context.target.owner
+        }
     },
+    handler: () => {
+        // ...
+    }
+});
+```
+
+Finally, you can pass a function to the `message` property that will be executed:
+```javascript
+this.action({
+    // ...
+    message: context => this.game.addMessage('{0} uses {1} to kill {2}', context.player, this, context.target),
     handler: () => {
         // ...
     }

--- a/server/game/AbilityMessage.js
+++ b/server/game/AbilityMessage.js
@@ -1,0 +1,97 @@
+class AbilityMessage {
+    static create(formatOrProperties) {
+        class NullValue {
+            output() {
+                // no-op.
+            }
+        }
+
+        class FunctionAdapter {
+            constructor(outputFunc) {
+                this.outputFunc = outputFunc;
+            }
+
+            output(outputter, context) {
+                this.outputFunc(context);
+            }
+        }
+
+        if(!formatOrProperties) {
+            return new NullValue();
+        }
+
+        if(typeof(formatOrProperties) === 'function') {
+            return new FunctionAdapter(formatOrProperties);
+        }
+
+        if(typeof(formatOrProperties) === 'string') {
+            return new AbilityMessage({ format: formatOrProperties });
+        }
+
+        return new AbilityMessage(formatOrProperties);
+    }
+
+    constructor(properties) {
+        this.args = properties.args || {};
+        this.format = this.translateNamedArgs(properties.format, this.args);
+        this.type = properties.type || 'message';
+
+        this.validateNamedArgs(properties.format, this.args);
+    }
+
+    translateNamedArgs(format, args) {
+        let result = format;
+        let index = 0;
+
+        for(let argName of this.getDefinedArgNames(args)) {
+            result = result.replace(`{${argName}}`, `{${index}}`);
+            ++index;
+        }
+
+        return result;
+    }
+
+    validateNamedArgs(format, args) {
+        let definedArgNames = this.getDefinedArgNames(args);
+        let usedArgNames = this.getUsedArgNames(format);
+        let undefinedArgNames = usedArgNames.filter(argName => !definedArgNames.includes(argName));
+
+        if(undefinedArgNames.length !== 0) {
+            throw new Error(`Undefined argument names for ability message: ${ undefinedArgNames.join(', ') }`);
+        }
+    }
+
+    getUsedArgNames(format) {
+        let result = [];
+        let namedArgRegex = /{(\w+)}/g;
+        let match;
+
+        while((match = namedArgRegex.exec(format)) !== null) {
+            result.push(match[1]);
+        }
+
+        return result;
+    }
+
+    getDefinedArgNames(args) {
+        return ['player', 'source', 'target'].concat(Object.keys(args));
+    }
+
+    output(outputter, context) {
+        let args = this.generateArgValues(context);
+
+        if(this.type === 'message') {
+            outputter.addMessage(this.format, ...args);
+        } else {
+            outputter.addAlert(this.type, this.format, ...args);
+        }
+    }
+
+    generateArgValues(context) {
+        let customArgs = Object.values(this.args).map(argFunc => argFunc(context));
+
+        return [context.player, context.source, context.target].concat(customArgs);
+    }
+}
+
+module.exports = AbilityMessage;

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -25,6 +25,7 @@ class BaseAbility {
         this.cost = this.buildCost(properties.cost);
         this.targets = this.buildTargets(properties);
         this.limit = properties.limit;
+        this.messageFunc = properties.message || (() => true);
         this.cannotBeCanceled = !!properties.cannotBeCanceled;
         this.chooseOpponentFunc = properties.chooseOpponent;
         this.abilitySourceType = properties.abilitySourceType || 'card';
@@ -192,6 +193,17 @@ class BaseAbility {
     incrementLimit() {
         if(this.limit) {
             this.limit.increment();
+        }
+    }
+
+    outputMessage(context) {
+        // The message function can either output a message directly, or just
+        // return an array with the message and arguments necessary to output
+        // the message.
+        let messageArgs = this.messageFunc(context);
+
+        if(Array.isArray(messageArgs)) {
+            this.game.addMessage(...messageArgs);
         }
     }
 

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -1,5 +1,6 @@
 const _ = require('underscore');
 
+const AbilityMessage = require('./AbilityMessage');
 const AbilityTarget = require('./AbilityTarget.js');
 
 /**
@@ -25,7 +26,7 @@ class BaseAbility {
         this.cost = this.buildCost(properties.cost);
         this.targets = this.buildTargets(properties);
         this.limit = properties.limit;
-        this.messageFunc = properties.message || (() => true);
+        this.message = AbilityMessage.create(properties.message);
         this.cannotBeCanceled = !!properties.cannotBeCanceled;
         this.chooseOpponentFunc = properties.chooseOpponent;
         this.abilitySourceType = properties.abilitySourceType || 'card';
@@ -197,14 +198,7 @@ class BaseAbility {
     }
 
     outputMessage(context) {
-        // The message function can either output a message directly, or just
-        // return an array with the message and arguments necessary to output
-        // the message.
-        let messageArgs = this.messageFunc(context);
-
-        if(Array.isArray(messageArgs)) {
-            this.game.addMessage(...messageArgs);
-        }
+        this.message.output(this.game, context);
     }
 
     /**

--- a/server/game/cards/01-Core/SealOfTheHand.js
+++ b/server/game/cards/01-Core/SealOfTheHand.js
@@ -7,9 +7,9 @@ class SealOfTheHand extends DrawCard {
             title: 'Stand attached character',
             condition: () => this.parent.kneeled,
             cost: ability.costs.kneelSelf(),
+            message: () => ['{0} kneels {1} to stand {2}', this.controller, this, this.parent],
             handler: () => {
                 this.controller.standCard(this.parent);
-                this.game.addMessage('{0} kneels {1} to stand {2}', this.controller, this, this.parent);
             }
         });
     }

--- a/server/game/cards/01-Core/SealOfTheHand.js
+++ b/server/game/cards/01-Core/SealOfTheHand.js
@@ -7,7 +7,7 @@ class SealOfTheHand extends DrawCard {
             title: 'Stand attached character',
             condition: () => this.parent.kneeled,
             cost: ability.costs.kneelSelf(),
-            message: () => ['{0} kneels {1} to stand {2}', this.controller, this, this.parent],
+            message: () => this.game.addMessage('{0} kneels {1} to stand {2}', this.controller, this, this.parent),
             handler: () => {
                 this.controller.standCard(this.parent);
             }

--- a/server/game/cards/12-KotI/BalonGreyjoy.js
+++ b/server/game/cards/12-KotI/BalonGreyjoy.js
@@ -9,6 +9,12 @@ class BalonGreyjoy extends DrawCard {
                 cardCondition: card => card.location === 'discard pile' && card.controller !== this.controller &&
                                        this.controller.canPutIntoPlay(card)
             },
+            message: {
+                format: '{player} uses {source} and kneels their faction card to put {target} into play from {targetOwner}\'s discard pile under their control',
+                args: {
+                    targetOwner: context => context.target.owner
+                }
+            },
             handler: context => {
                 context.player.putIntoPlay(context.target);
 
@@ -16,9 +22,6 @@ class BalonGreyjoy extends DrawCard {
                     match: context.target,
                     effect: ability.effects.shuffleIntoDeckIfStillInPlay()
                 }));
-
-                this.game.addMessage('{0} uses {1} and kneels their faction card to put {2} into play from {3}\'s discard pile under their control',
-                    context.player, this, context.target, context.target.owner);
             }
         });
     }

--- a/server/game/cards/12-KotI/CitadelArchivist.js
+++ b/server/game/cards/12-KotI/CitadelArchivist.js
@@ -9,6 +9,7 @@ class CitadelArchivist extends DrawCard {
                     event.card === this
             },
             location: 'discard pile',
+            message: '{player} uses {source} to shuffle each player\'s discard pile into their deck',
             handler: () => {
                 for(let player of this.game.getPlayersInFirstPlayerOrder()) {
                     for(let card of player.discardPile) {
@@ -17,8 +18,6 @@ class CitadelArchivist extends DrawCard {
 
                     player.shuffleDrawDeck();
                 }
-
-                this.game.addMessage('{0} uses {1} to shuffle each player\'s discard pile into their deck', this.controller, this);
             }
         });
     }

--- a/server/game/cards/12-KotI/Cohollo.js
+++ b/server/game/cards/12-KotI/Cohollo.js
@@ -9,10 +9,14 @@ class Cohollo extends DrawCard {
                 ability.costs.discardFromHand()
             ],
             condition: () => !!this.game.currentChallenge,
+            message: {
+                format: '{player} kneels {source} and discards {discardCost} to have {source} participate in the current challenge',
+                args: {
+                    discardCost: context => context.costs.discardFromHand
+                }
+            },
             handler: context => {
                 this.game.currentChallenge.addParticipantToSide(context.player, this);
-
-                this.game.addMessage('{0} kneels {1} to discard {2} and have {1} participate in the current challenge', context.player, this, context.costs.discardFromHand);
             }
         });
     }

--- a/server/game/cards/12-KotI/DanceOfTheDragons.js
+++ b/server/game/cards/12-KotI/DanceOfTheDragons.js
@@ -7,8 +7,8 @@ class DanceOfTheDragons extends DrawCard {
             target: {
                 cardCondition: card => card.controller === this.controller && card.location === 'discard pile' && card.getType() !== 'event' && card.getPrintedCost() <= 3
             },
+            message: '{player} plays {source} to return {target} to their hand',
             handler: context => {
-                this.game.addMessage('{0} plays {1} to return {2} to their hand', context.player, this, context.target);
                 context.player.returnCardToHand(context.target);
             }
         });

--- a/server/game/cards/12-KotI/EagerDeckhand.js
+++ b/server/game/cards/12-KotI/EagerDeckhand.js
@@ -7,10 +7,9 @@ class EagerDeckhand extends DrawCard {
                 onCardEntersPlay: event => event.card.getType() === 'location' && event.card.controller === this.controller && event.card.hasTrait('warship')
             },
             location: 'hand',
+            message: '{player} puts {source} into play from their hand',
             handler: () => {
                 this.controller.putIntoPlay(this);
-
-                this.game.addMessage('{0} puts {1} into play from their hand', this.controller, this);
             }
         });
     }

--- a/server/game/cards/12-KotI/Fury.js
+++ b/server/game/cards/12-KotI/Fury.js
@@ -16,8 +16,8 @@ class Fury extends DrawCard {
                 activePromptTitle: 'Select a card',
                 cardCondition: card => card.location === 'play area' && ['character', 'location'].includes(card.getType()) && card.power > 0
             },
+            message: '{player} kneels {source} to move 1 power from {target} to their faction card',
             handler: context => {
-                this.game.addMessage('{0} kneels {1} to move 1 power from {2} to their faction card', context.player, this, context.target);
                 this.game.movePower(context.target, this.controller.faction, 1);
             }
         });

--- a/server/game/cards/12-KotI/MaesterMurenmure.js
+++ b/server/game/cards/12-KotI/MaesterMurenmure.js
@@ -12,7 +12,7 @@ class MaesterMurenmure extends DrawCard {
                     (event.ability.isForcedAbility() || event.source.controller !== this.controller)
                 )
             },
-            cost:ability.costs.kneelSelf(),
+            cost: ability.costs.kneelSelf(),
             handler: context => {
                 this.game.addMessage('{0} kneels {1} to cancel {2}', this.controller, this, context.event.source);
                 context.event.cancel();

--- a/server/game/cards/12-KotI/MaidensBane.js
+++ b/server/game/cards/12-KotI/MaidensBane.js
@@ -11,8 +11,8 @@ class MaidensBane extends DrawCard {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.isAttacking() && card.kneeled,
                 gameAction: 'stand'
             },
+            message: '{player} kneels {source} to stand {target}',
             handler: context => {
-                this.game.addMessage('{0} kneels {1} to stand {2}', context.player, this, context.target);
                 context.player.standCard(context.target);
 
                 if(context.target.hasTrait('Captain')) {

--- a/server/game/cards/12-KotI/MyMindIsMyWeapon.js
+++ b/server/game/cards/12-KotI/MyMindIsMyWeapon.js
@@ -8,8 +8,8 @@ class MyMindIsMyWeapon extends DrawCard {
             target: {
                 cardCondition: card => card.location === 'play area' && card.controller === this.controller && card.getType() === 'character' && card.hasIcon('intrigue') && !card.isParticipating()
             },
+            message: '{player} plays {source} to add {target} to the challenge',
             handler: context => {
-                this.game.addMessage('{0} plays {1} to add {2} to the challenge', context.player, this, context.target);
                 this.game.currentChallenge.addParticipantToSide(context.player, context.target);
             }
         });

--- a/server/game/cards/12-KotI/OldGreyGull.js
+++ b/server/game/cards/12-KotI/OldGreyGull.js
@@ -9,8 +9,8 @@ class OldGreyGull extends DrawCard {
                 type: 'select',
                 cardCondition: card => card !== this && card.location === 'play area' && card.getType() === 'character' && card.isFaction('greyjoy') && card.controller === this.controller
             },
+            message: '{player} kneels {source} to kill {target}',
             handler: context => {
-                this.game.addMessage('{0} kneels {1} to kill {2}', context.player, this, context.target);
                 this.game.killCharacter(context.target);
                 this.game.queueSimpleStep(() => {
                     if(context.target.location !== 'dead pile') {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -172,6 +172,8 @@ class AbilityResolver extends BaseStep {
             return;
         }
 
+        this.ability.outputMessage(this.context);
+
         // Check to make sure the ability is actually a card ability. For
         // instance, marshaling does not count as initiating a card ability and
         // thus is not subject to cancels such as Treachery.

--- a/test/server/AbilityMessage.spec.js
+++ b/test/server/AbilityMessage.spec.js
@@ -1,0 +1,124 @@
+const AbilityMessage = require('../../server/game/AbilityMessage');
+
+describe('AbilityMessage', function() {
+    beforeEach(function() {
+        this.outputterSpy = jasmine.createSpyObj('outputter', ['addMessage', 'addAlert']);
+        this.context = {
+            player: 'PLAYER_OBJ',
+            source: 'SOURCE_OBJ',
+            target: 'TARGET_OBJ'
+        };
+    });
+
+    describe('.create()', function() {
+        describe('when nothing is passed in', function() {
+            it('creates a nullable message', function() {
+                let message = AbilityMessage.create(null);
+                message.output(this.outputterSpy, this.context);
+
+                expect(this.outputterSpy.addMessage).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when a function is passed', function() {
+            it('creates an object that wraps the function', function() {
+                let spy = jasmine.createSpy('outputFunc');
+                let message = AbilityMessage.create(spy);
+                message.output(this.outputterSpy, this.context);
+
+                expect(spy).toHaveBeenCalledWith(this.context);
+            });
+        });
+
+        describe('when just a format string is passed', function() {
+            it('creates a message with the specified format and no extra args', function() {
+                let message = AbilityMessage.create('{player} uses {source} to kill {target}');
+                message.output(this.outputterSpy, this.context);
+
+                expect(this.outputterSpy.addMessage).toHaveBeenCalledWith('{0} uses {1} to kill {2}', 'PLAYER_OBJ', 'SOURCE_OBJ', 'TARGET_OBJ');
+            });
+        });
+
+        describe('when a property object is passed', function() {
+            it('creates a message with the specified properties', function() {
+                let message = AbilityMessage.create({
+                    format: '{player} uses {source} to place {target} in {targetOwner}\'s discard pile',
+                    args: {
+                        targetOwner: () => 'TARGET_OWNER_OBJ'
+                    }
+                });
+                message.output(this.outputterSpy, this.context);
+
+                expect(this.outputterSpy.addMessage).toHaveBeenCalledWith('{0} uses {1} to place {2} in {3}\'s discard pile', 'PLAYER_OBJ', 'SOURCE_OBJ', 'TARGET_OBJ', 'TARGET_OWNER_OBJ');
+            });
+        });
+    });
+
+    describe('constructor', function() {
+        describe('when the format includes arguments that are not passed', function() {
+            it('throws an exception', function() {
+                expect(function() {
+                    new AbilityMessage({
+                        format: '{player} does {foo}',
+                        args: {
+                        }
+                    });
+                }).toThrow();
+            });
+        });
+    });
+
+    describe('output()', function() {
+        describe('when there are no additional args', function() {
+            beforeEach(function() {
+                this.message = new AbilityMessage({
+                    format: '{player} uses {source} to kill {target}'
+                });
+                this.message.output(this.outputterSpy, this.context);
+            });
+
+            it('translates named arguments to their numeric values', function() {
+                expect(this.outputterSpy.addMessage).toHaveBeenCalledWith('{0} uses {1} to kill {2}', jasmine.anything(), jasmine.anything(), jasmine.anything());
+            });
+
+            it('passes the arguments in the correct order', function() {
+                expect(this.outputterSpy.addMessage).toHaveBeenCalledWith(jasmine.any(String), 'PLAYER_OBJ', 'SOURCE_OBJ', 'TARGET_OBJ');
+            });
+        });
+
+        describe('when there are additional args', function() {
+            beforeEach(function() {
+                this.message = new AbilityMessage({
+                    format: '{player} uses {source} to place {target} in {targetOwner}\'s {targetLocation}',
+                    args: {
+                        targetLocation: () => 'TARGET_LOCATION_OBJ',
+                        targetOwner: () => 'TARGET_OWNER_OBJ'
+                    }
+                });
+                this.message.output(this.outputterSpy, this.context);
+            });
+
+            it('translates named arguments to their numeric values', function() {
+                expect(this.outputterSpy.addMessage).toHaveBeenCalledWith('{0} uses {1} to place {2} in {4}\'s {3}', jasmine.anything(), jasmine.anything(), jasmine.anything(), jasmine.anything(), jasmine.anything());
+            });
+
+            it('passes the arguments in the correct order', function() {
+                expect(this.outputterSpy.addMessage).toHaveBeenCalledWith(jasmine.any(String), 'PLAYER_OBJ', 'SOURCE_OBJ', 'TARGET_OBJ', 'TARGET_LOCATION_OBJ', 'TARGET_OWNER_OBJ');
+            });
+        });
+
+        describe('when the type property is sent', function() {
+            beforeEach(function() {
+                this.message = new AbilityMessage({
+                    format: '{player} uses {source} to kill {target}',
+                    type: 'danger'
+                });
+                this.message.output(this.outputterSpy, this.context);
+            });
+
+            it('uses the addAlert method', function() {
+                expect(this.outputterSpy.addAlert).toHaveBeenCalledWith('danger', '{0} uses {1} to kill {2}', 'PLAYER_OBJ', 'SOURCE_OBJ', 'TARGET_OBJ');
+            });
+        });
+    });
+});

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -11,7 +11,7 @@ describe('AbilityResolver', function() {
         this.game.reportError.and.callFake(error => {
             throw error;
         });
-        this.ability = jasmine.createSpyObj('ability', ['incrementLimit', 'isAction', 'isCardAbility', 'isForcedAbility', 'isPlayableEventAbility', 'needsChooseOpponent', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
+        this.ability = jasmine.createSpyObj('ability', ['incrementLimit', 'isAction', 'isCardAbility', 'isForcedAbility', 'isPlayableEventAbility', 'needsChooseOpponent', 'outputMessage', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
         this.ability.isCardAbility.and.returnValue(true);
         this.ability.resolveTargets.and.returnValue([]);
         this.player = jasmine.createSpyObj('player', ['moveCard']);


### PR DESCRIPTION
Adds a `message` property to triggered abilities in order to allow
messages to be output before the handler for the ability executes. This
will allow messages to be output to the game log before players are
prompted for cancel abilities (Treachery, Hand's Judgment, etc). It will
also enable the game action mechanism in the future, which will require
removing / replacing the existing `handler` property for abilities.