### PR TITLE
Disable menu items for unusable actions

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -444,7 +444,10 @@ class BaseCard {
 
     getMenu(player) {
         let actionIndexPairs = this.abilities.actions.map((action, index) => [action, index]);
-        let menuActionPairs = actionIndexPairs.filter(pair => !pair[0].isClickToActivate() && pair[0].allowMenu());
+        let menuActionPairs = actionIndexPairs.filter(pair => {
+            let action = pair[0];
+            return action.allowPlayer(player) && !action.isClickToActivate() && action.allowMenu();
+        });
 
         if(menuActionPairs.length === 0) {
             return;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -89,6 +89,10 @@ class CardAction extends BaseAbility {
         return ['play area', 'agenda', 'active plot'].includes(this.location) && this.card.getPrintedType() !== 'event';
     }
 
+    allowPlayer(player) {
+        return this.card.controller === player || this.anyPlayer;
+    }
+
     createContext(player) {
         return new AbilityContext({
             game: this.game,
@@ -114,7 +118,7 @@ class CardAction extends BaseAbility {
             return false;
         }
 
-        if(context.player !== this.card.controller && !this.anyPlayer) {
+        if(!this.allowPlayer(context.player)) {
             return false;
         }
 
@@ -157,7 +161,7 @@ class CardAction extends BaseAbility {
 
     getMenuItem(arg, player) {
         let context = this.createContext(player);
-        return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer, arg: arg, disabled: !this.meetsRequirements(context) };
+        return { text: this.title, method: 'doAction', arg: arg, disabled: !this.meetsRequirements(context) };
     }
 
     isAction() {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -155,8 +155,9 @@ class CardAction extends BaseAbility {
         this.handler(context);
     }
 
-    getMenuItem(arg) {
-        return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer, arg: arg };
+    getMenuItem(arg, player) {
+        let context = this.createContext(player);
+        return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer, arg: arg, disabled: !this.meetsRequirements(context) };
     }
 
     isAction() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -287,14 +287,15 @@ class Game extends EventEmitter {
         this.addAlert('danger', '{0} {1} {2}', player, standStatus, cardFragment);
     }
 
-    cardHasMenuItem(card, menuItem) {
-        return card.menu && card.menu.some(m => {
+    cardHasMenuItem(card, player, menuItem) {
+        let menu = card.getMenu(player) || [];
+        return menu.some(m => {
             return m.method === menuItem.method;
         });
     }
 
     callCardMenuCommand(card, player, menuItem) {
-        if(!card || !card[menuItem.method] || !this.cardHasMenuItem(card, menuItem)) {
+        if(!card || !card[menuItem.method] || !this.cardHasMenuItem(card, player, menuItem)) {
             return;
         }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -137,7 +137,7 @@ class PlayerInteractionWrapper {
             card = this.findCardByName(card);
         }
 
-        var items = _.filter(card.getMenu(), item => item.text === menuText);
+        var items = _.filter(card.getMenu(this.player), item => item.text === menuText);
 
         if(items.length === 0) {
             throw new Error(`Card ${card.name} does not have a menu item "${menuText}"`);

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -438,7 +438,7 @@ describe('CardAction', function () {
         });
 
         it('returns the menu item format', function() {
-            expect(this.menuItem).toEqual(jasmine.objectContaining({ text: 'Do the thing', method: 'doAction', anyPlayer: false, arg: 'arg' }));
+            expect(this.menuItem).toEqual(jasmine.objectContaining({ text: 'Do the thing', method: 'doAction', arg: 'arg' }));
         });
 
         it('should include whether the menu item is disabled', function() {

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -434,11 +434,15 @@ describe('CardAction', function () {
     describe('getMenuItem()', function() {
         beforeEach(function() {
             this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-            this.menuItem = this.action.getMenuItem('arg');
+            this.menuItem = this.action.getMenuItem('arg', this.playerSpy);
         });
 
         it('returns the menu item format', function() {
-            expect(this.menuItem).toEqual({ text: 'Do the thing', method: 'doAction', anyPlayer: false, arg: 'arg' });
+            expect(this.menuItem).toEqual(jasmine.objectContaining({ text: 'Do the thing', method: 'doAction', anyPlayer: false, arg: 'arg' }));
+        });
+
+        it('should include whether the menu item is disabled', function() {
+            expect(this.menuItem['disabled']).toBeDefined();
         });
     });
 


### PR DESCRIPTION
Also remove menus entirely for actions opponents can't trigger (i.e. every existing Action ability except Bronn).

Requires front end from throneteki/throneteki-client#41
Progress toward #2212 