### PR TITLE
Always prompt for dupes on stolen characters

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -66,7 +66,7 @@ class DrawCard extends BaseCard {
     }
 
     setupDuplicateAbility(ability) {
-        let dupeCondition = event => event.card === this.parent && this.parent.canBeSaved() && event.allowSave && this.controller.promptDupes;
+        let dupeCondition = event => event.card === this.parent && this.parent.canBeSaved() && event.allowSave && (this.controller.promptDupes || this.parent.controller !== this.controller);
 
         this.interrupt({
             abilitySourceType: 'game',

--- a/test/server/integration/Duplicates.spec.js
+++ b/test/server/integration/Duplicates.spec.js
@@ -1,5 +1,52 @@
 describe('Duplicates', function() {
     integration(function() {
+        describe('automatic dupes', function() {
+            describe('when a duped character you own would be killed after being stolen', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', [
+                        'A Noble Cause', 'Sneak Attack', 'Valar Morghulis',
+                        'Arya Stark (Core)', 'Arya Stark (Core)', 'Ward'
+                    ]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    [this.character, this.dupe] = this.player1.filterCardsByName('Arya Stark', 'hand');
+                    this.player1.clickCard(this.character);
+                    this.player1.clickCard(this.dupe);
+
+                    this.ward = this.player2.findCardByName('Ward', 'hand');
+
+                    this.completeSetup();
+                    this.player1.selectPlot('A Noble Cause');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    // Complete Player 1 marshalling
+                    this.player1.clickPrompt('Done');
+
+                    this.player2.clickCard(this.ward);
+                    this.player2.clickCard(this.character);
+                    this.player2.clickPrompt('Done');
+
+                    this.completeChallengesPhase();
+
+                    this.player1.selectPlot('Sneak Attack');
+                    this.player2.selectPlot('Valar Morghulis');
+                    this.selectFirstPlayer(this.player1);
+                });
+
+                it('should prompt to use the dupe on the controlled character', function() {
+                    expect(this.player1).toAllowAbilityTrigger(this.dupe);
+                });
+
+                it('should not automatically kill the controlled character', function() {
+                    expect(this.character.location).toBe('play area');
+                });
+            });
+        });
+
         describe('manual dupes', function() {
             beforeEach(function() {
                 this.player1.toggleManualDupes(true);

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -53,7 +53,9 @@ describe('take control', function() {
                         this.selectPlotOrder(this.player1);
                     });
 
-                    it('should kill the character even with dupes', function() {
+                    it('should kill the character if the owner passes on their dupe', function() {
+                        this.player2.clickPrompt('Pass');
+
                         expect(this.paxter.location).toBe('dead pile');
                     });
                 });


### PR DESCRIPTION
Prior to implementing manual dupes, there was no way for a player to use
the dupes on a character that was stolen from them. After manual dupes
was implemented, they could save stolen character if they had the manual
dupe option turned on. However, using automatic dupes still left no
option to save stolen characters.

Now, players will be prompted whether they want to use the dupe or pass
on a stolen character, regardless of whether they have the manual dupe
option turned on.

Fixes #2214 