### PR TITLE
Change the default of the "Before challenges" prompt to true

### DIFF
--- a/server/settings.js
+++ b/server/settings.js
@@ -1,7 +1,7 @@
 const defaultWindows = {
     plot: false,
     draw: false,
-    challengeBegin: false,
+    challengeBegin: true,
     attackersDeclared: true,
     defendersDeclared: true,
     dominance: false,


### PR DESCRIPTION
Rationale: Challenge phase timing is definitely the most crucial one.
Effects that are typically used before the declaration of the first
challenge are quite common: Nightmares, Flea Bottom, every Jump Event.
Not doing these in a proper action window can lead to difficult
technical and social situations on the table. Here is some examples:
* Player A (the FP) wants to play Nightmares on Player B's Flea Bottom but does
  not have the option turned on. Player B does have it turned on and immediately
  uses FB. If player A now wants to retroactively blank FB, this might lead to
  a difficult "social" situation.
* Player A (still having the option turned off) wants to play Last of the Giants
  to jump an attacker. He does so outside of action window with the CHallenge
  selection menu on screen and then immediately declares a challenge with the character.
  Player B however wanted to kneel that character with say Even Handed Justice.
  Now the technical difficulty of the challenge needing to be cancelled and so on appears...

There is plenty of other scenarios. I just named two to illustrate that this
happens in almost *ALL* games. Feel free to use this PR to express your
opinions on it and to turn it down if you don't like it.