### PR TITLE
Send 'X' strength to client

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -497,7 +497,7 @@ class DrawCard extends BaseCard {
         }
 
         return Object.assign(baseSummary, publicSummary, {
-            baseStrength: this.getPrintedStrength(),
+            baseStrength: this.cardData.strength,
             iconsAdded: this.getIconsAdded(),
             iconsRemoved: this.getIconsRemoved(),
             inChallenge: this.inChallenge,


### PR DESCRIPTION
Previously, if an X strength character reached 0 STR (e.g. a Stark-less
Dacey Mormonet or Beric Dondarrion with no kiss tokens), their strength
wouldn't be displayed by the client. This is because the client was
checking the numerical printed value of strength against the current
strength. For X STR characters, that's 0.

By sending 'X' STR to the client directly instead of 0, the client can
decide whether it should display a 0 STR value.

Suggested in #2216 
![screen shot 2018-09-20 at 1 58 53 pm](https://user-images.githubusercontent.com/145077/45846977-3f908e80-bcde-11e8-9dac-b83296e68c7c.png)