### PR TITLE
Display newest out-of-game card first

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1291,7 +1291,7 @@ class Player extends Spectator {
                 deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
                 discardPile: this.getSummaryForCardList(fullDiscardPile, activePlayer).reverse(),
                 hand: this.getSummaryForCardList(this.hand, activePlayer),
-                outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer),
+                outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer).reverse(),
                 plotDeck: plots,
                 plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
                 shadows: this.getSummaryForCardList(this.shadows, activePlayer)


### PR DESCRIPTION
Reverses the order of the out-of-game pile so that the last card added
to the pile displays first, as with the discard and dead piles.

Fixes #2230 