### PR TITLE
Anonymous spectators are spectators

### DIFF
--- a/server/game/anonymousspectator.js
+++ b/server/game/anonymousspectator.js
@@ -9,6 +9,10 @@ class AnonymousSpectator {
     getCardSelectionState() {
         return {};
     }
+
+    isSpectator() {
+        return true;
+    }
 }
 
 module.exports = AnonymousSpectator;


### PR DESCRIPTION
When an error occurs, the current game state is serialized for the error
report as if an anonymous spectator were watching the game. However, the
spectator detection changed in #2228 was not applied to the
AnonymousSpectator class, causing a crash when an error report would
occur.

Fixes THRONETEKI-2BB
Fixes THRONETEKI-2BC