### PR TITLE
Ambush("-") should translate to Ambush(0)

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -505,11 +505,11 @@ const Effects = {
     gainAmbush: function(costModifier = 0) {
         return {
             apply: function(card) {
-                let keyword = `Ambush (${card.getPrintedCost() + costModifier})`;
+                let keyword = `Ambush (${card.translateXValue(card.getPrintedCost()) + costModifier})`;
                 card.addKeyword(keyword);
             },
             unapply: function(card) {
-                let keyword = `Ambush (${card.getPrintedCost() + costModifier})`;
+                let keyword = `Ambush (${card.translateXValue(card.getPrintedCost()) + costModifier})`;
                 card.removeKeyword(keyword);
             }
         };


### PR DESCRIPTION
Fixes a bug where A Pinch of Powder could not use the Ambush keyword granted by Raider from Pyke.

Fixes #2267.