### PR TITLE
Warn when a player takes an action out of turn

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -779,7 +779,10 @@ class Game extends EventEmitter {
 
     markActionAsTaken(context) {
         if(this.currentActionWindow) {
-            this.currentActionWindow.markActionAsTaken();
+            if(this.currentActionWindow.currentPlayer !== context.player) {
+                this.addAlert('danger', '{0} uses {1} during {2}\'s turn in the action window', context.player, context.source, this.currentActionWindow.currentPlayer);
+            }
+            this.currentActionWindow.markActionAsTaken(context.player);
         } else if(this.currentPhase !== 'marshal' || this.hasOpenInterruptOrReactionWindow()) {
             this.addAlert('danger', '{0} uses {1} outside of an action window', context.player, context.source);
         }

--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -44,8 +44,8 @@ class ActionWindow extends PlayerOrderPrompt {
         return true;
     }
 
-    markActionAsTaken() {
-        this.setPlayers(this.rotatedPlayerOrder(this.currentPlayer));
+    markActionAsTaken(player) {
+        this.setPlayers(this.rotatedPlayerOrder(player));
         this.forceWindow = true;
     }
 

--- a/test/server/gamesteps/actionwindow.spec.js
+++ b/test/server/gamesteps/actionwindow.spec.js
@@ -51,7 +51,7 @@ describe('ActionWindow', function() {
                 this.prompt.onMenuCommand(this.player2);
 
                 // Player 1 takes an action
-                this.prompt.markActionAsTaken();
+                this.prompt.markActionAsTaken(this.player1);
             });
 
             it('should rotate the current player', function() {
@@ -70,6 +70,20 @@ describe('ActionWindow', function() {
                 this.prompt.onMenuCommand(this.player1);
 
                 expect(this.prompt.isComplete()).toBe(true);
+            });
+        });
+
+        describe('when someone other than the current player takes an action', function() {
+            beforeEach(function() {
+                // Player 2 is first player, so player 1 takes their action out
+                // of turn.
+                this.prompt.markActionAsTaken(this.player1);
+            });
+
+            it('should rotate the current player', function() {
+                // Since player 1 took their action out of turn, player 2 should
+                // be prompted again for their action.
+                expect(this.prompt.currentPlayer).toBe(this.player2);
             });
         });
     });


### PR DESCRIPTION
Previously, a warning message was added when a player takes an action
outside of a legal action window. However, while an action window was
open, each player could take actions no matter whose turn it was to take
an action.

Now, players can still take an action outside of their turn during an
action window, but it will add a warning message to the chat log
reminding the player that it was out of turn. This will keep play
unrestrictive while also making clear a game rule has been violated.

Fixes #2260 