### PR TITLE
Apply out-of-shadows reducers to event cards

### DIFF
--- a/server/game/costreducer.js
+++ b/server/game/costreducer.js
@@ -33,6 +33,10 @@ class CostReducer {
             return false;
         }
 
+        if(playingType === 'play' && this.playingTypes.includes('outOfShadows') && card.location === 'shadows') {
+            return !!this.match(card);
+        }
+
         return this.playingTypes.includes(playingType) && !!this.match(card);
     }
 

--- a/test/server/costreducer.spec.js
+++ b/test/server/costreducer.spec.js
@@ -85,6 +85,19 @@ describe('CostReducer', function () {
                 expect(this.reducer.canReduce('marshal', this.card)).toBe(false);
             });
         });
+
+        describe('when reducing out of shadows and playing an event out of shadow', function() {
+            beforeEach(function() {
+                this.reducer = new CostReducer(this.gameSpy, this.source, {
+                    playingTypes: 'outOfShadows'
+                });
+                this.card.location = 'shadows';
+            });
+
+            it('should return true', function() {
+                expect(this.reducer.canReduce('play', this.card)).toBe(true);
+            });
+        });
     });
 
     describe('markUsed()', function() {


### PR DESCRIPTION
Playing event cards always uses the 'play' playing type. However, cards
like Hizdahr zo Loraq that reduce bringing cards out-of-shadow are
defined with the 'outOfShadows' playing type. Therefore the
'outOfShadows' reduction should be applied to playing event cards that
are currently in shadows.

Fixes #2224 