### PR TITLE
Implement /cancel-challenge

### DIFF
--- a/server/game/AllowedChallenge.js
+++ b/server/game/AllowedChallenge.js
@@ -5,6 +5,16 @@ class AllowedChallenge {
         this.used = false;
     }
 
+    markUsed(challenge) {
+        this.challenge = challenge;
+        this.used = true;
+    }
+
+    resetUsage() {
+        this.challenge = null;
+        this.used = false;
+    }
+
     isMatch(challengeType, opponent) {
         return !this.used && this.challengeType === challengeType && this.opponentFunc(opponent);
     }

--- a/server/game/challengetracker.js
+++ b/server/game/challengetracker.js
@@ -38,14 +38,23 @@ class ChallengeTracker {
     useAllowedChallenge(challenge) {
         let allowedChallenge = this.allowedChallenges.find(allowedChallenge => allowedChallenge.isMatch(challenge.challengeType, challenge.defendingPlayer));
         if(allowedChallenge) {
-            allowedChallenge.used = true;
+            allowedChallenge.markUsed(challenge);
+        }
+    }
+
+    untrack(challenge) {
+        this.challenges = this.challenges.filter(c => c !== challenge);
+
+        let allowedChallenge = this.allowedChallenges.find(allowedChallenge => allowedChallenge.challenge === challenge && allowedChallenge.used);
+        if(allowedChallenge) {
+            allowedChallenge.resetUsage();
         }
     }
 
     reset() {
         this.challenges = [];
         for(let allowedChallenge of this.allowedChallenges) {
-            allowedChallenge.used = false;
+            allowedChallenge.resetUsage();
         }
     }
 

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -1,5 +1,6 @@
 const _ = require('underscore');
 const TextHelper = require('./TextHelper');
+const CancelChallengePrompt = require('./gamesteps/CancelChallengePrompt');
 
 class ChatCommands {
     constructor(game) {
@@ -12,6 +13,7 @@ class ChatCommands {
             '/bestow': this.bestow,
             '/blank': this.blank,
             '/cancel-prompt': this.cancelPrompt,
+            '/cancel-challenge': this.cancelChallenge,
             '/discard': this.discard,
             '/disconnectme': this.disconnectMe,
             '/draw': this.draw,
@@ -309,6 +311,15 @@ class ChatCommands {
         this.game.addAlert('danger', '{0} uses the /cancel-prompt to skip the current step.', player);
         this.game.pipeline.cancelStep();
         this.game.cancelPromptUsed = true;
+    }
+
+    cancelChallenge(player) {
+        if(!this.game.isDuringChallenge()) {
+            return;
+        }
+
+        this.game.addAlert('danger', '{0} uses /cancel-challenge to attempt to cancel the current challenge', player);
+        this.game.queueStep(new CancelChallengePrompt(this.game, player));
     }
 
     setToken(player, args) {

--- a/server/game/gamepipeline.js
+++ b/server/game/gamepipeline.js
@@ -43,6 +43,12 @@ class GamePipeline {
         }
     }
 
+    clear() {
+        this.cancelStep();
+        this.pipeline = [];
+        this.queue = [];
+    }
+
     cancelStep() {
         if(this.pipeline.length === 0) {
             return;

--- a/server/game/gamesteps/CancelChallengePrompt.js
+++ b/server/game/gamesteps/CancelChallengePrompt.js
@@ -1,0 +1,58 @@
+const AllPlayerPrompt = require('./allplayerprompt');
+
+class CancelChallengePrompt extends AllPlayerPrompt {
+    constructor(game, requestingPlayer) {
+        super(game);
+
+        this.challenge = game.currentChallenge;
+        this.requestingPlayer = requestingPlayer;
+        this.completedPlayers = new Set([requestingPlayer]);
+        this.cancelled = !this.challenge;
+    }
+
+    completionCondition(player) {
+        return this.cancelled || this.completedPlayers.has(player);
+    }
+
+    activePrompt() {
+        return {
+            menuTitle: `${this.requestingPlayer.name} requests to cancel the current challenge. Allow cancellation?`,
+            buttons: [
+                { arg: 'yes', text: 'Yes' },
+                { arg: 'no', text: 'No' }
+            ]
+        };
+    }
+
+    waitingPrompt() {
+        return {
+            menuTitle: 'Waiting for opponents to approve cancellation'
+        };
+    }
+
+    onMenuCommand(player, arg) {
+        if(arg === 'yes') {
+            this.game.addAlert('info', '{0} allows cancelling the current challenge', player);
+            this.completedPlayers.add(player);
+        } else {
+            this.game.addAlert('info', '{0} disallows cancelling the current challenge', player);
+            this.cancelled = true;
+        }
+
+        return true;
+    }
+
+    onCompleted() {
+        if(this.cancelled) {
+            return;
+        }
+
+        this.game.addAlert('danger', '{0} cancels the current challenge. Manually stand any knelt characters and work around any abilities already used', this.requestingPlayer);
+        for(let player of this.game.getPlayers()) {
+            player.untrackChallenge(this.challenge);
+        }
+        this.game.currentChallengeStep.cancelChallengeResolution();
+    }
+}
+
+module.exports = CancelChallengePrompt;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -334,6 +334,11 @@ class ChallengeFlow extends BaseStep {
     continue() {
         return this.challenge.cancelled || this.pipeline.continue();
     }
+
+    cancelChallengeResolution() {
+        this.challenge.cancelChallenge();
+        this.pipeline.clear();
+    }
 }
 
 module.exports = ChallengeFlow;

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -90,7 +90,8 @@ class ChallengePhase extends Phase {
             number: attackingPlayer.getNumberOfChallengesInitiated() + 1
         });
         this.game.currentChallenge = challenge;
-        this.game.queueStep(new ChallengeFlow(this.game, challenge));
+        this.game.currentChallengeStep = new ChallengeFlow(this.game, challenge);
+        this.game.queueStep(this.game.currentChallengeStep);
         this.game.queueSimpleStep(() => this.cleanupChallenge());
         this.game.queueSimpleStep(() => this.promptForChallenge());
     }
@@ -101,6 +102,7 @@ class ChallengePhase extends Phase {
         challenge.finish();
         challenge.unregisterEvents();
         this.game.currentChallenge = null;
+        this.game.currentChallengeStep = null;
         this.game.raiseEvent('onChallengeFinished', { challenge: challenge });
     }
 

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -51,6 +51,7 @@ class UiPrompt extends BaseStep {
 
         if(completed) {
             this.clearPrompts();
+            this.onCompleted();
         } else {
             this.setPrompt();
         }
@@ -62,6 +63,12 @@ class UiPrompt extends BaseStep {
         _.each(this.game.getPlayers(), player => {
             player.cancelPrompt();
         });
+    }
+
+    /**
+     * Handler that will be called once isComplete() returns true.
+     */
+    onCompleted() {
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -877,6 +877,10 @@ class Player extends Spectator {
         this.challenges.track(challenge);
     }
 
+    untrackChallenge(challenge) {
+        this.challenges.untrack(challenge);
+    }
+
     getParticipatedChallenges() {
         return this.challenges.getChallenges();
     }


### PR DESCRIPTION
Allows players to cancel the current challenge using the /cancel-challenge chat command. Each opponent is prompted on whether they want to allow the challenge to be cancelled:
![screen shot 2018-10-12 at 12 32 29 pm](https://user-images.githubusercontent.com/145077/46890784-c12a9680-ce1c-11e8-85a0-38d2abb2eca0.png)

If a single opponent clicks "No", the challenge will continue as normal from whatever step it was on.

If all opponents click "Yes", the challenge will be cancelled and untracked by the engine, allowing the player to re-initiate that challenge type with no consequences. **Character kneels and any abilities used are not undone currently, so players will need to re-stand and work around abilities used manually.**

Fixes #2165 