### PR TITLE
Prompt all players for actions when setting is on

### DIFF
--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -30,8 +30,8 @@ class ActionWindow extends PlayerOrderPrompt {
         };
     }
 
-    skipCondition(player) {
-        return !this.forceWindow && !player.promptedActionWindows[this.windowName];
+    skipCondition() {
+        return this.game.getPlayersInFirstPlayerOrder().every(player => !player.promptedActionWindows[this.windowName]);
     }
 
     onMenuCommand(player) {
@@ -46,7 +46,6 @@ class ActionWindow extends PlayerOrderPrompt {
 
     markActionAsTaken(player) {
         this.setPlayers(this.rotatedPlayerOrder(player));
-        this.forceWindow = true;
     }
 
     rotatedPlayerOrder(player) {

--- a/test/server/cards/04.5-GoH/Craster.spec.js
+++ b/test/server/cards/04.5-GoH/Craster.spec.js
@@ -60,7 +60,7 @@ describe('Craster', function() {
             describe('when sacrificing Craster in the following phase', function() {
                 beforeEach(function() {
                     // Clear plot phase by passing on the action window.
-                    this.player1.clickPrompt('Pass');
+                    this.skipActionWindow();
 
                     this.player1.clickMenu(this.craster, 'Sacrifice to resurrect');
                 });

--- a/test/server/gamesteps/actionwindow.spec.js
+++ b/test/server/gamesteps/actionwindow.spec.js
@@ -109,5 +109,33 @@ describe('ActionWindow', function() {
                 expect(this.prompt.continue()).toBe(true);
             });
         });
+
+        describe('when only the second player has the window enabled', function() {
+            beforeEach(function() {
+                this.player1.promptedActionWindows['test'] = true;
+                this.player2.promptedActionWindows['test'] = false;
+            });
+
+            it('should prompt the first player even though the window is off', function() {
+                this.prompt.continue();
+
+                expect(this.prompt.currentPlayer).toBe(this.player2);
+            });
+
+            it('should not complete the prompt', function() {
+                expect(this.prompt.continue()).toBe(false);
+            });
+        });
+
+        describe('when both players have the window disabled', function() {
+            beforeEach(function() {
+                this.player1.promptedActionWindows['test'] = false;
+                this.player2.promptedActionWindows['test'] = false;
+            });
+
+            it('should complete the prompt', function() {
+                expect(this.prompt.continue()).toBe(true);
+            });
+        });
     });
 });

--- a/test/server/gamesteps/dominancephase.spec.js
+++ b/test/server/gamesteps/dominancephase.spec.js
@@ -1,6 +1,7 @@
 const DominancePhase = require('../../../server/game/gamesteps/dominancephase.js');
 const Game = require('../../../server/game/game.js');
 const Player = require('../../../server/game/player.js');
+const Settings = require('../../../server/settings.js');
 
 describe('the DominancePhase', () => {
     var phase;
@@ -11,8 +12,8 @@ describe('the DominancePhase', () => {
     beforeEach(() => {
         let gameService = jasmine.createSpyObj('gameService', ['save']);
         game = new Game({ owner: {} }, { gameService: gameService });
-        player1 = new Player('1', { username: 'Player 1', settings: {} }, true, game);
-        player2 = new Player('2', { username: 'Player 2', settings: {} }, false, game);
+        player1 = new Player('1', Settings.getUserWithDefaultsSet({ username: 'Player 1' }), true, game);
+        player2 = new Player('2', Settings.getUserWithDefaultsSet({ username: 'Player 2' }), false, game);
         player2.firstPlayer = true;
         game.playersAndSpectators['Player 1'] = player1;
         game.playersAndSpectators['Player 2'] = player2;


### PR DESCRIPTION
Previously, when a single player had an action window setting turned on,
only the player with the setting turned on would be prompted. Any player
without the setting turned on would auto-pass when it was their turn in
the action window, unless another player had actually taken an action.

This could lead to confusion for players that do not understand that
they will auto-pass without the option turned on. A typical scenario
would be first player has the window off, and thus auto-passes. Then,
the second player has the window on, and uses an action. Then, the first
player, not realizing they auto-passed, complains that they should have
had the first opportunity to use an action.

To alleviate this confusion, auto-pass has been removed unless all
players have the action window turned off. If any player has the setting
turned on, each player will be prompted in first-player order, even if
they personally have the setting turned off.