### PR TITLE
Implement Nightfort Builder - Night's Watch card from Daggers in the …

### DIFF
--- a/server/game/cards/11.6-DitD/NightfortBuilder.js
+++ b/server/game/cards/11.6-DitD/NightfortBuilder.js
@@ -1,0 +1,28 @@
+const DrawCard = require('../../drawcard.js');
+
+class NightfortBuilder extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardKneeled: event => event.card === this
+            },
+            handler: () => {
+                let topCard = this.controller.drawDeck[0];
+                let message = '{0} uses {1} to reveal {2} as the top card of their deck';
+
+                if(this.controller.canDraw() && 
+                   ((topCard.isFaction('thenightswatch') && topCard.getType() === 'attachment') ||
+                    (topCard.isFaction('thenightswatch') && topCard.getType() === 'location'))) {
+                    this.controller.drawCardsToHand(1);
+                    message += ' and draw it';
+                }
+
+                this.game.addMessage(message, this.controller, this, topCard);
+            }
+        });
+    }
+}
+
+NightfortBuilder.code = '11105';
+
+module.exports = NightfortBuilder;


### PR DESCRIPTION
…Dark 

Nightfort Builder; 2 cost; non-unique; loyal; Builder; Power;
Reaction: After Nightfort Builder is knelt reveal top card of your deck. If it's Night's Watch location or attachment draw it.