### PR TITLE
Starfall Spy: do not allow to select itself

### DIFF
--- a/server/game/cards/11.6-DitD/StarfallSpy.js
+++ b/server/game/cards/11.6-DitD/StarfallSpy.js
@@ -9,7 +9,7 @@ class StarfallSpy extends DrawCard {
             cost: ability.costs.putSelfIntoShadows(),
             target: {
                 activePromptTitle: 'Select a card',
-                cardCondition: card => card.controller === this.controller && card.location === 'shadows' && this.controller.canPutIntoPlay(card)
+                cardCondition: card => card.controller === this.controller && card !== this && card.location === 'shadows' && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.game.addMessage('{0} returns {1} to shadows to put {2} into play', context.player, this, context.target);


### PR DESCRIPTION
Rationale: "to choose *another* card you control in shadows"