### PR TITLE
Don't reveal Assault from the Shadows card

### DIFF
--- a/server/game/cards/11.6-DitD/AssaultFromTheShadows.js
+++ b/server/game/cards/11.6-DitD/AssaultFromTheShadows.js
@@ -14,7 +14,11 @@ class AssaultFromTheShadows extends AgendaCard {
             cost: ability.costs.kneelFactionCard(),
             target: {
                 activePromptTitle: 'Select a card',
-                cardCondition: card => card.location === 'hand' && card.controller === this.controller
+                cardCondition: card => card.location === 'hand' && card.controller === this.controller,
+                // Even though the card text uses the word 'choose', use a non
+                // targeting prompt to prevent the card from being revealed
+                // when the opponent is prompted to cancel the ability.
+                type: 'select'
             },
             handler: context => {
                 this.game.addMessage('{0} uses {1} and kneels their faction card to put a card into shadow', context.player, this);


### PR DESCRIPTION
When a player had the ability cancellation option turned on and their
opponent used Assault from the Shadows to put a card into shadows, that
card was displayed on the prompt. This is because the prompt displays
any targets for the ability regardless of visibility. Most of the time
this is useful because the card must be revealed even while still in
hand to verify it meets the requirements for the ability (e.g. Core
Arianne Martell). In the case of Assault from the Shadows, there are no
characteristic requirements that need to be verified and thus the card
should not be revealed.

Thus, even though Assault from the Shadows uses the word "choose" and
thus the card should be considered a target, the implementation has been
changed to a non-targeting effect. This should prevent the card from
being revealed when the opponent is prompted to cancel and should have
minimal side effects regarding targeting.