### PR TITLE
Update lint rules about block spacing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,13 @@
 {
   "extends": "eslint:recommended",
   "rules": {
+    "arrow-spacing": [
+      "error",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
     "indent": [
       2,
       4,
@@ -111,6 +118,11 @@
           }
         }
       }
+    ],
+    "padded-blocks": ["error", "never"],
+    "padding-line-between-statements": [
+      "error",
+      { "blankLine": "always", "prev": "*", "next": "cjs-export" }
     ]
   },
   "env": {

--- a/server/game/AttachmentValidityCheck.js
+++ b/server/game/AttachmentValidityCheck.js
@@ -22,7 +22,6 @@ class AttachmentValidityCheck {
                     this.game.addMessage('{0} is forced to discard {1} due to being invalidly attached', owner, discarded);
                 });
             }
-
         });
         this.game.queueSimpleStep(() => {
             this.beingDiscarded = _.difference(this.beingDiscarded, needsDiscard);

--- a/server/game/cards/01-Core/Rebuilding.js
+++ b/server/game/cards/01-Core/Rebuilding.js
@@ -11,7 +11,6 @@ class Rebuilding extends PlotCard {
             handler: context => {
                 for(let card of context.target) {
                     this.controller.moveCard(card, 'draw deck');
-
                 }
 
                 this.controller.shuffleDrawDeck();

--- a/server/game/cards/01-Core/TheKnightOfFlowers.js
+++ b/server/game/cards/01-Core/TheKnightOfFlowers.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class TheKnightOfFlowers extends DrawCard {
-
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.isDuringChallenge({ attackingAlone: this }),
@@ -9,7 +8,6 @@ class TheKnightOfFlowers extends DrawCard {
             effect: ability.effects.setDefenderMaximum(1)
         });
     }
-
 }
 
 TheKnightOfFlowers.code = '01185';

--- a/server/game/cards/01-Core/WakingTheDragon.js
+++ b/server/game/cards/01-Core/WakingTheDragon.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class WakingTheDragon extends DrawCard {
-
     setupCardAbilities() {
         this.action({
             title: 'Stand a character',
@@ -27,7 +26,6 @@ class WakingTheDragon extends DrawCard {
             }
         });
     }
-
 }
 
 WakingTheDragon.code = '01178';

--- a/server/game/cards/02.1-TtB/Lady.js
+++ b/server/game/cards/02.1-TtB/Lady.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class Lady extends DrawCard {
-
     setupCardAbilities(ability) {
         this.attachmentRestriction({ faction: 'stark' });
         this.whileAttached({

--- a/server/game/cards/02.1-TtB/StreetOfTheSisters.js
+++ b/server/game/cards/02.1-TtB/StreetOfTheSisters.js
@@ -18,7 +18,6 @@ class StreetOfTheSisters extends DrawCard {
             }
         });
     }
-
 }
 
 StreetOfTheSisters.code = '02018';

--- a/server/game/cards/02.1-TtB/TheWatchHasNeed.js
+++ b/server/game/cards/02.1-TtB/TheWatchHasNeed.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class TheWatchHasNeed extends DrawCard {
-
     setupCardAbilities() {
         this.action({
             title: 'Search for a character',

--- a/server/game/cards/02.3-TKP/CroneOfVaesDothrak.js
+++ b/server/game/cards/02.3-TKP/CroneOfVaesDothrak.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class CroneOfVaesDothrak extends DrawCard {
-
     setupCardAbilities(ability) {
         this.reaction({
             when: {

--- a/server/game/cards/02.5-COW/TheEyrie.js
+++ b/server/game/cards/02.5-COW/TheEyrie.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class TheEyrie extends DrawCard {
-
     setupCardAbilities(ability) {
         this.reaction({
             when: {

--- a/server/game/cards/02.6-TS/CityWatch.js
+++ b/server/game/cards/02.6-TS/CityWatch.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class CityWatch extends DrawCard {
-
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
@@ -15,7 +14,6 @@ class CityWatch extends DrawCard {
         let opponents = this.game.getOpponents(this.controller);
         return opponents.some(opponent => this.controller.faction.power > opponent.faction.power);
     }
-
 }
 
 CityWatch.code = '02108';

--- a/server/game/cards/03-WotN/AryasGift.js
+++ b/server/game/cards/03-WotN/AryasGift.js
@@ -20,7 +20,6 @@ class AryasGift extends DrawCard {
                         card !== oldParent && this.controller.canAttach(attachment, card) && card.location === 'play area',
                     onSelect: (player, card) => this.moveAttachment(player, card, attachment, oldParent)
                 });
-
             }
         });
     }

--- a/server/game/cards/03-WotN/Nymeria.js
+++ b/server/game/cards/03-WotN/Nymeria.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class Nymeria extends DrawCard {
-
     setupCardAbilities(ability) {
         this.attachmentRestriction({ faction: 'stark', unique: true });
         this.whileAttached({

--- a/server/game/cards/03-WotN/Stonesnake.js
+++ b/server/game/cards/03-WotN/Stonesnake.js
@@ -28,7 +28,6 @@ class Stonesnake extends DrawCard {
                     },
                     source: this
                 });
-
             }
         });
     }

--- a/server/game/cards/04.3-FFH/BattleOfOxcross.js
+++ b/server/game/cards/04.3-FFH/BattleOfOxcross.js
@@ -1,7 +1,6 @@
 const PlotCard = require('../../plotcard.js');
 
 class BattleOfOxcross extends PlotCard {
-
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.isDuringChallenge({ attackingPlayer: this.controller, number: 1 }),
@@ -12,7 +11,6 @@ class BattleOfOxcross extends PlotCard {
             effect: ability.effects.cannotBeDeclaredAsDefender()
         });
     }
-
 }
 
 BattleOfOxcross.code = '04060';

--- a/server/game/cards/04.3-FFH/CrownOfGoldenRoses.js
+++ b/server/game/cards/04.3-FFH/CrownOfGoldenRoses.js
@@ -25,7 +25,6 @@ class CrownOfGoldenRoses extends DrawCard {
                     this.controller, this, context.costs.discardFromHand, strBoost, this.parent);
             }
         });
-
     }
 }
 

--- a/server/game/cards/04.3-FFH/NightGathers.js
+++ b/server/game/cards/04.3-FFH/NightGathers.js
@@ -15,7 +15,6 @@ class NightGathers extends DrawCard {
                         card.location === 'discard pile' &&
                         card.getType() === 'character')
                 }));
-
             }
         });
     }

--- a/server/game/cards/04.4-TIMC/AeronDamphair.js
+++ b/server/game/cards/04.4-TIMC/AeronDamphair.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class AeronDamphair extends DrawCard {
-
     setupCardAbilities() {
         this.reaction({
             when: {
@@ -19,7 +18,6 @@ class AeronDamphair extends DrawCard {
             }
         });
     }
-
 }
 
 AeronDamphair.code = '04071';

--- a/server/game/cards/04.4-TIMC/KingRenlySHost.js
+++ b/server/game/cards/04.4-TIMC/KingRenlySHost.js
@@ -3,7 +3,6 @@ const _ = require('underscore');
 const DrawCard = require('../../drawcard.js');
 
 class KingRenlySHost extends DrawCard {
-
     setupCardAbilities(ability) {
         this.persistentEffect({ // STR increase while Summer
             condition: () => this.anyPlotHasTrait('Summer'),
@@ -22,7 +21,6 @@ class KingRenlySHost extends DrawCard {
             player.activePlot
                      && player.activePlot.hasTrait(trait));
     }
-
 }
 
 KingRenlySHost.code = '04063';

--- a/server/game/cards/04.5-GoH/GhostsOfHarrenhal.js
+++ b/server/game/cards/04.5-GoH/GhostsOfHarrenhal.js
@@ -3,7 +3,6 @@ const _ = require('underscore');
 const PlotCard = require('../../plotcard.js');
 
 class GhostsOfHarrenhal extends PlotCard {
-
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
@@ -20,7 +19,6 @@ class GhostsOfHarrenhal extends PlotCard {
             }
         });
     }
-
 }
 
 GhostsOfHarrenhal.code = '04100';

--- a/server/game/cards/04.6-TC/QuaitheOfTheShadow.js
+++ b/server/game/cards/04.6-TC/QuaitheOfTheShadow.js
@@ -24,7 +24,6 @@ class QuaitheOfTheShadow extends DrawCard {
             }
         });
     }
-
 }
 
 QuaitheOfTheShadow.code = '04113';

--- a/server/game/cards/05-LoCR/EdricStorm.js
+++ b/server/game/cards/05-LoCR/EdricStorm.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class EdricStorm extends DrawCard {
-
     setupCardAbilities() {
         this.reaction({
             when: {

--- a/server/game/cards/05-LoCR/JeyneWesterling.js
+++ b/server/game/cards/05-LoCR/JeyneWesterling.js
@@ -13,7 +13,6 @@ class JeyneWesterling extends DrawCard {
             handler: context => {
                 context.target.controller.standCard(context.target);
                 this.game.addMessage('{0} kneels {1} to stand {2}', this.controller, this, context.target);
-
             }
         });
     }

--- a/server/game/cards/05-LoCR/SerLancelLannister.js
+++ b/server/game/cards/05-LoCR/SerLancelLannister.js
@@ -20,7 +20,6 @@ class SerLancelLannister extends DrawCard {
 
         return;
     }
-
 }
 
 SerLancelLannister.code = '05014';

--- a/server/game/cards/06.1-AMAF/AttackFromTheMountains.js
+++ b/server/game/cards/06.1-AMAF/AttackFromTheMountains.js
@@ -18,7 +18,6 @@ class AttackFromTheMountains extends DrawCard {
                 context.target.owner.putIntoPlay(context.target);
                 this.game.addMessage('{0} plays {1} to put {2} into play from their hand',
                     this.controller, this, context.target);
-
             }
         });
     }

--- a/server/game/cards/07-WotW/GrizzledMiner.js
+++ b/server/game/cards/07-WotW/GrizzledMiner.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 
 class GrizzledMiner extends DrawCard {
-
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
@@ -20,7 +19,6 @@ class GrizzledMiner extends DrawCard {
 
         return cards.length;
     }
-
 }
 
 GrizzledMiner.code = '07006';

--- a/server/game/cards/07-WotW/RaidingTheBayOfIce.js
+++ b/server/game/cards/07-WotW/RaidingTheBayOfIce.js
@@ -19,7 +19,6 @@ class RaidingTheBayOfIce extends DrawCard {
                 context.target.owner.moveCardToTopOfDeck(context.target);
                 this.game.addMessage('{0} plays {1} to move {2} to the top of {3}\'s deck',
                     this.controller, this, context.target, context.target.owner);
-
             }
         });
     }

--- a/server/game/cards/08.2-JtO/Kingslayer.js
+++ b/server/game/cards/08.2-JtO/Kingslayer.js
@@ -16,7 +16,6 @@ class Kingslayer extends DrawCard {
                 this.game.killCharacter(context.target);
                 this.game.addMessage('{0} uses {1} and kneels {2} to kill {3}',
                     context.player, this, this.parent, context.target);
-
             }
         });
 

--- a/server/game/cards/08.5-TFM/TheFaithMilitant.js
+++ b/server/game/cards/08.5-TFM/TheFaithMilitant.js
@@ -2,7 +2,6 @@ const AgendaCard = require('../../agendacard.js');
 
 class TheFaithMilitant extends AgendaCard {
     setupCardAbilities(ability) {
-
         this.persistentEffect({
             match: card =>
                 !card.hasTrait('The Seven') &&
@@ -34,7 +33,6 @@ class TheFaithMilitant extends AgendaCard {
                     this.controller, this, otherPlayer, context.target);
             }
         });
-
     }
 }
 

--- a/server/game/cards/09-HoT/TheKnightOfFlowers.js
+++ b/server/game/cards/09-HoT/TheKnightOfFlowers.js
@@ -8,7 +8,7 @@ class TheKnightOfFlowers extends DrawCard {
             },
             handler: () => {
                 this.game.addMessage('{0} uses {1} to gain +2 STR until the end of the phase', this.controller, this);
-                this.untilEndOfPhase(ability =>({
+                this.untilEndOfPhase(ability => ({
                     match: this,
                     effect: ability.effects.modifyStrength(2)
                 }));

--- a/server/game/cards/09-HoT/TheSpidersWeb.js
+++ b/server/game/cards/09-HoT/TheSpidersWeb.js
@@ -13,7 +13,7 @@ class TheSpidersWeb extends PlotCard {
                     targetController: 'current',
                     effect: ability.effects.mayInitiateAdditionalChallenge('intrigue')
                 }));
-                this.untilEndOfPhase(ability =>({
+                this.untilEndOfPhase(ability => ({
                     condition: () => this.game.isDuringChallenge({ challengeType: 'intrigue' }),
                     match: card => card === this.controller.activePlot,
                     effect: ability.effects.modifyClaim(1)

--- a/server/game/cards/10-SoD/ForcedMarch.js
+++ b/server/game/cards/10-SoD/ForcedMarch.js
@@ -76,7 +76,6 @@ class ForcedMarch extends PlotCard {
     filterForOpponents() {
         return _.filter(this.game.getPlayers(), player => player !== this.controller &&
                                                           this.hasStandingMilIcon(player));
-
     }
 
     hasStandingMilIcon(player) {

--- a/server/game/cards/10-SoD/OldtownScholar.js
+++ b/server/game/cards/10-SoD/OldtownScholar.js
@@ -14,7 +14,6 @@ class OldtownScholar extends DrawCard {
                 let drawn = context.player.drawCardsToHand(numToDraw);
                 this.game.addMessage('{0} kneels {1} to draw {2}',
                     context.player, this, TextHelper.count(drawn.length, 'card'));
-
             }
         });
     }

--- a/server/game/cards/11.3-SoKL/Dragonbinder.js
+++ b/server/game/cards/11.3-SoKL/Dragonbinder.js
@@ -76,7 +76,6 @@ class Dragonbinder extends DrawCard {
         player.putIntoPlay(card);
         this.game.addMessage('{0} uses {1} and kills {2} to search their deck and put {3} into play',
             player, this, this.costCard, card);
-
     }
 
     onGJCanceled(player) {

--- a/server/game/cards/11.4-MoD/ShireenBaratheon.js
+++ b/server/game/cards/11.4-MoD/ShireenBaratheon.js
@@ -10,7 +10,7 @@ class ShireenBaratheon extends DrawCard {
             },
             handler: context => {
                 this.game.addMessage('{0} uses {1} to have {1} and {2} not contribute STR to the challenge', this.controller, this, context.target);
-                this.untilEndOfChallenge(ability =>({
+                this.untilEndOfChallenge(ability => ({
                     match: card => [this, context.target].includes(card),
                     targetController: 'any',
                     effect: ability.effects.doesNotContributeStrength()

--- a/server/game/cards/11.5-IDP/IronVictorysCrew.js
+++ b/server/game/cards/11.5-IDP/IronVictorysCrew.js
@@ -26,7 +26,6 @@ class IronVictorysCrew extends DrawCard {
             this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand', player, this, card);
             player.moveCard(card, 'hand');
         }
-
     }
 
     doneSelecting(player) {

--- a/server/game/cards/12-KotI/GreatWyk.js
+++ b/server/game/cards/12-KotI/GreatWyk.js
@@ -4,7 +4,7 @@ class GreatWyk extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction ({
             when: {
-                onCardEntersPlay: event=>(
+                onCardEntersPlay: event => (
                     event.card.getType() === 'character' &&
                     event.card.controller === this.controller &&
                     event.originalLocation === 'dead pile'
@@ -12,7 +12,6 @@ class GreatWyk extends DrawCard {
             },
             limit: ability.limit.perPhase(1),
             handler: () => {
-                 
                 for(let opponent of this.game.getOpponents(this.controller)) {
                     if(opponent.hand.length > 0) {
                         this.game.promptForSelect(opponent, {
@@ -27,7 +26,6 @@ class GreatWyk extends DrawCard {
                 }        
             }
         });
-
     }
 
     onSelectCard(player,card) {
@@ -39,11 +37,10 @@ class GreatWyk extends DrawCard {
         player.discardCard(card);
         this.game.addMessage('{0} chooses {1} for {2}', player, card, this);
         return true;
-
     }
-
 }
 
 GreatWyk.code = '12017';
+
 module.exports = GreatWyk;
     

--- a/server/game/cards/12-KotI/WhenIWoke.js
+++ b/server/game/cards/12-KotI/WhenIWoke.js
@@ -8,7 +8,6 @@ class WhenIWoke extends DrawCard {
             },
             max: ability.limit.perChallenge(1),
             handler: () => {
-                
                 var losingplayer = this.game.currentChallenge.loser;
                 this.game.promptForSelect(losingplayer, {
                     activePromptTitle: 'Select a card',
@@ -31,7 +30,6 @@ class WhenIWoke extends DrawCard {
         player.moveCardToTopOfDeck(card);
         this.game.addMessage('{0} chooses {1} for {2} ', player, card, this);
         return true;
-
     }
 }
 

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -188,7 +188,6 @@ describe('CardForcedReaction', function () {
                 handler: () => true
             };
             this.reaction = this.createReaction();
-
         });
 
         it('should unregister all previously registered when event handlers', function() {

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -310,7 +310,6 @@ describe('CardReaction', function () {
                 handler: () => true
             };
             this.reaction = this.createReaction();
-
         });
 
         it('should unregister all previously registered when event handlers', function() {

--- a/test/server/cards/04.5-GoH/Craster.spec.js
+++ b/test/server/cards/04.5-GoH/Craster.spec.js
@@ -20,7 +20,6 @@ describe('Craster', function() {
             this.character = this.player1.findCardByName('Steward at the Wall', 'hand');
 
             this.opponentCharacter = this.player2.findCardByName('Steward at the Wall', 'hand');
-
         });
 
         describe('while Craster is out when characters are killed', function() {

--- a/test/server/game/power.spec.js
+++ b/test/server/game/power.spec.js
@@ -21,7 +21,6 @@ describe('Game', function() {
             });
 
             it('should not transfer power', function() {
-
                 expect(this.target.power).toBe(1);
                 expect(this.source.power).toBe(2);
             });

--- a/test/server/gamepipeline/queuestep.spec.js
+++ b/test/server/gamepipeline/queuestep.spec.js
@@ -8,7 +8,6 @@ describe('the GamePipeline', function() {
 
     describe('the queueStep() function', function() {
         describe('when the pipeline is empty', function() {
-
             it('should add the step directly to the pipeline', function() {
                 this.pipeline.queueStep(this.step);
                 expect(this.pipeline.length).toBe(1);

--- a/test/server/gamesteps/ForcedTriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/ForcedTriggeredAbilityWindow.spec.js
@@ -49,7 +49,6 @@ describe('ForcedTriggeredAbilityWindow', function() {
 
         spyOn(this.window, 'gatherChoices');
         spyOn(this.window, 'resolveAbility');
-
     });
 
     describe('continue()', function() {

--- a/test/server/integration/pillage.spec.js
+++ b/test/server/integration/pillage.spec.js
@@ -50,6 +50,5 @@ describe('pillage', function() {
                 expect(this.player2Object.discardPile.length).toBe(2);
             });
         });
-
     });
 });

--- a/test/server/player/discardcards.spec.js
+++ b/test/server/player/discardcards.spec.js
@@ -1,7 +1,6 @@
 const Player = require('../../../server/game/player.js');
 
 describe('Player', function() {
-
     function createCardSpy(num) {
         let spy = jasmine.createSpyObj('card', ['moveTo', 'removeDuplicate']);
         spy.num = num;


### PR DESCRIPTION
Disallow newlines after { / before }, enforce spacing around arrow
lambdas.