### PR TITLE
Various fixes to Gold Cloaks

### DIFF
--- a/server/game/EventTrackers/CardEntersPlayTracker.js
+++ b/server/game/EventTrackers/CardEntersPlayTracker.js
@@ -1,0 +1,26 @@
+class CardEntersPlayTracker {
+    static forPhase(game) {
+        return new CardEntersPlayTracker(game, 'onPhaseEnded');
+    }
+
+    constructor(game, endingEvent) {
+        this.events = [];
+
+        game.on('onCardEntersPlay', event => this.trackEvent(event));
+        game.on(endingEvent, () => this.clearEvents());
+    }
+
+    trackEvent(event) {
+        this.events.push(event);
+    }
+
+    clearEvents() {
+        this.events = [];
+    }
+
+    hasAmbushed(card) {
+        return this.events.some(event => event.card === card && event.playingType === 'ambush');
+    }
+}
+
+module.exports = CardEntersPlayTracker;

--- a/server/game/EventTrackers/CardEntersPlayTracker.js
+++ b/server/game/EventTrackers/CardEntersPlayTracker.js
@@ -21,6 +21,10 @@ class CardEntersPlayTracker {
     hasAmbushed(card) {
         return this.events.some(event => event.card === card && event.playingType === 'ambush');
     }
+
+    hasComeOutOfShadows(card) {
+        return this.events.some(event => event.card === card && event.playingType === 'outOfShadows');
+    }
 }
 
 module.exports = CardEntersPlayTracker;

--- a/server/game/cards/01-Core/GoldCloaks.js
+++ b/server/game/cards/01-Core/GoldCloaks.js
@@ -1,10 +1,13 @@
-const DrawCard = require('../../drawcard.js');
+const DrawCard = require('../../drawcard');
+const CardEntersPlayTracker = require('../../EventTrackers/CardEntersPlayTracker');
 
 class GoldCloaks extends DrawCard {
     setupCardAbilities() {
+        this.tracker = CardEntersPlayTracker.forPhase(this.game);
+
         this.forcedInterrupt({
             when: {
-                onPhaseEnded: () => this.wasAmbush
+                onPhaseEnded: () => this.tracker.hasAmbushed(this)
             },
             handler: () => {
                 this.controller.discardCard(this);

--- a/server/game/cards/01-Core/GoldCloaks.js
+++ b/server/game/cards/01-Core/GoldCloaks.js
@@ -10,7 +10,7 @@ class GoldCloaks extends DrawCard {
                 onPhaseEnded: () => this.tracker.hasAmbushed(this)
             },
             handler: () => {
-                this.controller.discardCard(this);
+                this.controller.discardCard(this, false);
                 this.game.addMessage('{0} is forced to discard {1} from play at the end of the phase', this.controller, this);
             }
         });

--- a/server/game/cards/05-LoCR/ShaggaSonOfDolf.js
+++ b/server/game/cards/05-LoCR/ShaggaSonOfDolf.js
@@ -9,7 +9,6 @@ class ShaggaSonOfDolf extends DrawCard {
             condition: () => this.hasClansmanOrTyrion(),
             handler: () => {
                 this.controller.putIntoPlay(this, 'ambush');
-                this.wasAmbush = true;
                 this.game.addMessage('{0} ambushes {1} into play for free', this.controller, this);
             }
         });

--- a/server/game/cards/11.4-MoD/GreyGhost.js
+++ b/server/game/cards/11.4-MoD/GreyGhost.js
@@ -1,21 +1,18 @@
 const DrawCard = require('../../drawcard');
+const CardEntersPlayTracker = require('../../EventTrackers/CardEntersPlayTracker');
 
 class GreyGhost extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.tracker = new ShadowsTracker(this.game, this);
-    }
-
     setupCardAbilities(ability) {
+        this.tracker = CardEntersPlayTracker.forPhase(this.game);
+
         this.action({
             title: 'Prevent character(s) from defending',
             cost: ability.costs.kneelSelf(),
             handler: () => {
                 this.game.promptForSelect(this.controller, {
                     multiSelect: true,
-                    numCards: this.tracker.hasComeOutOfShadowsThisPhase ? 2 : 1,
-                    activePromptTitle: this.tracker.hasComeOutOfShadowsThisPhase ? 'Select 2 characters' : 'Select a character',
+                    numCards: this.tracker.hasComeOutOfShadows(this) ? 2 : 1,
+                    activePromptTitle: this.tracker.hasComeOutOfShadows(this) ? 'Select 2 characters' : 'Select a character',
                     source: this,
                     cardCondition: card => card.location === 'play area' && card.getType() === 'character',
                     onSelect: (player, cards) => this.onSelect(player, cards),
@@ -39,18 +36,6 @@ class GreyGhost extends DrawCard {
 
     cancelSelection(player) {
         this.game.addAlert('danger', '{0} cancels the resolution of {1}', player, this);
-    }
-}
-
-class ShadowsTracker {
-    constructor(game, card) {
-        this.hasComeOutOfShadowsThisPhase = false;
-        game.on('onCardOutOfShadows', event => {
-            if(event.card === card) {
-                this.hasComeOutOfShadowsThisPhase = true;
-            }
-        });
-        game.on('onPhaseEnded', () => this.hasComeOutOfShadowsThisPhase = false);
     }
 }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -31,7 +31,6 @@ class DrawCard extends BaseCard {
         this.kneeled = false;
         this.inChallenge = false;
         this.inDanger = false;
-        this.wasAmbush = false;
         this.saved = false;
         this.challengeOptions = new ReferenceCountedSetProperty();
         this.stealthLimit = 1;
@@ -395,7 +394,6 @@ class DrawCard extends BaseCard {
 
     leavesPlay() {
         this.kneeled = false;
-        this.wasAmbush = false;
         this.new = false;
         this.clearDanger();
         this.resetForChallenge();

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -604,7 +604,6 @@ class Player extends Spectator {
             this.moveCard(card, 'play area', { isDupe: !!dupeCard });
             card.takeControl(this);
             card.kneeled = playingType !== 'setup' && !!card.entersPlayKneeled || !!options.kneeled;
-            card.wasAmbush = (playingType === 'ambush');
 
             if(!dupeCard && !isSetupAttachment) {
                 card.applyPersistentEffects();

--- a/test/server/cards/01-Core/GoldCloaks.spec.js
+++ b/test/server/cards/01-Core/GoldCloaks.spec.js
@@ -1,0 +1,63 @@
+describe('Gold Cloaks', function() {
+    integration(function() {
+        describe('when Gold Cloaks is ambushed normally', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Gold Cloaks'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.character = this.player1.findCardByName('Gold Cloaks', 'hand');
+
+                this.player1.clickCard(this.character);
+
+                this.completeChallengesPhase();
+            });
+
+            it('should discard it from play', function() {
+                expect(this.character.location).toBe('discard pile');
+            });
+        });
+
+        describe('when Gold Cloaks is blanked during the phase it is ambushed into play', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Gold Cloaks', 'Nightmares'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.character = this.player1.findCardByName('Gold Cloaks', 'hand');
+
+                this.player1.clickCard(this.character);
+
+                // Blank Gold Cloaks to prevent the forced interrupt this phase
+                this.player1.clickCard('Nightmares', 'hand');
+                this.player1.clickCard(this.character);
+
+                this.completeChallengesPhase();
+            });
+
+            it('should not discard it the following phase', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+    });
+});

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -234,10 +234,6 @@ describe('Player', function() {
                     expect(this.cardSpy.new).toBe(true);
                 });
 
-                it('should play the card as an ambush', function() {
-                    expect(this.cardSpy.wasAmbush).toBe(true);
-                });
-
                 it('should apply effects for the card', function() {
                     expect(this.cardSpy.applyPersistentEffects).toHaveBeenCalled();
                 });


### PR DESCRIPTION
* Only discards Gold Cloaks during the phase it was ambushed. The previous `wasAmbush` flag never got reset, so it would cause Gold Cloaks to be discarded in subsequent phases if it were blanked previously.
* Ensures that the discard cannot be saved per card text
* Generalizes tracking of cards coming into play with `CardEntersPlayTracker`, which can be extended for different durations (challenge, round, etc) or actions (was marshalled, general was put into play) as needed.

Fixes #2321 