### PR TITLE
Expire effects in reverse order

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -211,9 +211,13 @@ class EffectEngine {
 
     unapplyAndRemove(match) {
         var [matchingEffects, remainingEffects] = _.partition(this.effects, match);
-        _.each(matchingEffects, effect => {
+
+        // Explicitly cancel effects in reverse order that they were applied so
+        // that problems with STR reduction and burn are avoided.
+        for(let effect of matchingEffects.reverse()) {
             effect.cancel();
-        });
+        }
+
         this.effects = remainingEffects;
     }
 }

--- a/test/server/integration/burneffects.spec.js
+++ b/test/server/integration/burneffects.spec.js
@@ -36,6 +36,66 @@ describe('burn effects', function() {
             });
         });
 
+        describe('when a character with a lasting effect STR buff will be burned', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('tyrell', [
+                    'Trading with the Pentoshi',
+                    'Hedge Knight', 'Varys (Core)', '"Lord Renly\'s Ride"'
+                ]);
+                const deck2 = this.buildDeck('targaryen', [
+                    'A Noble Cause',
+                    'Drogon (Core)', 'Dracarys!'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Hedge Knight', 'hand');
+                this.player1.clickCard(this.character);
+
+                this.dragon = this.player2.findCardByName('Drogon', 'hand');
+                this.player2.clickCard(this.dragon);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                // Drag Varys to the dead pile to get +3 STR from Lord Renly's Ride
+                let deadCharacter = this.player1.findCardByName('Varys', 'hand');
+                this.player1.dragCard(deadCharacter, 'dead pile');
+
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+
+                // Buff the character by +3 STR
+                this.player1.clickCard('"Lord Renly\'s Ride"', 'hand');
+                this.player1.clickCard(this.character);
+
+                this.player2.clickCard('Dracarys!');
+                this.player2.clickCard(this.dragon);
+                this.player2.clickCard(this.character);
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                // Skip claim
+                this.player1.clickPrompt('Continue');
+
+                this.completeChallengesPhase();
+            });
+
+            it('should not kill the character when lasting effects expire', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+
         describe('when effects are self-applied to a card that will be burned', function() {
             beforeEach(function() {
                 const deck1 = this.buildDeck('baratheon', [


### PR DESCRIPTION
Previously, lasting effects that buffed and then burned a character
could end up killing the character if they expired simultaneously. The
STR buff would expire first, putting the character at 0 STR and thus
killing the character before even attempting to expire the burn effect.

Now, just as effects are applied in a specific order, they are expired
in reverse order from which they were applied. This should ensure that
negative effects are expired first, preventing STR from improperly
reaching 0 and thus killing the character.

Fixes #2328 
Fixes #1706 
