### PR TITLE
Apply attachment lasting effect to specific parent

### DIFF
--- a/server/game/cards/01-Core/Heartsbane.js
+++ b/server/game/cards/01-Core/Heartsbane.js
@@ -9,7 +9,7 @@ class Heartsbane extends DrawCard {
             cost: ability.costs.kneelSelf(),
             handler: () => {
                 this.untilEndOfChallenge(ability => ({
-                    match: card => card === this.parent,
+                    match: this.parent,
                     effect: ability.effects.modifyStrength(3)
                 }));
                 this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the challenge', this.controller, this, this.parent);

--- a/server/game/cards/04.3-FFH/CrownOfGoldenRoses.js
+++ b/server/game/cards/04.3-FFH/CrownOfGoldenRoses.js
@@ -17,7 +17,7 @@ class CrownOfGoldenRoses extends DrawCard {
                 let strBoost = this.parent.getNumberOfIcons();
 
                 this.untilEndOfPhase(ability => ({
-                    match: card => card === this.parent,
+                    match: this.parent,
                     effect: ability.effects.modifyStrength(strBoost)
                 }));
 


### PR DESCRIPTION
Previously, Heartbane and Crown of Golden Roses were generating a
lasting effect that applied to any card it was attached on, instead of
only the card it was attach on when the ability triggered. This led to a
bug where if the attachment was moved to another character, the new
character would improperly gain the effect applied to its original
parent.

Fixes #2325 