### PR TITLE
Implement Reckless

### DIFF
--- a/server/game/cards/12-KotI/Reckless.js
+++ b/server/game/cards/12-KotI/Reckless.js
@@ -1,0 +1,16 @@
+const DrawCard = require('../../drawcard.js');
+
+class Reckless extends DrawCard {
+    setupCardAbilities(ability) {
+        this.whileAttached({
+            effect: [
+                ability.effects.mustBeDeclaredAsAttacker(),
+                ability.effects.mustBeDeclaredAsDefender()
+            ]
+        });
+    }
+}
+
+Reckless.code = '12043';
+
+module.exports = Reckless;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -412,10 +412,6 @@ class DrawCard extends BaseCard {
         this.inChallenge = false;
     }
 
-    canDeclareAsAttacker(challengeType) {
-        return this.allowGameAction('declareAsAttacker') && this.canDeclareAsParticipant(challengeType);
-    }
-
     canDeclareAsParticipant(challengeType) {
         return (
             this.canParticipateInChallenge() &&

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -416,10 +416,6 @@ class DrawCard extends BaseCard {
         return this.allowGameAction('declareAsAttacker') && this.canDeclareAsParticipant(challengeType);
     }
 
-    canDeclareAsDefender(challengeType) {
-        return this.allowGameAction('declareAsDefender') && this.canDeclareAsParticipant(challengeType);
-    }
-
     canDeclareAsParticipant(challengeType) {
         return (
             this.canParticipateInChallenge() &&

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -118,6 +118,7 @@ const Effects = {
     },
     canBeDeclaredWithoutIcon: challengeOptionEffect('canBeDeclaredWithoutIcon'),
     canBeDeclaredWhileKneeling: challengeOptionEffect('canBeDeclaredWhileKneeling'),
+    mustBeDeclaredAsAttacker: challengeOptionEffect('mustBeDeclaredAsAttacker'),
     mustBeDeclaredAsDefender: challengeOptionEffect('mustBeDeclaredAsDefender'),
     restrictAttachmentsTo: function(trait) {
         return Effects.addKeyword(`No attachments except <i>${trait}</i>`);

--- a/server/game/gamesteps/challenge/ChooseParticipantsPrompt.js
+++ b/server/game/gamesteps/challenge/ChooseParticipantsPrompt.js
@@ -1,0 +1,96 @@
+const BaseStep = require('../basestep');
+
+class ChooseParticipantsPrompt extends BaseStep {
+    constructor(game, choosingPlayer, properties) {
+        super(game);
+
+        this.game = game;
+        this.choosingPlayer = choosingPlayer;
+        this.limits = choosingPlayer[properties.limitsProperty];
+        this.properties = properties;
+        this.challengeType = properties.challengeType;
+        this.onSelect = properties.onSelect || (() => true);
+    }
+
+    continue() {
+        let forcedParticipants = this.choosingPlayer.filterCardsInPlay(card => this.isRequiredParticipant(card));
+        let participantMax = this.limits.getMax();
+
+        if(forcedParticipants.length !== 0) {
+            if(forcedParticipants.length <= participantMax || participantMax === 0) {
+                let message = forcedParticipants.length === 1 ? this.properties.messages.autoDeclareSingular : this.properties.messages.autoDeclarePlural;
+                this.game.addMessage(message, forcedParticipants);
+            }
+        }
+
+        this.game.promptForSelect(this.choosingPlayer, {
+            numCards: participantMax,
+            multiSelect: true,
+            activePromptTitle: this.getPromptTitle(),
+            waitingPromptTitle: this.properties.waitingPromptTitle,
+            cardCondition: card => this.canParticipate(card),
+            mustSelect: forcedParticipants,
+            onSelect: (player, participants) => this.chooseParticipants(participants),
+            onCancel: () => this.chooseParticipants([])
+        });
+    }
+
+    canParticipate(card) {
+        return card.controller === this.choosingPlayer &&
+            card.getType() === 'character' &&
+            card.canDeclareAsParticipant(this.challengeType) &&
+            card.allowGameAction(this.properties.gameAction) &&
+            !card.isParticipating();
+    }
+
+    isRequiredParticipant(card) {
+        return this.canParticipate(card) && card.challengeOptions.contains(this.properties.mustBeDeclaredOption);
+    }
+
+    getPromptTitle() {
+        let title = this.properties.activePromptTitle;
+        let max = this.limits.getMax();
+        let min = this.limits.getMin();
+        let restrictions = [];
+
+        if(min !== 0) {
+            restrictions.push(`min ${min}`);
+        }
+
+        if(max !== 0) {
+            restrictions.push(`max ${max}`);
+        }
+
+        if(restrictions.length !== 0) {
+            title += ` (${restrictions.join(', ')})`;
+        }
+
+        return title;
+    }
+
+    chooseParticipants(participants) {
+        if(!this.hasMetParticipantMinimum(participants)) {
+            let min = this.limits.getMin();
+            let message = min === 1 ? this.properties.messages.notEnoughSingular : this.properties.messages.notEnoughPlural;
+            this.game.addAlert('danger', message, this.choosingPlayer, min);
+        }
+
+        this.onSelect(participants);
+        return true;
+    }
+
+    hasMetParticipantMinimum(participants) {
+        let min = this.limits.getMin();
+
+        if(min === 0) {
+            return true;
+        }
+
+        let eligibleParticipants = this.choosingPlayer.getNumberOfCardsInPlay(card => this.canParticipate(card));
+        let actualMinimum = Math.min(min, eligibleParticipants);
+
+        return participants.length >= actualMinimum;
+    }
+}
+
+module.exports = ChooseParticipantsPrompt;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -2,6 +2,7 @@ const _ = require('underscore');
 const BaseStep = require('../basestep.js');
 const GamePipeline = require('../../gamepipeline.js');
 const SimpleStep = require('../simplestep.js');
+const ChooseParticipantsPrompt = require('./ChooseParticipantsPrompt');
 const ChooseStealthTargets = require('./choosestealthtargets.js');
 const ClaimPrompt = require('./ClaimPrompt');
 const ActionWindow = require('../actionwindow.js');
@@ -126,90 +127,26 @@ class ChallengeFlow extends BaseStep {
             return;
         }
 
-        this.forcedDefenders = this.challenge.defendingPlayer.filterCardsInPlay(card => {
-            return card.getType() === 'character' &&
-                card.canDeclareAsDefender(this.challenge.challengeType) &&
-                card.challengeOptions.contains('mustBeDeclaredAsDefender');
-        });
-
-        let defenderMaximum = this.challenge.defendingPlayer.defenderLimits.getMax();
-        let defenderMinimum = this.challenge.defendingPlayer.defenderLimits.getMin();
-        let selectableLimit = defenderMaximum;
-
-        if(!_.isEmpty(this.forcedDefenders)) {
-            if(this.forcedDefenders.length === defenderMaximum) {
-                this.game.addMessage('{0} {1} automatically declared as {2}',
-                    this.forcedDefenders, this.forcedDefenders.length > 1 ? 'are' : 'is', this.forcedDefenders.length > 1 ? 'defenders' : 'defender');
-
-                this.chooseDefenders([]);
-                return;
-            }
-
-            if(this.forcedDefenders.length < defenderMaximum || defenderMaximum === 0) {
-                this.game.addMessage('{0} {1} automatically declared as {2}',
-                    this.forcedDefenders, this.forcedDefenders.length > 1 ? 'are' : 'is', this.forcedDefenders.length > 1 ? 'defenders' : 'defender');
-
-                if(defenderMaximum !== 0) {
-                    selectableLimit -= this.forcedDefenders.length;
-                }
-            }
-        }
-
-        let title = 'Select defenders';
-        let restrictions = [];
-        if(defenderMinimum !== 0) {
-            restrictions.push(`min ${defenderMinimum}`);
-        }
-        if(defenderMaximum !== 0) {
-            restrictions.push(`max ${defenderMaximum}`);
-        }
-        if(restrictions.length !== 0) {
-            title += ` (${restrictions.join(', ')})`;
-        }
-
-        this.game.promptForSelect(this.challenge.defendingPlayer, {
-            numCards: selectableLimit,
-            multiSelect: true,
-            activePromptTitle: title,
+        this.game.queueStep(new ChooseParticipantsPrompt(this.game, this.challenge.defendingPlayer, {
+            challengeType: this.challenge.challengeType,
+            gameAction: 'declareAsDefender',
+            mustBeDeclaredOption: 'mustBeDeclaredAsDefender',
+            limitsProperty: 'defenderLimits',
+            activePromptTitle: 'Select defenders',
             waitingPromptTitle: 'Waiting for opponent to defend',
-            cardCondition: card => this.allowAsDefender(card),
-            onSelect: (player, defenders) => this.chooseDefenders(defenders),
-            onCancel: () => this.chooseDefenders([])
-        });
-    }
-
-    allowAsDefender(card) {
-        return this.challenge.defendingPlayer === card.controller &&
-            card.canDeclareAsDefender(this.challenge.challengeType) &&
-            this.mustBeDeclaredAsDefender(card) &&
-            !this.challenge.isDefending(card);
-    }
-
-    mustBeDeclaredAsDefender(card) {
-        if(_.isEmpty(this.forcedDefenders)) {
-            return true;
-        }
-
-        let defenderMax = this.challenge.defendingPlayer.defenderLimits.getMax();
-        if(this.forcedDefenders.length < defenderMax || defenderMax === 0) {
-            return !this.forcedDefenders.includes(card);
-        }
-
-        return this.forcedDefenders.includes(card);
+            messages: {
+                autoDeclareSingular: '{0} is automatically declared as a defender',
+                autoDeclarePlural: '{0} are automatically declared as defenders',
+                notEnoughSingular: '{0} did not declare at least {1} defender but had characters to do so',
+                notEnoughPlural: '{0} did not declare at least {1} defenders but had characters to do so'
+            },
+            onSelect: defenders => {
+                this.chooseDefenders(defenders);
+            }
+        }));
     }
 
     chooseDefenders(defenders) {
-        let defendingPlayer = this.challenge.defendingPlayer;
-        let defenderMaximum = defendingPlayer.defenderLimits.getMax();
-        let defenderMinimum = defendingPlayer.defenderLimits.getMin();
-        if(this.forcedDefenders.length <= defenderMaximum || defenderMaximum === 0) {
-            defenders = defenders.concat(this.forcedDefenders);
-        }
-
-        if(!this.hasMetDefenderMinimum(defenders)) {
-            this.game.addAlert('danger', '{0} did not declare at least {1} defender but had characters to do so', defendingPlayer, defenderMinimum);
-        }
-
         let defendersToKneel = [];
         this.challenge.addDefenders(defenders);
 
@@ -239,20 +176,6 @@ class ChallengeFlow extends BaseStep {
         defendersToKneel = undefined;
 
         return true;
-    }
-
-    hasMetDefenderMinimum(defenders) {
-        let defendingPlayer = this.challenge.defendingPlayer;
-        let defenderMinimum = defendingPlayer.defenderLimits.getMin();
-
-        if(defenderMinimum === 0) {
-            return true;
-        }
-
-        let potentialDefenders = defendingPlayer.getNumberOfCardsInPlay(card => this.allowAsDefender(card));
-        let actualMinimum = Math.min(defenderMinimum, potentialDefenders);
-
-        return defenders.length >= actualMinimum;
     }
 
     announceDefenderStrength() {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -49,28 +49,29 @@ class ChallengeFlow extends BaseStep {
     }
 
     promptForAttackers() {
-        let title = 'Select challenge attackers';
-        let attackerMax = this.challenge.attackingPlayer.attackerLimits.getMax();
-        if(attackerMax !== 0) {
-            title += ' (max ' + attackerMax + ')';
+        this.game.queueStep(new ChooseParticipantsPrompt(this.game, this.challenge.attackingPlayer, {
+            challengeType: this.challenge.challengeType,
+            gameAction: 'declareAsAttacker',
+            mustBeDeclaredOption: 'mustBeDeclaredAsAttacker',
+            limitsProperty: 'attackerLimits',
+            activePromptTitle: 'Select challenge attackers',
+            waitingPromptTitle: 'Waiting for opponent to select attackers',
+            messages: {
+                autoDeclareSingular: '{0} is automatically declared as an attacker',
+                autoDeclarePlural: '{0} are automatically declared as attackers',
+                notEnoughSingular: '{0} did not declare at least {1} attacker but had characters to do so',
+                notEnoughPlural: '{0} did not declare at least {1} attackers but had characters to do so'
+            },
+            onSelect: attackers => this.chooseAttackers(attackers)
+        }));
+    }
+
+    chooseAttackers(attackers) {
+        if(attackers.length === 0) {
+            this.challenge.cancelChallenge();
+            return;
         }
 
-        this.game.promptForSelect(this.challenge.attackingPlayer, {
-            numCards: attackerMax,
-            multiSelect: true,
-            activePromptTitle: title,
-            waitingPromptTitle: 'Waiting for opponent to select attackers',
-            cardCondition: card => this.allowAsAttacker(card),
-            onSelect: (player, attackers) => this.chooseAttackers(player, attackers),
-            onCancel: () => this.challenge.cancelChallenge()
-        });
-    }
-
-    allowAsAttacker(card) {
-        return this.challenge.attackingPlayer === card.controller && card.canDeclareAsAttacker(this.challenge.challengeType);
-    }
-
-    chooseAttackers(player, attackers) {
         this.attackersToKneel = [];
         this.challenge.addAttackers(attackers);
 
@@ -140,9 +141,7 @@ class ChallengeFlow extends BaseStep {
                 notEnoughSingular: '{0} did not declare at least {1} defender but had characters to do so',
                 notEnoughPlural: '{0} did not declare at least {1} defenders but had characters to do so'
             },
-            onSelect: defenders => {
-                this.chooseDefenders(defenders);
-            }
+            onSelect: defenders => this.chooseDefenders(defenders)
         }));
     }
 

--- a/test/server/gamesteps/challenge/ChooseParticipantsPrompt.spec.js
+++ b/test/server/gamesteps/challenge/ChooseParticipantsPrompt.spec.js
@@ -1,0 +1,132 @@
+const ChooseParticipantsPrompt = require('../../../../server/game/gamesteps/challenge/ChooseParticipantsPrompt');
+
+describe('ChooseParticipantsPrompt', function() {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['addAlert', 'addMessage', 'promptForSelect']);
+        this.limitsSpy = jasmine.createSpyObj('limits', ['getMax', 'getMin']);
+        this.limitsSpy.getMax.and.returnValue(0);
+        this.limitsSpy.getMin.and.returnValue(0);
+        this.playerSpy = jasmine.createSpyObj('player', ['getNumberOfCardsInPlay', 'filterCardsInPlay']);
+        this.playerSpy.getNumberOfCardsInPlay.and.returnValue(10);
+        this.playerSpy.filterCardsInPlay.and.returnValue([]);
+        this.playerSpy.genericLimits = this.limitsSpy;
+        this.onSelectSpy = jasmine.createSpy('onSelect');
+        this.properties = {
+            challengeType: 'military',
+            gameAction: 'GAME_ACTION',
+            mustBeDeclaredOption: 'FORCED_DECLARE_OPTION',
+            limitsProperty: 'genericLimits',
+            activePromptTitle: 'Select participants',
+            waitingPromptTitle: 'Waiting for opponent to declare participants',
+            messages: {},
+            onSelect: this.onSelectSpy
+        };
+        this.prompt = new ChooseParticipantsPrompt(this.gameSpy, this.playerSpy, this.properties);
+    });
+
+    describe('continue()', function() {
+        describe('when there are no forced participants', function() {
+            it('prompts the choosing player', function() {
+                this.prompt.continue();
+                expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.playerSpy, jasmine.objectContaining({
+                    activePromptTitle: 'Select participants',
+                    waitingPromptTitle: 'Waiting for opponent to declare participants'
+                }));
+            });
+
+            describe('when there is a minimum number of participants', function() {
+                beforeEach(function() {
+                    this.limitsSpy.getMin.and.returnValue(23);
+                });
+
+                it('adds the requirement to the prompt title', function() {
+                    this.prompt.continue();
+                    expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.playerSpy, jasmine.objectContaining({
+                        activePromptTitle: 'Select participants (min 23)'
+                    }));
+                });
+            });
+
+            describe('when there is a maximum number of participants', function() {
+                beforeEach(function() {
+                    this.limitsSpy.getMax.and.returnValue(45);
+                });
+
+                it('adds the requirement to the prompt title', function() {
+                    this.prompt.continue();
+                    expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.playerSpy, jasmine.objectContaining({
+                        activePromptTitle: 'Select participants (max 45)'
+                    }));
+                });
+
+                it('limits the number of cards that can be selected', function() {
+                    this.prompt.continue();
+                    expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.playerSpy, jasmine.objectContaining({
+                        numCards: 45
+                    }));
+                });
+            });
+        });
+
+        describe('when there are forced participants', function() {
+            beforeEach(function() {
+                this.card1 = { card: 1 };
+                this.card2 = { card: 2 };
+                this.playerSpy.filterCardsInPlay.and.returnValue([this.card1, this.card2]);
+                this.prompt.continue();
+            });
+
+            it('prompts with mustSelect', function() {
+                expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.playerSpy, jasmine.objectContaining({
+                    mustSelect: [this.card1, this.card2]
+                }));
+            });
+
+            it('adds a log message', function() {
+                expect(this.gameSpy.addMessage).toHaveBeenCalled();
+            });
+        });
+
+        describe('the select prompt', function() {
+            describe('onSelect', function() {
+                beforeEach(function() {
+                    this.prompt.continue();
+                    let call = this.gameSpy.promptForSelect.calls.mostRecent();
+                    this.selectPrompt = call.args[1];
+                });
+
+                it('calls the onSelect handler with the selected cards', function() {
+                    this.selectPrompt.onSelect(this.playerSpy, ['card']);
+                    expect(this.onSelectSpy).toHaveBeenCalledWith(['card']);
+                });
+
+                describe('and there is an met minimum', function() {
+                    beforeEach(function() {
+                        // 2 eligible cards in play, a minimum selection of 3 cards, all 2 selected
+                        this.playerSpy.getNumberOfCardsInPlay.and.returnValue(2);
+                        this.limitsSpy.getMin.and.returnValue(3);
+
+                        this.selectPrompt.onSelect(this.playerSpy, ['card1', 'card2']);
+                    });
+
+                    it('does not add an alert', function() {
+                        expect(this.gameSpy.addAlert).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('and there is an unmet minimum', function() {
+                    beforeEach(function() {
+                        // 3 eligible cards in play, a minimum selection of 2 cards, only 1 selected
+                        this.playerSpy.getNumberOfCardsInPlay.and.returnValue(3);
+                        this.limitsSpy.getMin.and.returnValue(2);
+                        this.selectPrompt.onSelect(this.playerSpy, ['card']);
+                    });
+
+                    it('adds an alert', function() {
+                        expect(this.gameSpy.addAlert).toHaveBeenCalled();
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Also:
* Shows auto-declared attackers / defenders within the select prompt instead of adding them after selection. Future improvement could be to highlight these unselectable cards in a different color.
* Extracts the "must be declared" and minimum participant logic into its own class, so that it can be used for both attackers and defenders.