### PR TITLE
Move phase logic off player

### DIFF
--- a/server/game/Constants.js
+++ b/server/game/Constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+    StartingHandSize: 7
+};

--- a/server/game/Constants.js
+++ b/server/game/Constants.js
@@ -1,3 +1,6 @@
 module.exports = {
+    DrawPhaseCards: 2,
+    MarshalIntoShadowsCost: 2,
+    SetupGold: 8,
     StartingHandSize: 7
 };

--- a/server/game/PlayActions/MarshalCardAction.js
+++ b/server/game/PlayActions/MarshalCardAction.js
@@ -23,6 +23,7 @@ class MarshalCardAction extends BaseAbility {
         return (
             game.currentPhase === 'marshal' &&
             source.getType() !== 'event' &&
+            player.allowMarshal &&
             player.isCardInPlayableLocation(source, 'marshal') &&
             player.canPutIntoPlay(source, 'marshal')
         );

--- a/server/game/PlayActions/MarshalIntoShadowsAction.js
+++ b/server/game/PlayActions/MarshalIntoShadowsAction.js
@@ -22,6 +22,7 @@ class MarshalIntoShadowsAction extends BaseAbility {
         return (
             game.currentPhase === 'marshal' &&
             source.isShadow() &&
+            player.allowMarshal &&
             player.isCardInPlayableLocation(source, 'marshal')
         );
     }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -26,7 +26,7 @@ class Challenge {
     singlePlayerDefender() {
         let dummyPlayer = new Player('', Settings.getUserWithDefaultsSet({ name: 'Dummy Player' }), false, this.game);
         dummyPlayer.initialise();
-        dummyPlayer.startPlotPhase();
+        dummyPlayer.resetForStartOfRound();
         return dummyPlayer;
     }
 

--- a/server/game/gamesteps/drawphase.js
+++ b/server/game/gamesteps/drawphase.js
@@ -1,4 +1,3 @@
-const _ = require('underscore');
 const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
 const ActionWindow = require('./actionwindow.js');
@@ -13,9 +12,12 @@ class DrawPhase extends Phase {
     }
 
     draw() {
-        _.each(this.game.getPlayers(), p => {
-            p.drawPhase();
-        });
+        for(let player of this.game.getPlayers()) {
+            if(player.canDraw()) {
+                let cards = player.drawCardsToHand(player.drawPhaseCards);
+                this.game.addMessage('{0} draws {1} cards', player, cards.length);
+            }
+        }
     }
 }
 

--- a/server/game/gamesteps/marshalingphase.js
+++ b/server/game/gamesteps/marshalingphase.js
@@ -17,9 +17,18 @@ class MarshalingPhase extends Phase {
 
     promptForMarshal() {
         let currentPlayer = this.remainingPlayers.shift();
-        currentPlayer.beginMarshal();
+        this.collectIncome(currentPlayer);
         this.game.queueStep(new MarshalCardsPrompt(this.game, currentPlayer));
         return this.remainingPlayers.length === 0;
+    }
+
+    collectIncome(player) {
+        if(player.canGainGold()) {
+            let gold = this.game.addGold(player, player.getTotalIncome());
+            this.game.addMessage('{0} collects {1} gold', player, gold);
+        }
+
+        this.game.raiseEvent('onIncomeCollected', { player: player });
     }
 }
 

--- a/server/game/gamesteps/marshalingphase.js
+++ b/server/game/gamesteps/marshalingphase.js
@@ -17,8 +17,15 @@ class MarshalingPhase extends Phase {
 
     promptForMarshal() {
         let currentPlayer = this.remainingPlayers.shift();
+
         this.collectIncome(currentPlayer);
+
+        currentPlayer.allowMarshal = true;
         this.game.queueStep(new MarshalCardsPrompt(this.game, currentPlayer));
+        this.game.queueSimpleStep(() => {
+            currentPlayer.allowMarshal = false;
+        });
+
         return this.remainingPlayers.length === 0;
     }
 

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -30,7 +30,7 @@ class PlotPhase extends Phase {
 
     startPlotPhase() {
         for(const player of this.game.getPlayers()) {
-            player.startPlotPhase();
+            player.resetForStartOfRound();
         }
     }
 

--- a/server/game/gamesteps/setup/keepormulliganprompt.js
+++ b/server/game/gamesteps/setup/keepormulliganprompt.js
@@ -1,8 +1,14 @@
 const AllPlayerPrompt = require('../allplayerprompt.js');
 
 class KeepOrMulliganPrompt extends AllPlayerPrompt {
+    constructor(game) {
+        super(game);
+
+        this.completedPlayers = new Set();
+    }
+
     completionCondition(player) {
-        return player.readyToStart;
+        return this.completedPlayers.has(player);
     }
 
     activePrompt() {
@@ -20,6 +26,12 @@ class KeepOrMulliganPrompt extends AllPlayerPrompt {
     }
 
     onMenuCommand(player, arg) {
+        if(this.completedPlayers.has(player)) {
+            return;
+        }
+
+        this.completedPlayers.add(player);
+
         if(arg === 'keep') {
             player.keep();
             this.game.addMessage('{0} has kept their hand', player);

--- a/server/game/gamesteps/setup/keepormulliganprompt.js
+++ b/server/game/gamesteps/setup/keepormulliganprompt.js
@@ -1,5 +1,7 @@
 const AllPlayerPrompt = require('../allplayerprompt.js');
 
+const { StartingHandSize } = require('../../Constants');
+
 class KeepOrMulliganPrompt extends AllPlayerPrompt {
     constructor(game) {
         super(game);
@@ -33,12 +35,18 @@ class KeepOrMulliganPrompt extends AllPlayerPrompt {
         this.completedPlayers.add(player);
 
         if(arg === 'keep') {
-            player.keep();
             this.game.addMessage('{0} has kept their hand', player);
-        } else if(arg === 'mulligan' && player.mulligan()) {
+        } else if(arg === 'mulligan') {
+            this.mulligan(player);
             this.game.addMessage('{0} has taken a mulligan', player);
         }
         this.game.raiseEvent('onPlayerKeepHandOrMulligan', { player: player, choice: arg });
+    }
+
+    mulligan(player) {
+        player.resetDrawDeck();
+        player.shuffleDrawDeck();
+        player.drawCardsToHand(StartingHandSize);
     }
 }
 

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -65,7 +65,8 @@ class SetupPhase extends Phase {
 
     startGame() {
         for(const player of this.game.getPlayers()) {
-            player.startGame();
+            player.readyToStart = true;
+            this.game.addGold(player, player.setupGold);
         }
     }
 

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -89,7 +89,13 @@ class SetupPhase extends Phase {
 
     setupDone() {
         for(const player of this.game.getPlayers()) {
-            player.setupDone();
+            // Draw back up to starting hand size
+            if(player.hand.length < StartingHandSize) {
+                player.drawCardsToHand(StartingHandSize - player.hand.length);
+            }
+
+            this.game.returnGoldToTreasury({ player: player, amount: player.gold });
+            player.revealSetupCards();
         }
     }
 }

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -5,6 +5,7 @@ const SetupCardsPrompt = require('./setup/setupcardsprompt.js');
 const CheckAttachmentsPrompt = require('./setup/checkattachmentsprompt.js');
 const RookerySetupPrompt = require('./setup/RookerySetupPrompt');
 const TextHelper = require('../TextHelper');
+const { StartingHandSize } = require('../Constants');
 
 class SetupPhase extends Phase {
     constructor(game) {
@@ -58,7 +59,7 @@ class SetupPhase extends Phase {
 
     drawSetupHand() {
         for(const player of this.game.getPlayers()) {
-            player.drawSetupHand();
+            player.drawCardsToHand(StartingHandSize);
         }
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -14,8 +14,8 @@ const PlayActionPrompt = require('./gamesteps/playactionprompt.js');
 const PlayerPromptState = require('./playerpromptstate.js');
 const MinMaxProperty = require('./PropertyTypes/MinMaxProperty');
 const GoldSource = require('./GoldSource.js');
+const { StartingHandSize } = require('./Constants');
 
-const StartingHandSize = 7;
 const DrawPhaseCards = 2;
 const MarshalIntoShadowsCost = 2;
 
@@ -355,10 +355,6 @@ class Player extends Spectator {
         this.shuffleDrawDeck();
     }
 
-    drawSetupHand() {
-        this.drawCardsToHand(StartingHandSize);
-    }
-
     prepareDecks() {
         var deck = new Deck(this.deck);
         var preparedDeck = deck.prepare(this);
@@ -402,7 +398,7 @@ class Player extends Spectator {
         }
 
         this.initDrawDeck();
-        this.drawSetupHand();
+        this.drawCardsToHand(StartingHandSize);
         this.takenMulligan = true;
         this.readyToStart = true;
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -384,14 +384,6 @@ class Player extends Spectator {
         this.agenda = deck.createAgendaCard(this);
     }
 
-    startGame() {
-        if(!this.readyToStart) {
-            return;
-        }
-
-        this.gold = this.setupGold;
-    }
-
     mulligan() {
         if(this.takenMulligan) {
             return false;
@@ -400,13 +392,11 @@ class Player extends Spectator {
         this.initDrawDeck();
         this.drawCardsToHand(StartingHandSize);
         this.takenMulligan = true;
-        this.readyToStart = true;
 
         return true;
     }
 
     keep() {
-        this.readyToStart = true;
     }
 
     addCostReducer(reducer) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -613,10 +613,9 @@ class Player extends Spectator {
         this.cardsInPlay = processedCards;
     }
 
-    startPlotPhase() {
+    resetForStartOfRound() {
         this.firstPlayer = false;
         this.selectedPlot = undefined;
-        this.roundDone = false;
 
         if(this.resetTimerAtEndOfRound) {
             this.noTimer = false;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -702,13 +702,6 @@ class Player extends Spectator {
         }
     }
 
-    drawPhase() {
-        if(this.canDraw()) {
-            this.game.addMessage('{0} draws {1} cards', this, this.drawPhaseCards);
-            this.drawCardsToHand(this.drawPhaseCards);
-        }
-    }
-
     beginMarshal() {
         if(this.canGainGold()) {
             let gold = this.game.addGold(this, this.getTotalIncome());

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -612,11 +612,7 @@ class Player extends Spectator {
         }
     }
 
-    setupDone() {
-        if(this.hand.length < StartingHandSize) {
-            this.drawCardsToHand(StartingHandSize - this.hand.length);
-        }
-
+    revealSetupCards() {
         let processedCards = [];
 
         for(const card of this.cardsInPlay) {
@@ -637,7 +633,6 @@ class Player extends Spectator {
         }
 
         this.cardsInPlay = processedCards;
-        this.gold = 0;
     }
 
     startPlotPhase() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -14,7 +14,6 @@ const PlayActionPrompt = require('./gamesteps/playactionprompt.js');
 const PlayerPromptState = require('./playerpromptstate.js');
 const MinMaxProperty = require('./PropertyTypes/MinMaxProperty');
 const GoldSource = require('./GoldSource.js');
-const { StartingHandSize } = require('./Constants');
 
 const DrawPhaseCards = 2;
 const MarshalIntoShadowsCost = 2;
@@ -350,11 +349,6 @@ class Player extends Spectator {
         this.deadPile = [];
     }
 
-    initDrawDeck() {
-        this.resetDrawDeck();
-        this.shuffleDrawDeck();
-    }
-
     prepareDecks() {
         var deck = new Deck(this.deck);
         var preparedDeck = deck.prepare(this);
@@ -382,21 +376,6 @@ class Player extends Spectator {
         let deck = new Deck(this.deck);
         this.faction = deck.createFactionCard(this);
         this.agenda = deck.createAgendaCard(this);
-    }
-
-    mulligan() {
-        if(this.takenMulligan) {
-            return false;
-        }
-
-        this.initDrawDeck();
-        this.drawCardsToHand(StartingHandSize);
-        this.takenMulligan = true;
-
-        return true;
-    }
-
-    keep() {
     }
 
     addCostReducer(reducer) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -15,8 +15,7 @@ const PlayerPromptState = require('./playerpromptstate.js');
 const MinMaxProperty = require('./PropertyTypes/MinMaxProperty');
 const GoldSource = require('./GoldSource.js');
 
-const DrawPhaseCards = 2;
-const MarshalIntoShadowsCost = 2;
+const { DrawPhaseCards, MarshalIntoShadowsCost, SetupGold } = require('./Constants');
 
 class Player extends Spectator {
     constructor(id, user, owner, game) {
@@ -45,7 +44,7 @@ class Player extends Spectator {
         this.owner = owner;
         this.takenMulligan = false;
 
-        this.setupGold = 8;
+        this.setupGold = SetupGold;
         this.drawPhaseCards = DrawPhaseCards;
         this.cardsInPlayBeforeSetup = [];
         this.deck = {};

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -702,15 +702,6 @@ class Player extends Spectator {
         }
     }
 
-    beginMarshal() {
-        if(this.canGainGold()) {
-            let gold = this.game.addGold(this, this.getTotalIncome());
-            this.game.addMessage('{0} collects {1} gold', this, gold);
-        }
-
-        this.game.raiseEvent('onIncomeCollected', { player: this });
-    }
-
     hasUnmappedAttachments() {
         return this.cardsInPlay.some(card => {
             return card.getType() === 'attachment';

--- a/test/server/PlayActions/MarshalCardAction.spec.js
+++ b/test/server/PlayActions/MarshalCardAction.spec.js
@@ -22,6 +22,7 @@ describe('MarshalCardAction', function () {
     describe('meetsRequirements()', function() {
         beforeEach(function() {
             this.gameSpy.currentPhase = 'marshal';
+            this.playerSpy.allowMarshal = true;
             this.playerSpy.canPutIntoPlay.and.returnValue(true);
             this.playerSpy.isCardInPlayableLocation.and.returnValue(true);
             this.cardSpy.getType.and.returnValue('character');

--- a/test/server/gamesteps/setup/keepormulliganprompt.spec.js
+++ b/test/server/gamesteps/setup/keepormulliganprompt.spec.js
@@ -3,7 +3,7 @@ const KeepOrMulliganPrompt = require('../../../../server/game/gamesteps/setup/ke
 describe('the KeepOrMulliganPrompt', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'raiseEvent']);
-        this.playerSpy = jasmine.createSpyObj('player', ['keep', 'mulligan']);
+        this.playerSpy = jasmine.createSpyObj('player', ['drawCardsToHand', 'resetDrawDeck', 'shuffleDrawDeck']);
         this.prompt = new KeepOrMulliganPrompt(this.gameSpy);
     });
 
@@ -13,9 +13,10 @@ describe('the KeepOrMulliganPrompt', function() {
                 this.prompt.onMenuCommand(this.playerSpy, 'keep');
             });
 
-            it('should call keep on the player', function() {
-                expect(this.playerSpy.keep).toHaveBeenCalled();
-                expect(this.playerSpy.mulligan).not.toHaveBeenCalled();
+            it('should not mulligan the player', function() {
+                expect(this.playerSpy.drawCardsToHand).not.toHaveBeenCalled();
+                expect(this.playerSpy.resetDrawDeck).not.toHaveBeenCalled();
+                expect(this.playerSpy.shuffleDrawDeck).not.toHaveBeenCalled();
             });
 
             it('should raise the onPlayerKeepHandOrMerged event', function() {
@@ -28,9 +29,10 @@ describe('the KeepOrMulliganPrompt', function() {
                 this.prompt.onMenuCommand(this.playerSpy, 'mulligan');
             });
 
-            it('should call mulligan on the player', function() {
-                expect(this.playerSpy.keep).not.toHaveBeenCalled();
-                expect(this.playerSpy.mulligan).toHaveBeenCalled();
+            it('should mulligan the player', function() {
+                expect(this.playerSpy.drawCardsToHand).toHaveBeenCalledWith(7);
+                expect(this.playerSpy.resetDrawDeck).toHaveBeenCalled();
+                expect(this.playerSpy.shuffleDrawDeck).toHaveBeenCalled();
             });
 
             it('should raise the onPlayerKeepHandOrMerged event', function() {

--- a/test/server/integration/marshalphase.spec.js
+++ b/test/server/integration/marshalphase.spec.js
@@ -206,5 +206,31 @@ describe('marshal phase', function() {
                 });
             });
         });
+
+        describe('when it is not your turn to marshal', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'Trading with the Pentoshi', 'Sneak Attack',
+                    'The Roseroad'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.skipSetupPhase();
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should not allow you to marshal cards', function() {
+                let card = this.player2.findCardByName('The Roseroad', 'hand');
+                this.player2.clickCard(card);
+
+                // Even if player 2 has enough gold to marshal the card, since
+                // it is player 1's turn, it should not allow the card to be
+                // marshalled.
+                expect(card.location).not.toBe('play area');
+            });
+        });
     });
 });


### PR DESCRIPTION
Moves game flow rules off of the `Player` class so that it can concentrate on methods that directly mutate the player or return info about it.

Bonus: fixes the long standing bug that allowed players to marshal outside of their turn.

Theoretically fixes #1851 by blocking double clicks earlier in the keep or mulligan prompt.