### PR TITLE
Allow Spare Boot to stand unusable attachments

### DIFF
--- a/server/game/cards/10-SoD/SpareBoot.js
+++ b/server/game/cards/10-SoD/SpareBoot.js
@@ -10,21 +10,38 @@ class SpareBoot extends DrawCard {
                 activePromptTitle: 'Select an attachment',
                 cardCondition: card => card.location === 'play area' && card.getType() === 'attachment' &&
                                        card.parent && card.parent.controller === this.controller &&
-                                       (card.parent !== this || card.kneeled) &&
-                                       card.controller.canAttach(card, this)
+                                       (this.allowMoveAttachment(card) || card.kneeled)
             },
             handler: context => {
-                if(context.target.parent !== this) {
-                    context.player.attach(context.target.controller, context.target, this);
+                let attachment = context.target;
+                let canMove = this.allowMoveAttachment(attachment);
+                let canStand = attachment.kneeled;
+
+                if(canMove) {
+                    context.player.attach(attachment.controller, attachment, this);
                 }
 
-                if(context.target.kneeled) {
-                    context.player.standCard(context.target);
+                if(canStand) {
+                    context.player.standCard(attachment);
                 }
 
-                this.game.addMessage('{0} stands and moves {1} to {2}', context.player, context.target, this);
+                let message;
+
+                if(canMove && canStand) {
+                    message = '{0} uses {1} to stand {2} and move it to {1}';
+                } else if(canMove) {
+                    message = '{0} uses {1} to move {2} to {1}';
+                } else {
+                    message = '{0} uses {1} to stand {2}';
+                }
+
+                this.game.addMessage(message, context.player, this, attachment);
             }
         });
+    }
+
+    allowMoveAttachment(attachment) {
+        return attachment.parent !== this && attachment.controller.canAttach(attachment, this);
     }
 }
 

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -122,6 +122,29 @@ var customMatchers = {
                 return result;
             }
         };
+    },
+    toAllowSelect: function(util, customEqualityMatchers) {
+        return {
+            compare: function(actual, expected) {
+                let result = {};
+                if(typeof expected !== 'string') {
+                    expected = expected.name;
+                }
+
+                let selectableCardNames = actual.player.getSelectableCards().map(card => card.name);
+                let includesCard = selectableCardNames.some(cardName => util.equals(cardName, expected, customEqualityMatchers));
+
+                result.pass = includesCard;
+
+                if(result.pass) {
+                    result.message = `Expected ${actual.name} not to be allowed to select ${expected} but it is.`;
+                } else {
+                    result.message = `Expected ${actual.name} to be allowed to select ${expected} but it isn't.`;
+                }
+
+                return result;
+            }
+        };
     }
 };
 

--- a/test/server/cards/10-SoD/SpareBoot.spec.js
+++ b/test/server/cards/10-SoD/SpareBoot.spec.js
@@ -1,0 +1,107 @@
+describe('Spare Boot', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('thenightswatch', [
+                'Trading with the Pentoshi',
+                'Spare Boot', 'Bran Stark (Core)', 'Seal of the Hand', 'Syrio\'s Training', 'Little Bird'
+            ]);
+
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.spareBoot = this.player1.findCardByName('Spare Boot', 'hand');
+            this.otherCharacter = this.player1.findCardByName('Bran Stark', 'hand');
+            this.nonUsableAttachment = this.player1.findCardByName('Seal of the Hand', 'hand');
+            this.usableAttachment = this.player1.findCardByName('Syrio\'s Training', 'hand');
+            this.spareBootAttachment = this.player1.findCardByName('Little Bird', 'hand');
+
+            this.player1.clickCard(this.spareBoot);
+            this.player1.clickCard(this.otherCharacter);
+            this.player1.clickCard(this.nonUsableAttachment);
+            this.player1.clickCard(this.usableAttachment);
+
+            this.completeSetup();
+
+            // place attachments
+            this.player1.clickCard(this.nonUsableAttachment);
+            this.player1.clickCard(this.otherCharacter);
+            this.player1.clickCard(this.usableAttachment);
+            this.player1.clickCard(this.otherCharacter);
+
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.player1.clickCard(this.spareBootAttachment);
+            this.player1.clickCard(this.spareBoot);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when the attachment is movable', function() {
+            beforeEach(function() {
+                this.player1.clickMenu(this.spareBoot, 'Stand and move attachment');
+                this.player1.clickCard(this.usableAttachment);
+            });
+
+            it('moves the attachment', function() {
+                expect(this.usableAttachment.parent).toBe(this.spareBoot);
+            });
+        });
+
+        describe('when the attachment is not movable but is knelt', function() {
+            beforeEach(function() {
+                // Manually kneel the attachment
+                this.player1.clickCard(this.nonUsableAttachment);
+
+                this.player1.clickMenu(this.spareBoot, 'Stand and move attachment');
+            });
+
+            it('allows selection of the non-movable attachment', function() {
+                expect(this.player1).toAllowSelect(this.nonUsableAttachment);
+            });
+
+            it('stands the attachment', function() {
+                this.player1.clickCard(this.nonUsableAttachment);
+
+                expect(this.nonUsableAttachment.kneeled).toBe(false);
+            });
+
+            it('does not move the attachment', function() {
+                this.player1.clickCard(this.nonUsableAttachment);
+
+                expect(this.nonUsableAttachment.parent).toBe(this.otherCharacter);
+            });
+        });
+
+        describe('when the attachment is on Spare Boot already but is knelt', function() {
+            beforeEach(function() {
+                expect(this.spareBootAttachment.kneeled).toBe(false);
+
+                // Manually kneel the attachment
+                this.player1.clickCard(this.spareBootAttachment);
+
+                expect(this.spareBootAttachment.kneeled).toBe(true);
+
+                this.player1.clickMenu(this.spareBoot, 'Stand and move attachment');
+            });
+
+            it('allows selection of the attachment', function() {
+                expect(this.player1).toAllowSelect(this.spareBootAttachment);
+            });
+
+            it('stands the attachment', function() {
+                this.player1.clickCard(this.spareBootAttachment);
+
+                expect(this.spareBootAttachment.kneeled).toBe(false);
+            });
+
+            it('does not move the attachment', function() {
+                this.player1.clickCard(this.spareBootAttachment);
+
+                expect(this.spareBootAttachment.parent).toBe(this.spareBoot);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Spare Boot's ability is worded such that he can stand an attachment that
could not be moved to him (e.g. Seal of the Hand) or one that is already
attachment to him.