### PR TITLE
Add script to generate implementation status list

### DIFF
--- a/server/scripts/implementation-status.js
+++ b/server/scripts/implementation-status.js
@@ -1,0 +1,25 @@
+/*eslint no-console:0 */
+
+/**
+ * Script to generate a markdown based todo list, so that we can track card
+ * implementation status in Github issues.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const packCode = process.argv[2];
+
+if(!packCode) {
+    console.log('Usage: implementation-status.js PACK_CODE [PATH_TO_JSON_DATA]');
+    process.exit(1);
+}
+
+const pathToData = process.argv[3] || path.join(__dirname, '../../throneteki-json-data');
+const packData = JSON.parse(fs.readFileSync(path.join(pathToData, 'packs', packCode + '.json')));
+const implementedCards = require('../game/cards');
+
+for(let card of packData.cards) {
+    let checkedState = implementedCards[card.code] ? 'x' : ' ';
+    console.log(`* [${checkedState}] ${card.code} - [${card.name}](https://thronesdb.com/card/${card.code})`);
+}


### PR DESCRIPTION
This is a fuller version of the script I used to generate #2376 and #2377. Can be used to regenerate those lists once more card data has been entered while keeping the checkboxes checked for implemented cards.