### PR TITLE
Fix Grand Melee when adding/removing participants

### DIFF
--- a/server/game/cards/10-SoD/GrandMelee.js
+++ b/server/game/cards/10-SoD/GrandMelee.js
@@ -3,6 +3,9 @@ const PlotCard = require('../../plotcard.js');
 class GrandMelee extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
+            // Add always-on condition so that attacking / defending alone is
+            // rechecked after participants are added or removed from challenges
+            condition: () => true,
             match: card => this.game.isDuringChallenge({ attackingAlone: card }) || this.game.isDuringChallenge({ defendingAlone: card }),
             targetController: 'any',
             effect: ability.effects.doesNotContributeStrength()

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -39,11 +39,17 @@ function losesAspectEffect(aspect) {
 function challengeOptionEffect(key) {
     return function() {
         return {
-            apply: function(card) {
+            apply: function(card, context) {
                 card.challengeOptions.add(key);
+                if(context.game.currentChallenge) {
+                    context.game.currentChallenge.calculateStrength();
+                }
             },
-            unapply: function(card) {
+            unapply: function(card, context) {
                 card.challengeOptions.remove(key);
+                if(context.game.currentChallenge) {
+                    context.game.currentChallenge.calculateStrength();
+                }
             }
         };
     };

--- a/test/server/cards/10-SoD/GrandMelee.spec.js
+++ b/test/server/cards/10-SoD/GrandMelee.spec.js
@@ -1,0 +1,60 @@
+describe('Grand Melee', function() {
+    integration(function() {
+        describe('when removing a character from the challenge', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'Grand Melee', 'A Noble Cause',
+                    'Garden Caretaker', 'Garden Caretaker', 'Renly Baratheon (FFH)', 'Highgarden'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.smallAttacker = this.player1.findCardByName('Garden Caretaker', 'hand');
+                this.largeAttacker = this.player1.findCardByName('Renly Baratheon', 'hand');
+                this.defenders = this.player2.filterCardsByName('Garden Caretaker', 'hand');
+
+                this.player1.clickCard(this.smallAttacker);
+                this.player1.clickCard(this.largeAttacker);
+
+                for(let defender of this.defenders) {
+                    this.player2.clickCard(defender);
+                }
+                this.player2.clickCard('Highgarden', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Grand Melee');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.smallAttacker);
+                this.player1.clickCard(this.largeAttacker);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                for(let defender of this.defenders) {
+                    this.player2.clickCard(defender);
+                }
+                this.player2.clickPrompt('Done');
+
+                // Remove the smaller character to ensure that the opponent does
+                // not win with the remaining, stronger character.
+                this.player2.clickMenu('Highgarden', 'Remove character from challenge');
+                this.player2.clickCard(this.smallAttacker);
+                expect(this.game.currentChallenge.attackers).not.toContain(this.smallAttacker);
+            });
+
+            it('should not count STR for characters participating alone', function() {
+                expect(this.game.currentChallenge.attackerStrength).toBe(0);
+                expect(this.game.currentChallenge.defenderStrength).toBe(2);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Recalculates Grand Melee's effect after every game step in order to
ensure that its "does not contribute STR" effect is added or removed
when the number of participants change. Additionally, challenge strength
is now recalculated when the "does not contribute STR" effect is applied
to a card.

Fixes #2231 