### PR TITLE
Allow "pay X gold" prompts to have a 0 maximum

### DIFF
--- a/server/game/costs/XValuePrompt.js
+++ b/server/game/costs/XValuePrompt.js
@@ -13,7 +13,8 @@ class XValuePrompt extends BaseStep {
     }
 
     continue() {
-        if(this.max === 0 || this.min > this.max) {
+        if(this.min > this.max) {
+            this.resolveCost(this.max);
             return;
         }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -123,10 +123,6 @@ class PlayerInteractionWrapper {
             card = this.findCardByName(card, location);
         }
 
-        if(card.location === 'draw deck') {
-            throw new Error(`Cannot click on ${card.name} because it is in the ${card.location}.`);
-        }
-
         this.game.cardClicked(this.player.name, card.uuid);
         this.game.continue();
         this.checkUnserializableGameState();

--- a/test/server/cards/11.6-DitD/GiftsForTheWidow.spec.js
+++ b/test/server/cards/11.6-DitD/GiftsForTheWidow.spec.js
@@ -1,0 +1,49 @@
+describe('Gifts for the Widow', function() {
+    integration(function() {
+        describe('when the player has no gold', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Gifts for the Widow', 'Eddard Stark (Core)', 'Noble Lineage'
+                ]);
+
+                this.player1.togglePromptedActionWindow('draw', true);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Eddard Stark', 'hand');
+                this.player1.clickCard(this.character);
+
+                this.attachment = this.player1.findCardByName('Noble Lineage', 'hand');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                // Move Noble Lineage back into the deck for searching
+                this.player1.dragCard(this.attachment, 'draw deck');
+
+                // Play Gifts for the Widow during the draw phase action window
+                // when neither player has gold
+                this.player1.clickCard('Gifts for the Widow', 'hand');
+                this.player1.clickPrompt('0');
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.character);
+            });
+
+            it('works', function() {
+                expect(this.character.attachments).toContain(this.attachment);
+            });
+
+            it('allows the player to collect income', function() {
+                this.player2.clickPrompt('Pass');
+                this.player1.clickPrompt('Pass');
+
+                expect(this.player1Object.gold).toBe(5);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, if a card that had an X cost whose value could only be 0,
the prompt would be skipped without setting the `xValue` on the context
object. This lead to the player's gold becoming `NaN` for the rest of
the game with no way to recover. The most common scenario was playing
Gifts for the Widow while having no gold - you'd want to search for a 0
cost attachment but it would trigger the bug.

Now, the XValuePrompt will properly ask the player to choose the number,
even if it's only 0. As a safety measure, if the prompt is called with
an invalid range, it automatically resolve for the lower end of the
range to ensure an `xValue` is always set. While this would still be a
bug, it would be less catastrophic than rendering gold useless the rest
of the game.

Fixes #2419 