### PR TITLE
The Sordid Tale of Quentyn Martell continued

### DIFF
--- a/server/game/cards/01-Core/RisenFromTheSea.js
+++ b/server/game/cards/01-Core/RisenFromTheSea.js
@@ -47,7 +47,7 @@ class RisenFromTheSea extends DrawCard {
     }
 
     canSurviveBurn(card) {
-        return card.controller.canAttach(this, card) && card.getBoostedStrength(1 + card.burnValue) > 0;
+        return card.controller.canAttach(this, card) && card.getBoostedStrength(1) > 0;
     }
 
     // Explicitly override since it has printed type 'event'.

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -22,7 +22,6 @@ class DrawCard extends BaseCard {
         }
 
         this.power = 0;
-        this.burnValue = 0;
         this.strengthModifier = 0;
         this.strengthMultiplier = 1;
         this.strengthSet = undefined;
@@ -185,23 +184,18 @@ class DrawCard extends BaseCard {
     }
 
     modifyStrength(amount, applying = true) {
-        if(this.isBurning && this.burnValue === 0 && this.getBoostedStrength(amount) <= 0) {
-            this.burnValue = amount;
-            this.game.killCharacter(this, { allowSave: false, isBurn: true });
-            this.game.queueSimpleStep(() => {
-                this.strengthModifier += amount;
-                this.burnValue = 0;
-            });
-            return;
-        }
-
         this.strengthModifier += amount;
 
         if(!this.strengthSet) {
-            this.game.raiseEvent('onCardStrengthChanged', {
+            let params = {
                 card: this,
                 amount: amount,
                 applying: applying
+            };
+            this.game.raiseEvent('onCardStrengthChanged', params, () => {
+                if(this.isBurning && this.getStrength() <= 0) {
+                    this.game.killCharacter(this, { allowSave: false, isBurn: true });
+                }
             });
         }
     }

--- a/test/server/integration/burneffects.spec.js
+++ b/test/server/integration/burneffects.spec.js
@@ -188,21 +188,10 @@ describe('burn effects', function() {
                     this.player2.clickCard('Dracarys!', 'hand');
                     this.player2.clickCard(this.dragon);
                     this.player2.clickCard(this.quentyn);
-
-                    // 4 base = 4 remaining when Dracarys'ed
-                    expect(this.quentyn.getStrength()).toBe(4);
-
-                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
-                it('should not allow a 4 STR character to be killed', function() {
-                    this.player1.clickCard(this.str4);
-                    expect(this.str4.location).toBe('play area');
-                });
-
-                it('should allow a 3 STR character to be killed', function() {
-                    this.player1.clickCard(this.str3);
-                    expect(this.str3.location).toBe('dead pile');
+                it('should die at STR 0', function() {
+                    expect(this.player1).not.toAllowAbilityTrigger('Quentyn Martell');
                 });
             });
 
@@ -221,21 +210,10 @@ describe('burn effects', function() {
                     this.player2.clickCard('Dracarys!', 'hand');
                     this.player2.clickCard(this.dragon);
                     this.player2.clickCard(this.quentyn);
-
-                    // 4 base + 1 Song of Summer - 1 Blood of Dragon = 4 remaining when Dracarys'ed
-                    expect(this.quentyn.getStrength()).toBe(4);
-
-                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
-                it('should not allow a 4 STR character to be killed', function() {
-                    this.player1.clickCard(this.str4);
-                    expect(this.str4.location).toBe('play area');
-                });
-
-                it('should allow a 3 STR character to be killed', function() {
-                    this.player1.clickCard(this.str3);
-                    expect(this.str3.location).toBe('dead pile');
+                it('should die at STR 0', function() {
+                    expect(this.player1).not.toAllowAbilityTrigger('Quentyn Martell');
                 });
             });
 
@@ -261,21 +239,10 @@ describe('burn effects', function() {
                     this.player2.clickCard('Dracarys!', 'hand');
                     this.player2.clickCard(this.dragon);
                     this.player2.clickCard(this.quentyn);
-
-                    // 4 base + 1 Song of Summer - 2 Astapor = 3 remaining when Dracarys'ed
-                    expect(this.quentyn.getStrength()).toBe(3);
-
-                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
-                it('should not allow a 3 STR character to be killed', function() {
-                    this.player1.clickCard(this.str3);
-                    expect(this.str3.location).toBe('play area');
-                });
-
-                it('should allow a 2 STR character to be killed', function() {
-                    this.player1.clickCard(this.str2);
-                    expect(this.str2.location).toBe('dead pile');
+                it('should die at STR 0', function() {
+                    expect(this.player1).not.toAllowAbilityTrigger('Quentyn Martell');
                 });
             });
 
@@ -301,21 +268,10 @@ describe('burn effects', function() {
                     this.player1.clickPrompt('Pass');
                     this.player2.clickMenu(this.astapor, 'Give character -STR');
                     this.player2.clickCard(this.quentyn);
-
-                    // 4 base + 1 Song of Summer - 4 Dracarys! = 1 remaining when Astapor'ed
-                    expect(this.quentyn.getStrength()).toBe(1);
-
-                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
-                it('should not allow a 1 STR character to be killed', function() {
-                    this.player1.clickCard(this.str1);
-                    expect(this.str1.location).toBe('play area');
-                });
-
-                it('should allow a 0 STR character to be killed', function() {
-                    this.player1.clickCard(this.str0);
-                    expect(this.str0.location).toBe('dead pile');
+                it('should die at STR 0', function() {
+                    expect(this.player1).not.toAllowAbilityTrigger('Quentyn Martell');
                 });
             });
         });


### PR DESCRIPTION
Before October 2017, it was ruled that characters killed by burn would
die at their STR before the burn was applied. For example, Quentyn
Martell killed by Dracarys! would be able to trigger his ability to
target a character with less than 4 STR.

Then it was re-ruled in FAQ 1.2 that they should die at STR 0 after all,
as would be common sense. I guess it's about time we changed it back?

Fixes #1643 