### PR TITLE
Activate non-play-area effects for /add-card

### DIFF
--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -457,6 +457,8 @@ class ChatCommands {
         let deck = new Deck();
         let preparedCard = deck.createCard(player, card);
 
+        preparedCard.applyAnyLocationPersistentEffects();
+
         if(deck.isDrawCard(card)) {
             player.moveCard(preparedCard, 'draw deck');
         } else if(deck.isPlotCard(card)) {


### PR DESCRIPTION
Previously, persistent effects for a card that are normally activated
during the setup phase were not being activated when adding a new card
mid-game via `/add-card`. This made cards like Sansa Stark (Core)
created via `/add-card` not enter play knelt properly.

Fixes #2388 