### PR TITLE
Change Risen / BMR text to lasting effect

### DIFF
--- a/server/game/cards/01-Core/RisenFromTheSea.js
+++ b/server/game/cards/01-Core/RisenFromTheSea.js
@@ -1,7 +1,7 @@
 const DrawCard = require('../../drawcard.js');
 
 class RisenFromTheSea extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.interrupt({
             canCancel: true,
             when: {
@@ -23,14 +23,17 @@ class RisenFromTheSea extends DrawCard {
                             ability.effects.addTrait('Condition')
                         ]
                     }));
+
+                    this.lastingEffect(ability => ({
+                        condition: () => this.location === 'play area',
+                        targetLocation: 'any',
+                        match: card => card === this.parent,
+                        effect: ability.effects.modifyStrength(1)
+                    }));
                 }
 
                 this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.event.card);
             }
-        });
-
-        this.whileAttached({
-            effect: ability.effects.modifyStrength(1)
         });
     }
 

--- a/server/game/cards/02.5-COW/BloodMagicRitual.js
+++ b/server/game/cards/02.5-COW/BloodMagicRitual.js
@@ -1,7 +1,7 @@
 const DrawCard = require('../../drawcard.js');
 
 class BloodMagicRitual extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.interrupt({
             canCancel: true,
             when: {
@@ -25,12 +25,15 @@ class BloodMagicRitual extends DrawCard {
                     }));
                 }
 
+                this.lastingEffect(ability => ({
+                    condition: () => this.location === 'play area',
+                    targetLocation: 'any',
+                    match: card => card === this.parent,
+                    effect: ability.effects.blankExcludingTraits
+                }));
+
                 this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.event.card);
             }
-        });
-
-        this.whileAttached({
-            effect: ability.effects.blankExcludingTraits
         });
     }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -180,6 +180,12 @@ class PlayerInteractionWrapper {
         this.checkUnserializableGameState();
     }
 
+    sendChat(text) {
+        this.game.chat(this.player.name, text);
+        this.game.continue();
+        this.checkUnserializableGameState();
+    }
+
     discardToReserve() {
         let needsDiscard = this.player.hand.length - this.player.getTotalReserve();
         for(let i = 0; i < needsDiscard; ++i) {

--- a/test/server/cards/01-Core/RisenFromTheSea.spec.js
+++ b/test/server/cards/01-Core/RisenFromTheSea.spec.js
@@ -144,4 +144,55 @@ describe('Risen from the Sea', function() {
             });
         });
     });
+
+    integration(function() {
+        describe('when blanked', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('greyjoy', [
+                    'A Noble Cause',
+                    'Theon Greyjoy (Core)', 'Risen from the Sea'
+                ]);
+                const deck2 = this.buildDeck('targaryen', [
+                    'A Noble Cause',
+                    'House Tully Septon', 'Brother\'s Robes'
+                ]);
+
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Theon Greyjoy');
+                this.risen = this.player1.findCardByName('Risen from the Sea');
+
+                this.sevenCharacter = this.player2.findCardByName('House Tully Septon');
+                this.robes = this.player2.findCardByName('Brother\'s Robes');
+
+                this.player1.clickCard(this.character);
+                this.player2.clickCard(this.sevenCharacter);
+                this.player2.clickCard(this.robes);
+
+                this.completeSetup();
+
+                this.player2.clickCard(this.robes);
+                this.player2.clickCard(this.sevenCharacter);
+
+                this.selectFirstPlayer(this.player1);
+
+                // Kill Theon to trigger Risen
+                this.player1.sendChat('/kill');
+                this.player1.clickCard(this.character);
+                this.player1.triggerAbility(this.risen);
+
+                // Kneel The Seven character to trigger Brother's Robes
+                this.player2.clickCard(this.sevenCharacter);
+                this.player2.triggerAbility(this.robes);
+                this.player2.clickCard(this.risen);
+            });
+
+            it('does not remove the +1 STR bonus', function() {
+                expect(this.character.getStrength()).toBe(4);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Previously, the +1 STR effect on Risen from the Sea and the blanking
effect on Blood Magic Ritual were implemented as persistence effects.
This resulted in losing the effect when blanked by Brother's Robes,
which should only blank printed text and not gained text.

Now these effects are implemented as lasting effects that are active
while the cards remain in play.

Fixes #2433 