### PR TITLE
Prevent Watch Has Need when player has 0 reserve

### DIFF
--- a/server/game/cards/02.1-TtB/TheWatchHasNeed.js
+++ b/server/game/cards/02.1-TtB/TheWatchHasNeed.js
@@ -4,6 +4,7 @@ class TheWatchHasNeed extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Search for a character',
+            condition: () => this.controller.getTotalReserve() > 0,
             handler: () => {
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {


### PR DESCRIPTION
Previously, triggering The Watch Has Need while you had 0 reserve would
allow you to search your entire deck for NW characters. This is because
the select prompt views `numCards: 0` as being able to select unlimited
cards. Now, Watch Has Need cannot be triggered because it isn't possible
to search through the top 0 cards of your deck.