### PR TITLE
Use `context.player` on Gate locations

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -134,7 +134,7 @@ class CardAction extends BaseAbility {
             return false ;
         }
 
-        if(this.condition && !this.condition()) {
+        if(this.condition && !this.condition(context)) {
             return false;
         }
 

--- a/server/game/cards/13.1-AtG/DragonGate.js
+++ b/server/game/cards/13.1-AtG/DragonGate.js
@@ -8,19 +8,19 @@ class DragonGate extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.getCardCount() >= 2,
+            condition: context => this.getCardCount(context.player) >= 2,
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
                 this.game.addMessage('{0} sacrifices {1} to draw {2}',
-                    this.controller, this, TextHelper.count(cards, 'card'));
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }
 
-    getCardCount() {
-        return this.controller.getNumberOfCardsInPlay(card => ['attachment'].includes(card.getType()));
+    getCardCount(player) {
+        return player.getNumberOfCardsInPlay(card => ['attachment'].includes(card.getType()));
     }
 }
 

--- a/server/game/cards/13.1-AtG/FleaBottomAlley.js
+++ b/server/game/cards/13.1-AtG/FleaBottomAlley.js
@@ -7,8 +7,14 @@ class FleaBottomAlley extends DrawCard {
             title: 'Put character into play',
             phase: 'marshal',
             target: {
-                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.isFaction('thenightswatch') &&
-                                       card.getType() === 'character' && card.getPrintedCost() <= 3 && this.controller.canPutIntoPlay(card)
+                cardCondition: (card, context) => (
+                    card.location === 'hand' &&
+                    card.controller === context.player &&
+                    card.isFaction('thenightswatch') &&
+                    card.getType() === 'character' &&
+                    card.getPrintedCost() <= 3 &&
+                    context.player.canPutIntoPlay(card)
+                )
             },
             cost: [
                 ability.costs.kneelSelf(),
@@ -16,7 +22,7 @@ class FleaBottomAlley extends DrawCard {
             ],
             handler: context => {
                 context.player.putIntoPlay(context.target);
-                let cards = this.controller.drawCardsToHand(1).length;
+                let cards = context.player.drawCardsToHand(1).length;
                 this.game.addMessage('{0} kneels and sacrifice {1} to put {2} into play from their hand and to draw {3} to hand',
                     context.player, this, context.target, TextHelper.count(cards, 'card'));
             }

--- a/server/game/cards/13.1-AtG/GateOfTheGods.js
+++ b/server/game/cards/13.1-AtG/GateOfTheGods.js
@@ -8,23 +8,23 @@ class GateOfTheGods extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.characterWithHighestStrength(),
+            condition: context => this.characterWithHighestStrength(context.player),
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
-                this.game.addMessage('{0} sacrifices {1} to draw {2}', 
-                    this.controller, this, TextHelper.count(cards, 'card'));
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
+                this.game.addMessage('{0} sacrifices {1} to draw {2}',
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }
 
-    characterWithHighestStrength() {
+    characterWithHighestStrength(player) {
         let charactersInPlay = this.game.filterCardsInPlay(card => card.getType() === 'character');
         let strengths = charactersInPlay.map(card => card.getStrength());
         let highestStrength = Math.max(...strengths);
 
-        return this.controller.anyCardsInPlay(card => card.getType() === 'character' && card.getStrength() >= highestStrength);
+        return player.anyCardsInPlay(card => card.getType() === 'character' && card.getStrength() >= highestStrength);
     }
 }
 

--- a/server/game/cards/13.1-AtG/IronGate.js
+++ b/server/game/cards/13.1-AtG/IronGate.js
@@ -8,13 +8,13 @@ class IronGate extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.controller.firstPlayer,
+            condition: context => context.player.firstPlayer,
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
                 this.game.addMessage('{0} sacrifices {1} to draw {2}',
-                    this.controller, this, TextHelper.count(cards, 'card'));
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }

--- a/server/game/cards/13.1-AtG/KingsGate.js
+++ b/server/game/cards/13.1-AtG/KingsGate.js
@@ -8,13 +8,13 @@ class KingsGate extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.controller.faction.power >= 5,
+            condition: context => context.player.faction.power >= 5,
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
-                this.game.addMessage('{0} sacrifices {1} to draw {2}', 
-                    this.controller, this, TextHelper.count(cards, 'card'));
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
+                this.game.addMessage('{0} sacrifices {1} to draw {2}',
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }

--- a/server/game/cards/13.1-AtG/LionGate.js
+++ b/server/game/cards/13.1-AtG/LionGate.js
@@ -8,13 +8,13 @@ class LionGate extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.controller.shadows.length >= 2,
+            condition: context => context.player.shadows.length >= 2,
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
                 this.game.addMessage('{0} sacrifices {1} to draw {2}',
-                    this.controller, this, TextHelper.count(cards, 'card'));
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }

--- a/server/game/cards/13.1-AtG/OldGate.js
+++ b/server/game/cards/13.1-AtG/OldGate.js
@@ -8,20 +8,20 @@ class OldGate extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.allCharactersHaveStarkAffiliation(),
+            condition: context => this.allCharactersHaveStarkAffiliation(context.player),
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
             handler: () => {
                 let cards = this.controller.drawCardsToHand(2).length;
-                this.game.addMessage('{0} sacrifices {1} to draw {2}', 
+                this.game.addMessage('{0} sacrifices {1} to draw {2}',
                     this.controller, this, TextHelper.count(cards, 'card'));
             }
         });
     }
 
-    allCharactersHaveStarkAffiliation() {
-        return (this.controller.getNumberOfCardsInPlay(card => card.getType() === 'character')
-            === this.controller.getNumberOfCardsInPlay(card => card.getType() === 'character' && card.isFaction('stark')));
+    allCharactersHaveStarkAffiliation(player) {
+        return (player.getNumberOfCardsInPlay(card => card.getType() === 'character')
+            === player.getNumberOfCardsInPlay(card => card.getType() === 'character' && card.isFaction('stark')));
     }
 }
 

--- a/server/game/cards/13.1-AtG/RiverGate.js
+++ b/server/game/cards/13.1-AtG/RiverGate.js
@@ -8,19 +8,19 @@ class RiverGate extends DrawCard {
         });
         this.action({
             title: 'Sacrifice to draw 2 cards',
-            condition: () => this.hasLost2Challenges(),
+            condition: context => this.hasLost2Challenges(context.player),
             phase: 'challenge',
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
                 this.game.addMessage('{0} sacrifices {1} to draw {2}',
-                    this.controller, this, TextHelper.count(cards, 'card'));
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }
 
-    hasLost2Challenges() {
-        return this.controller.challenges.countChallenges(challenge => challenge.loser === this.controller) >= 2;
+    hasLost2Challenges(player) {
+        return player.challenges.countChallenges(challenge => challenge.loser === player) >= 2;
     }
 }
 


### PR DESCRIPTION
Because the Gate cards from At the Gates sacrifice themselves as a cost,
they *must* refer to `context.player` instead of `this.controller`
because the controller does not reflect the player that controlled the
card before sacrifice.

Also pass `context` to `condition` methods to further reduce the usages
of `this.controller`.

Fixes #2468 