### PR TITLE
Send plain text log to Sentry

### DIFF
--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -111,7 +111,7 @@ class GameServer {
             debugData.game = gameState;
             debugData.game.players = undefined;
 
-            debugData.messages = game.messages;
+            debugData.messages = game.getPlainTextLog();
             debugData.game.messages = undefined;
 
             _.each(game.getPlayers(), player => {


### PR DESCRIPTION
The plain text log is easier to read than the rich-object array the
messages are actually represented with.