### PR TITLE
Improve messages for the plot phase

### DIFF
--- a/server/game/gamesteps/ForcedTriggeredAbilityWindow.js
+++ b/server/game/gamesteps/ForcedTriggeredAbilityWindow.js
@@ -48,7 +48,7 @@ class ForcedTriggeredAbilityWindow extends BaseAbilityWindow {
             return false;
         }
         if(this.abilityType === 'whenrevealed') {
-            this.game.addMessage('{0} has chosen to resolve first the when revealed ability of {1}\'s {2}',
+            this.game.addMessage('{0} chooses to resolve {1}\'s {2}',
                 player, choice.player.name, choice.card);
         }
 

--- a/server/game/gamesteps/revealplots.js
+++ b/server/game/gamesteps/revealplots.js
@@ -15,6 +15,9 @@ class RevealPlots extends BaseStep {
     }
 
     continue() {
+        for(let plot of this.plots) {
+            this.game.addMessage('{0} reveals {1}', plot.controller, plot);
+        }
         let event = this.generateEvent(this.plots);
         if(this.parentEvent) {
             this.parentEvent.thenAttachEvent(event);


### PR DESCRIPTION
* Adds a message announcing which plot each player has revealed to make
  it easier to follow the game within the log
* Simplifies the message when first player chooses the order of
  resolution for plots