### PR TITLE
Filter out null target selections

### DIFF
--- a/server/game/gamesteps/ResolvedTargets.js
+++ b/server/game/gamesteps/ResolvedTargets.js
@@ -35,7 +35,7 @@ class ResolvedTargets {
     }
 
     getTargets() {
-        let targetingSelections = this.selections.filter(selection => selection.targetingType === 'choose');
+        let targetingSelections = this.selections.filter(selection => selection.resolved && selection.hasValue() && selection.targetingType === 'choose');
         return flatten(targetingSelections.map(selection => selection.value));
     }
 

--- a/test/server/ResolvedTargets.spec.js
+++ b/test/server/ResolvedTargets.spec.js
@@ -1,0 +1,78 @@
+const ResolvedTargets = require('../../server/game/gamesteps/ResolvedTargets');
+const AbilityChoiceSelection = require('../../server/game/AbilityChoiceSelection');
+
+describe('ResolvedTargets', function () {
+    beforeEach(function () {
+        this.targets = new ResolvedTargets();
+    });
+
+    describe('getTargets()', function() {
+        describe('when the targeting type is "select"', function() {
+            beforeEach(function() {
+                let choice = new AbilityChoiceSelection({
+                    name: 'target',
+                    choosingPlayer: 'PLAYER',
+                    eligibleChoices: ['a', 'b'],
+                    targetingType: 'select'
+                });
+                choice.resolve('b');
+                this.targets.setSelections([choice]);
+            });
+
+            it('does not include it', function() {
+                expect(this.targets.getTargets()).toEqual([]);
+            });
+        });
+
+        describe('when the targeting type is "choose"', function() {
+            beforeEach(function() {
+                this.choice1 = new AbilityChoiceSelection({
+                    name: 'target',
+                    choosingPlayer: 'PLAYER',
+                    eligibleChoices: ['a', 'b'],
+                    targetingType: 'choose'
+                });
+                this.choice2 = new AbilityChoiceSelection({
+                    name: 'target',
+                    choosingPlayer: 'PLAYER',
+                    eligibleChoices: ['a', 'b'],
+                    targetingType: 'choose'
+                });
+
+                this.choice1.resolve('b');
+            });
+
+            describe('and the choice was rejected', function() {
+                beforeEach(function() {
+                    this.choice2.reject();
+                    this.targets.setSelections([this.choice1, this.choice2]);
+                });
+
+                it('excludes the value', function() {
+                    expect(this.targets.getTargets()).toEqual(['b']);
+                });
+            });
+
+            describe('and the choice has not been resolved', function() {
+                beforeEach(function() {
+                    this.targets.setSelections([this.choice1, this.choice2]);
+                });
+
+                it('excludes the value', function() {
+                    expect(this.targets.getTargets()).toEqual(['b']);
+                });
+            });
+
+            describe('and the choice has been resovled', function() {
+                beforeEach(function() {
+                    this.choice2.resolve('a');
+                    this.targets.setSelections([this.choice1, this.choice2]);
+                });
+
+                it('excludes the value', function() {
+                    expect(this.targets.getTargets()).toEqual(['b', 'a']);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
In order to support "if able" and "each player" target selections, the
value of the selection now has to allow null. The ability cancellation
UI tries to display a list of chosen cards, but was crashing due to null
values being in the array.

Now, null selections and unresolved selections are filtered out of that
array.

Fixes THRONETEKI-2EV
Fixes THRONETEKI-2EZ