### PR TITLE
Fix Gates of the Moon w/ Riddle + AtG

### DIFF
--- a/server/game/cards/02.5-COW/PullingTheStrings.js
+++ b/server/game/cards/02.5-COW/PullingTheStrings.js
@@ -30,6 +30,7 @@ class PullingTheStrings extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', player, this, card);
         card.takeControl(player, this);
+        this.game.raiseEvent('onCardTakenControl', { card });
 
         let whenRevealed = card.getWhenRevealedAbility();
         if(whenRevealed) {
@@ -39,7 +40,7 @@ class PullingTheStrings extends PlotCard {
         }
         this.game.queueSimpleStep(() => {
             card.revertControl(this);
-
+            this.game.raiseEvent('onCardTakenControl', { card });
             this.resolving = false;
         });
 

--- a/server/game/cards/04.1-AtSK/VaryssRiddle.js
+++ b/server/game/cards/04.1-AtSK/VaryssRiddle.js
@@ -44,6 +44,7 @@ class VaryssRiddle extends PlotCard {
     resolveWhenRevealed(plot) {
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, plot);
         plot.takeControl(this.controller, this);
+        this.game.raiseEvent('onCardTakenControl', { card: plot });
         this.resolving = true;
 
         let whenRevealed = plot.getWhenRevealedAbility();
@@ -55,6 +56,7 @@ class VaryssRiddle extends PlotCard {
         this.game.queueSimpleStep(() => {
             this.resolving = false;
             plot.revertControl(this);
+            this.game.raiseEvent('onCardTakenControl', { card: plot });
         });
     }
 }

--- a/server/game/cards/04.6-TC/TyrionsChain.js
+++ b/server/game/cards/04.6-TC/TyrionsChain.js
@@ -51,6 +51,7 @@ class TyrionsChain extends DrawCard {
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, warPlot);
         warPlot.takeControl(this.controller, this);
+        this.game.raiseEvent('onCardTakenControl', { card: warPlot });
 
         let whenRevealed = warPlot.getWhenRevealedAbility();
         if(whenRevealed) {
@@ -60,6 +61,7 @@ class TyrionsChain extends DrawCard {
         }
         this.game.queueSimpleStep(() => {
             warPlot.revertControl(this);
+            this.game.raiseEvent('onCardTakenControl', { card: warPlot });
             this.resolving = false;
         });
         return true;

--- a/test/server/cards/13.1-AtG/AtTheGates.spec.js
+++ b/test/server/cards/13.1-AtG/AtTheGates.spec.js
@@ -1,0 +1,39 @@
+describe('At The Gates', function() {
+    integration(function() {
+        describe('vs Varys Riddle + Gates of the Moon', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'At the Gates', 'Varys\'s Riddle',
+                    'Gates of the Moon'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.gates1 = this.player1.findCardByName('Gates of the Moon');
+                this.gates2 = this.player2.findCardByName('Gates of the Moon');
+
+                this.completeSetup();
+
+                // Draw the Gates back into the deck
+                this.player1.dragCard(this.gates1, 'draw deck');
+                this.player2.dragCard(this.gates2, 'draw deck');
+
+                this.player1.selectPlot('At the Gates');
+                this.player2.selectPlot('Varys\'s Riddle');
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard(this.gates1);
+
+                this.player2.clickCard(this.gates2);
+            });
+
+            it('modifies income correctly', function() {
+                expect(this.player1Object.getTotalIncome()).toBe(7);
+                expect(this.player2Object.getTotalIncome()).toBe(8);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Because Varys's Riddle is implemented to temporarily "take control" of
the plot, when At the Gates is copied and brings out a card that applies
an effect to opponent plot card (such as Gates of the Moon), the current
controller is incorrect and the effect isn't applied. Since Riddle
wasn't raising the `onCardTakenControl` event, the effect engine never
knew to recalculate the effect.

Fixes #2503 