### PR TITLE
Fixed Black Market Merchant Bug #2511

### DIFF
--- a/server/game/cards/13.2-CoS/BlackMarketMerchant.js
+++ b/server/game/cards/13.2-CoS/BlackMarketMerchant.js
@@ -11,7 +11,7 @@ class BlackMarketMerchant extends DrawCard {
                     numCards: 10,
                     activePromptTitle: 'Select an attachment',
                     cardCondition: card => card.getType() === 'attachment' && this.canAttachToControlledCharacter(context.player, card),
-                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onSelect: (player, card) => this.cardSelected(context, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this
                 });
@@ -23,10 +23,23 @@ class BlackMarketMerchant extends DrawCard {
         return player.anyCardsInPlay(card => card.getType() === 'character' && player.canAttach(attachment, card));
     }
 
-    cardSelected(player, card) {
-        player.putIntoPlay(card);
-        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play',
-            player, this, card);
+    cardSelected(context, attachment) {
+        this.game.addMessage('{0} uses {1} to search their deck and finds {2}',
+            context.player, this, attachment);
+        this.game.promptForSelect(context.player, {
+            activePromptTitle: 'Select target for attachment',
+            cardCondition: card => card.getType() === 'character' && card.controller === context.player && context.player.canAttach(attachment, card),
+            onSelect: (player, card) => {
+                this.game.addMessage('{0} puts {1} into play attached to {2}', context.player, attachment, card);
+                context.player.attach(context.player, attachment, card);
+                return true;
+            },
+            onCancel: () => {
+                this.game.addAlert('danger', '{0} does not put {1} into play', context.player, attachment);
+                return true;
+            },
+            source: this
+        });
     }
 
     doneSelecting(player) {


### PR DESCRIPTION
Fixes the Issue #2511
The problem was that the card was just put into play with no restrictions. This made it so you could target any card. I used the card 'Gifts for the Widow' as a reference as that seemed to work without the bug. To keep everything the same i changed a bit of the naming, so that it is in line with the other card.