### PR TITLE
Fix claim increase effects for FotS

### DIFF
--- a/server/game/cards/14-FotS/CapeWrath.js
+++ b/server/game/cards/14-FotS/CapeWrath.js
@@ -8,6 +8,7 @@ class CapeWrath extends DrawCard {
                 this.game.isDuringChallenge({ challengeType: 'power', defendingPlayer: this.controller })
             ),
             match: card => card === this.game.currentChallenge.attackingPlayer.activePlot,
+            targetController: 'any',
             effect: ability.effects.modifyClaim(1)
         });
     }

--- a/server/game/cards/14-FotS/DesperateAttack.js
+++ b/server/game/cards/14-FotS/DesperateAttack.js
@@ -5,6 +5,7 @@ class DesperateAttack extends PlotCard {
         this.persistentEffect({
             condition: () => this.game.isDuringChallenge({ defendingPlayer: this.controller }),
             match: card => card === this.game.currentChallenge.attackingPlayer.activePlot,
+            targetController: 'any',
             effect: ability.effects.modifyClaim(1)
         });
     }


### PR DESCRIPTION
Both Cape Wrath and Desperate Attack need to be explicitly applied to
any controller and not just the current one.

Fixes #2601 