### PR TITLE
Do not execute cancelled simultaneous events

### DIFF
--- a/server/game/SimultaneousEvents.js
+++ b/server/game/SimultaneousEvents.js
@@ -4,12 +4,16 @@ class SimultaneousEvents {
         this.postHandlers = [];
     }
 
+    get activeChildEvents() {
+        return this.childEvents.filter(event => !event.cancelled);
+    }
+
     addChildEvent(event) {
         this.childEvents.push(event);
     }
 
     emitTo(emitter, suffix) {
-        for(let event of this.childEvents) {
+        for(let event of this.activeChildEvents) {
             event.emitTo(emitter, suffix);
         }
     }
@@ -19,7 +23,7 @@ class SimultaneousEvents {
     }
 
     cancel() {
-        for(let event of this.childEvents) {
+        for(let event of this.activeChildEvents) {
             event.cancel();
         }
 
@@ -29,13 +33,13 @@ class SimultaneousEvents {
     }
 
     executeHandler() {
-        for(let event of this.childEvents) {
+        for(let event of this.activeChildEvents) {
             event.executeHandler();
         }
     }
 
     executePostHandler() {
-        for(let event of this.childEvents) {
+        for(let event of this.activeChildEvents) {
             event.executePostHandler();
         }
 
@@ -45,13 +49,13 @@ class SimultaneousEvents {
     }
 
     getConcurrentEvents() {
-        return this.childEvents.reduce((concurrentEvents, event) => {
+        return this.activeChildEvents.reduce((concurrentEvents, event) => {
             return concurrentEvents.concat(event.getConcurrentEvents());
         }, []);
     }
 
     getPrimaryEvent() {
-        return this.childEvents[0];
+        return this.activeChildEvents[0];
     }
 
     thenExecute(func) {
@@ -60,7 +64,7 @@ class SimultaneousEvents {
     }
 
     toString() {
-        return `simultaneous(${this.childEvents.map(e => e.toString()).join(', ')})`;
+        return `simultaneous(${this.activeChildEvents.map(e => e.toString()).join(', ')})`;
     }
 }
 

--- a/test/server/SimultaneousEvents.spec.js
+++ b/test/server/SimultaneousEvents.spec.js
@@ -1,5 +1,5 @@
 const SimultaneousEvents = require('../../server/game/SimultaneousEvents');
-const Event = require('../../server/game/Event');
+const Event = require('../../server/game/event');
 
 describe('SimultaneousEvents', function() {
     beforeEach(function() {

--- a/test/server/SimultaneousEvents.spec.js
+++ b/test/server/SimultaneousEvents.spec.js
@@ -1,0 +1,116 @@
+const SimultaneousEvents = require('../../server/game/SimultaneousEvents');
+const Event = require('../../server/game/Event');
+
+describe('SimultaneousEvents', function() {
+    beforeEach(function() {
+        this.childEvent1 = new Event('event1');
+        this.childEvent2 = new Event('event2');
+        this.childEvent3 = new Event('event3');
+
+        this.event = new SimultaneousEvents();
+        this.event.addChildEvent(this.childEvent1);
+        this.event.addChildEvent(this.childEvent2);
+        this.event.addChildEvent(this.childEvent3);
+
+        // Explicitly cancel one of the events to ensure it is excluded from
+        // operations
+        this.childEvent2.cancel();
+    });
+
+    describe('emitTo', function() {
+        beforeEach(function() {
+            this.emitter = jasmine.createSpyObj('emitter', ['emit']);
+            this.event.emitTo(this.emitter, 'suffix');
+        });
+
+        it('should call emitTo on all non-cancelled children', function() {
+            expect(this.emitter.emit).toHaveBeenCalledWith('event1:suffix', jasmine.any(Object));
+            expect(this.emitter.emit).not.toHaveBeenCalledWith('event2:suffix', jasmine.any(Object));
+            expect(this.emitter.emit).toHaveBeenCalledWith('event3:suffix', jasmine.any(Object));
+        });
+    });
+
+    describe('executeHandler', function() {
+        beforeEach(function() {
+            spyOn(this.childEvent1, 'executeHandler');
+            spyOn(this.childEvent2, 'executeHandler');
+            spyOn(this.childEvent3, 'executeHandler');
+            this.event.executeHandler();
+        });
+
+        it('should call executeHandler on all children', function() {
+            expect(this.childEvent1.executeHandler).toHaveBeenCalled();
+            expect(this.childEvent2.executeHandler).not.toHaveBeenCalled();
+            expect(this.childEvent3.executeHandler).toHaveBeenCalled();
+        });
+    });
+
+    describe('cancel', function() {
+        beforeEach(function() {
+            this.event.cancel();
+        });
+
+        it('should mark the event as cancelled', function() {
+            expect(this.event.cancelled).toBe(true);
+        });
+
+        it('should mark the child events as cancelled', function() {
+            expect(this.childEvent1.cancelled).toBe(true);
+            expect(this.childEvent2.cancelled).toBe(true);
+            expect(this.childEvent3.cancelled).toBe(true);
+        });
+
+        describe('when the event has a parent', function() {
+            beforeEach(function() {
+                this.parentEventSpy = jasmine.createSpyObj('parentEvent', ['onChildCancelled']);
+                this.event.parent = this.parentEventSpy;
+                this.event.cancel();
+            });
+
+            it('should notify the parent', function() {
+                expect(this.parentEventSpy.onChildCancelled).toHaveBeenCalledWith(this.event);
+            });
+        });
+    });
+
+    xdescribe('addChildEvent', function() {
+        beforeEach(function() {
+            this.childEvent1.params = { prop1: 'foo', prop2: 'bar' };
+            this.event = new SimultaneousEvents();
+            this.event.addChildEvent(this.childEvent1);
+        });
+
+        it('should add the child to the list of children', function() {
+            expect(this.event.childEvents).toContain(this.childEvent1);
+        });
+
+        it('should set the parent for the child', function() {
+            expect(this.childEvent1.parent).toBe(this.event);
+        });
+
+        it('should extend any properties of the child onto the event', function() {
+            expect(this.event.prop1).toBe('foo');
+            expect(this.event.prop2).toBe('bar');
+        });
+    });
+
+    xdescribe('onChildCancelled', function() {
+        beforeEach(function() {
+            this.event.onChildCancelled(this.childEvent1);
+        });
+
+        it('should cancel all other children', function() {
+            expect(this.childEvent2.cancel).toHaveBeenCalled();
+        });
+
+        it('should remove all child events', function() {
+            expect(this.event.childEvents).toEqual([]);
+        });
+    });
+
+    describe('getConcurrentEvents', function() {
+        it('should return an array with the concurrent events of the children', function() {
+            expect(this.event.getConcurrentEvents()).toEqual([this.childEvent1, this.childEvent3]);
+        });
+    });
+});


### PR DESCRIPTION
This should fix the issue with dupes not properly saving vs Poltical
Disaster, Varys (Core), and other simultaneous discards.

The SimultaneousEvents class groups together a series of events for
simultaneous execution. However, if one of those events is cancelled, it
should not be executed. The Event class itself achieves this by marking
a `parent` event object and notifying the parent to remove the event
upon cancellation. This mechanism is not directly possible with
simultaneous events because each event may have its own parent already.

Now, the SimultaneousEvents class will manually filter through cancelled
child events to ensure that they are properly excluded.

Progress towards #2600 