### PR TITLE
Limit STR boost for Dothraki Steed

### DIFF
--- a/server/game/cards/14-FotS/DothrakiSteed.js
+++ b/server/game/cards/14-FotS/DothrakiSteed.js
@@ -5,6 +5,7 @@ class DothrakiSteed extends DrawCard {
         this.attachmentRestriction(card => card.getType() === 'character' && card.attachments.every(attachment => attachment === this || attachment.name !== 'Dothraki Steed'));
 
         this.whileAttached({
+            condition: () => this.isAttacking(),
             effect: ability.effects.dynamicStrength(() => this.getSTR())
         });
     }


### PR DESCRIPTION
It should only be active while the attached character is attacking.

Fixes #2609 