### PR TITLE
Fixes for Azor Ahai Reborn

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -166,10 +166,6 @@ class Challenge {
         }
     }
 
-    getStealthAttackers() {
-        return this.attackers.filter(card => card.needsStealthTarget());
-    }
-
     determineWinner() {
         this.calculateStrength();
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -279,10 +279,6 @@ class DrawCard extends BaseCard {
         this.icons.remove(icon);
     }
 
-    needsStealthTarget() {
-        return this.isStealth() && !this.stealthTarget;
-    }
-
     canUseStealthToBypass(targetCard) {
         return this.isStealth() && targetCard.canBeBypassedByStealth();
     }

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -11,6 +11,7 @@ class ChallengeFlow extends BaseStep {
     constructor(game, challenge) {
         super(game);
         this.challenge = challenge;
+        this.declaredAttackers = [];
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SimpleStep(this.game, () => this.resetCards()),
@@ -73,6 +74,7 @@ class ChallengeFlow extends BaseStep {
             return;
         }
 
+        this.declaredAttackers = attackers;
         this.attackersToKneel = [];
         this.challenge.addAttackers(attackers);
 
@@ -89,7 +91,8 @@ class ChallengeFlow extends BaseStep {
     }
 
     chooseStealthTargets() {
-        this.game.queueStep(new ChooseStealthTargets(this.game, this.challenge, this.challenge.getStealthAttackers()));
+        const stealthAttackers = this.declaredAttackers.filter(card => card.isStealth());
+        this.game.queueStep(new ChooseStealthTargets(this.game, this.challenge, stealthAttackers));
     }
 
     initiateChallenge() {
@@ -100,7 +103,7 @@ class ChallengeFlow extends BaseStep {
             { name: 'onAttackersDeclared', params: { challenge: this.challenge } }
         ];
 
-        let attackerEvents = this.challenge.attackers.map(card => {
+        let attackerEvents = this.declaredAttackers.map(card => {
             return { name: 'onDeclaredAsAttacker', params: { card: card } };
         });
 

--- a/test/server/cards/14-FotS/AzorAhaiReborn.spec.js
+++ b/test/server/cards/14-FotS/AzorAhaiReborn.spec.js
@@ -1,0 +1,46 @@
+describe('Azor Ahai Reborn', function() {
+    integration(function() {
+        describe('when the character has stealth', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('baratheon', [
+                    'A Noble Cause',
+                    'Fiery Followers', 'Maester Wendamyr', 'Azor Ahai Reborn'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Maester Wendamyr');
+                this.attachment = this.player1.findCardByName('Azor Ahai Reborn');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard('Fiery Followers', 'hand');
+
+                // Setup a character that can be bypassed by stealth, otherwise
+                // the prompt won't trigger.
+                this.player2.clickCard('Fiery Followers', 'hand');
+
+                this.completeSetup();
+
+                // Place attachments
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.character);
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard('Fiery Followers', 'play area');
+                this.player1.clickPrompt('Done');
+            });
+
+            it('does not prompt for stealth', function() {
+                expect(this.game.currentChallenge.attackers).toContain(this.character);
+                expect(this.player1).not.toHavePrompt('Select stealth target for Maester Wendamyr');
+            });
+        });
+    });
+});

--- a/test/server/cards/14-FotS/AzorAhaiReborn.spec.js
+++ b/test/server/cards/14-FotS/AzorAhaiReborn.spec.js
@@ -1,5 +1,52 @@
 describe('Azor Ahai Reborn', function() {
     integration(function() {
+        describe('when the only other R\'hllor character is remove from the challenge', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('baratheon', [
+                    'A Noble Cause',
+                    'Fiery Followers', 'Maester Wendamyr', 'Azor Ahai Reborn', 'Highgarden'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.rhllor = this.player1.findCardByName('Fiery Followers');
+                this.character = this.player1.findCardByName('Maester Wendamyr');
+                this.attachment = this.player1.findCardByName('Azor Ahai Reborn');
+                this.highgarden = this.player2.findCardByName('Highgarden');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.rhllor);
+                this.player2.clickCard(this.highgarden);
+
+                this.completeSetup();
+
+                // Place attachments
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.character);
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard('Fiery Followers', 'play area');
+                this.player1.clickPrompt('Done');
+
+                this.player1.clickPrompt('Pass');
+            });
+
+            it('removes the attached character from the challenge', function() {
+                // Remove the declared attacker from the challenge
+                this.player2.clickMenu(this.highgarden, 'Remove character from challenge');
+                this.player2.clickCard(this.rhllor);
+
+                expect(this.game.currentChallenge.attackers).toEqual([]);
+            });
+        });
+
         describe('when the character has stealth', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('baratheon', [


### PR DESCRIPTION
Limits stealth character to those declared as attackers, and adds a test around removing the only other R'hllor character to ensure Azor Ahai gets kicked out of the challenge.

Fixes #2644 
Fixes #2594 