### PR TITLE
add attachmentRestriction for Ruby of R'hllor

### DIFF
--- a/server/game/cards/04.1-AtSK/RubyOfRhllor.js
+++ b/server/game/cards/04.1-AtSK/RubyOfRhllor.js
@@ -2,6 +2,9 @@ const DrawCard = require('../../drawcard.js');
 
 class RubyOfRhllor extends DrawCard {
     setupCardAbilities() {
+        this.attachmentRestriction(
+            { trait: 'R\'hllor' }
+        );
         this.reaction({
             when: {
                 afterChallenge: event =>


### PR DESCRIPTION
The card was missing the attachmentRestriction so it can only be attached to R'hllor characters
Closes #2659 