### PR TITLE
Allow event abilities to trigger from draw deck

### DIFF
--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -120,8 +120,10 @@ class TriggeredAbility extends BaseAbility {
         // game events in all open information locations plus while in hand.
         // The location property of the ability will prevent it from firing in
         // inappropriate locations when requirements are checked for the ability.
+        //
+        // Also apparently the draw deck because of Maester Gormon.
         if(this.isPlayableEventAbility()) {
-            return ['discard pile', 'hand', 'shadows', 'play area'].includes(location);
+            return ['discard pile', 'draw deck', 'hand', 'shadows', 'play area'].includes(location);
         }
 
         return this.location.includes(location);

--- a/test/server/cards/13.3-PoS/MaesterGormon.spec.js
+++ b/test/server/cards/13.3-PoS/MaesterGormon.spec.js
@@ -1,0 +1,41 @@
+describe('Maester Gormon', function() {
+    integration(function() {
+        describe('playing events from top of deck', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'A Noble Cause',
+                    'Maester Gormon', 'The Hand\'s Judgment',
+                    'Margaery Tyrell (Core)', 'Growing Strong'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.topDeckEvent = this.player1.findCardByName('The Hand\'s Judgment');
+                this.opponentChar = this.player2.findCardByName('Margaery Tyrell');
+                this.opponentEvent = this.player2.findCardByName('Growing Strong');
+
+                this.player1.clickCard('Maester Gormon', 'hand');
+                this.player2.clickCard(this.opponentChar);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player2);
+                this.completeMarshalPhase();
+
+                // Drag the event to the top of the deck
+                this.player1.dragCard(this.topDeckEvent, 'draw deck');
+            });
+
+            it('allows the event to be played', function() {
+                this.player2.clickCard(this.opponentEvent);
+                this.player2.clickCard(this.opponentChar);
+                this.player2.clickPrompt('Done');
+
+                expect(this.player1).toAllowAbilityTrigger(this.topDeckEvent);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Maester Gormon requires that event cards listen to game events even
while in the draw deck. The ability system should already prevent event
card abilities from triggering while the card is not in a playable
location - Maester Gormon simply makes the top of the deck a playable
location.

Fixes #2664 