### PR TITLE
Fix targeting and cancellation of Forced March

### DIFF
--- a/server/game/AbilityContext.js
+++ b/server/game/AbilityContext.js
@@ -2,6 +2,7 @@ const ResolvedTargets = require('./gamesteps/ResolvedTargets.js');
 
 class AbilityContext {
     constructor(properties) {
+        this.ability = properties.ability;
         this.challenge = properties.challenge;
         this.game = properties.game;
         this.source = properties.source;

--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -6,7 +6,7 @@ const Messages = require('./Messages');
 class AbilityTarget {
     static create(name, properties) {
         let {message, messages, ...rest} = properties;
-        let defaultMessages = properties.choosingPlayer === 'each' ? Messages.eachPlayerTargeting : null;
+        let defaultMessages = ['each', 'eachOpponent'].includes(properties.choosingPlayer) ? Messages.eachPlayerTargeting : null;
 
         let abilityMessages = new AbilityTargetMessages({
             message,
@@ -57,6 +57,10 @@ class AbilityTarget {
     getChoosingPlayers(context) {
         if(this.choosingPlayer === 'each') {
             return context.game.getPlayersInFirstPlayerOrder();
+        }
+
+        if(this.choosingPlayer === 'eachOpponent') {
+            return context.game.getOpponentsInFirstPlayerOrder(context.player);
         }
 
         return [context.player];

--- a/server/game/ThenClauseAbility.js
+++ b/server/game/ThenClauseAbility.js
@@ -7,6 +7,7 @@ class ThenClauseAbility extends BaseAbility {
 
         this.player = properties.player;
         this.handler = properties.handler;
+        this.condition = properties.condition || (() => true);
     }
 
     isTriggeredAbility() {
@@ -24,8 +25,8 @@ class ThenClauseAbility extends BaseAbility {
         return context;
     }
 
-    meetsRequirements() {
-        return true;
+    meetsRequirements(context) {
+        return this.condition(context);
     }
 
     executeHandler(context) {

--- a/server/game/ThenClauseAbility.js
+++ b/server/game/ThenClauseAbility.js
@@ -15,6 +15,7 @@ class ThenClauseAbility extends BaseAbility {
 
     createContext(parentContext) {
         let context = new AbilityContext({
+            ability: this,
             game: parentContext.game,
             player: this.player || parentContext.player,
             source: parentContext.source

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -93,6 +93,7 @@ class CardAction extends BaseAbility {
 
     createContext(player) {
         return new AbilityContext({
+            ability: this,
             game: this.game,
             player: player,
             source: this.card

--- a/server/game/cards/10-SoD/ForcedMarch.js
+++ b/server/game/cards/10-SoD/ForcedMarch.js
@@ -1,79 +1,39 @@
-const PlotCard = require('../../plotcard.js');
+const PlotCard = require('../../plotcard');
+const GameActions = require('../../GameActions');
 
 class ForcedMarch extends PlotCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.whenRevealed({
-            handler: () => {
-                this.initiate();
+            target: {
+                choosingPlayer: 'eachOpponent',
+                ifAble: true,
+                cardCondition: (card, context) => this.isStandingMilIcon(card) && card.controller === context.choosingPlayer
+            },
+            handler: context => {
+                let cards = context.targets.selections.map(selection => selection.value).filter(card => !!card);
+                this.game.resolveGameAction(
+                    GameActions.simultaneously(
+                        cards.map(card => GameActions.kneelCard({ card }))
+                    ).then(originalContext => ({
+                        condition: () => this.hasValidTargets(originalContext.player),
+                        cost: ability.costs.kneel(card => this.isStandingMilIcon(card)),
+                        message: {
+                            format: '{player} then kneels {kneeled} to initate the effect of {source} again',
+                            args: { kneeled: context => context.costs.kneeled }
+                        },
+                        handler: () => {
+                            let newContext = originalContext.ability.createContext(originalContext.event);
+                            this.game.resolveAbility(newContext.ability, newContext);
+                        }
+                    })),
+                    context
+                );
             }
         });
     }
 
-    initiate() {
-        this.remainingOpponents = this.filterForOpponents();
-        this.selections = [];
-        this.proceedToNextStep();
-    }
-
-    proceedToNextStep() {
-        if(this.remainingOpponents.length > 0) {
-            let currentOpponent = this.remainingOpponents.shift();
-
-            this.game.promptForSelect(currentOpponent, {
-                source: this,
-                gameAction: 'kneel',
-                cardCondition: card => this.isStandingMilIcon(card) && card.controller === currentOpponent,
-                onSelect: (player, card) => this.onToKneelSelected(player, card),
-                onCancel: player => this.onToKneelCanceled(player)
-            });
-        } else {
-            this.doKneel();
-        }
-    }
-
-    onToKneelSelected(player, card) {
-        this.selections.push(card);
-        this.game.addMessage('{0} kneels {1} for {2}', player, card, this);
-        this.proceedToNextStep();
-        return true;
-    }
-
-    onToKneelCanceled(player) {
-        this.game.addAlert('danger', '{0} did not choose a character with a {1} icon to kneel for {2}', player, 'military', this);
-        this.proceedToNextStep();
-        return true;
-    }
-
-    doKneel() {
-        for(let card of this.selections) {
-            card.controller.kneelCard(card);
-        }
-
-        if(this.hasStandingMilIcon(this.controller) && this.filterForOpponents().length > 0) {
-            this.game.promptForSelect(this.controller, {
-                source: this,
-                gameAction: 'kneel',
-                cardCondition: card => this.isStandingMilIcon(card) && card.controller === this.controller,
-                onSelect: (player, card) => this.onCostKneelSelected(player, card),
-                onCancel: player => this.onCostKneelCancelled(player)
-            });
-        }
-    }
-
-    onCostKneelSelected(player, card) {
-        player.kneelCard(card);
-        this.game.addMessage('{0} then kneels {1} to initiate the effect of {2} again', player, card, this);
-        this.initiate();
-        return true;
-    }
-
-    onCostKneelCancelled() {
-        return true;
-    }
-
-    filterForOpponents() {
-        return this.game.getPlayers().filter(player => player !== this.controller &&
-                                                          this.hasStandingMilIcon(player));
+    hasValidTargets(player) {
+        return this.game.getOpponents(player).some(opponent => this.hasStandingMilIcon(opponent));
     }
 
     hasStandingMilIcon(player) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -176,6 +176,10 @@ class Game extends EventEmitter {
         return this.getPlayers().filter(p => p !== player);
     }
 
+    getOpponentsInFirstPlayerOrder(player) {
+        return this.getPlayersInFirstPlayerOrder().filter(p => p !== player);
+    }
+
     isCardVisible(card, player) {
         return this.cardVisibility.isVisible(card, player);
     }

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -52,7 +52,13 @@ class TriggeredAbility extends BaseAbility {
     }
 
     createContext(event) {
-        return new TriggeredAbilityContext({ event: event, game: this.game, source: this.card, player: this.playerFunc() });
+        return new TriggeredAbilityContext({
+            ability: this,
+            event: event,
+            game: this.game,
+            source: this.card,
+            player: this.playerFunc()
+        });
     }
 
     triggersFor(eventName) {

--- a/test/server/cards/10-SoD/ForcedMarch.spec.js
+++ b/test/server/cards/10-SoD/ForcedMarch.spec.js
@@ -1,0 +1,102 @@
+describe('Forced March', function() {
+    integration(function() {
+        describe('when revealed', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Forced March', 'A Noble Cause',
+                    'Hedge Knight', 'Hedge Knight', 'Hedge Knight'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                [this.char1, this.char2, this.char3] = this.player1.filterCardsByName('Hedge Knight');
+                [this.opponentChar1, this.opponentChar2, this.opponentChar3] = this.player2.filterCardsByName('Hedge Knight');
+
+                this.player1.clickCard(this.char1);
+                this.player1.clickCard(this.char2);
+                this.player1.clickCard(this.char3);
+                this.player2.clickCard(this.opponentChar1);
+                this.player2.clickCard(this.opponentChar2);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Forced March');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player2.clickCard(this.opponentChar1);
+            });
+
+            it('requires each opponent to kneel a military character', function() {
+                expect(this.opponentChar1.kneeled).toBe(true);
+            });
+
+            it('prompts to re-initiate', function() {
+                expect(this.player1).toHavePrompt('Select card to kneel');
+            });
+
+            describe('when there are no more valid targets to kneel', function() {
+                beforeEach(function() {
+                    // Kneel another to initiate again
+                    this.player1.clickCard(this.char1);
+
+                    this.player2.clickCard(this.opponentChar2);
+                });
+
+                it('does not prompt to re-initiate', function() {
+                    expect(this.player1).toHavePrompt('Marshal your cards');
+                });
+            });
+        });
+
+        describe('vs cancels', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Forced March', 'A Noble Cause', 'Outwit',
+                    'Hedge Knight', 'Hedge Knight', 'Hedge Knight', 'Maester Wendamyr'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                [this.char1, this.char2, this.char3] = this.player1.filterCardsByName('Hedge Knight');
+                [this.opponentChar1, this.opponentChar2, this.opponentChar3] = this.player2.filterCardsByName('Hedge Knight');
+                this.maester = this.player2.findCardByName('Maester Wendamyr');
+                this.outwit = this.player2.findCardByName('Outwit');
+
+                this.player1.clickCard(this.char1);
+                this.player1.clickCard(this.char2);
+                this.player1.clickCard(this.char3);
+                this.player2.clickCard(this.opponentChar1);
+                this.player2.clickCard(this.opponentChar2);
+                this.player2.clickCard(this.maester);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Forced March');
+                this.player2.selectPlot('Outwit');
+                this.selectFirstPlayer(this.player1);
+
+                this.player2.clickCard(this.opponentChar1);
+
+                // Pass Outwit for original initiation
+                this.player2.clickPrompt('Pass');
+
+                // Kneel another to initiate again
+                this.player1.clickCard(this.char1);
+
+                // Choose it
+                this.player2.clickCard(this.opponentChar2);
+            });
+
+            it('gives another chance to cancel', function() {
+                expect(this.player2).toAllowAbilityTrigger(this.outwit);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Prevents Forced March from allowing the player to kneel a character to re-initiate the effect unless the opponent has valid targets.
* Allows the re-initiated effect to be cancelled separately from the initial effect.

Fixes #2663 