### PR TITLE
Fix Dale Seaworth

### DIFF
--- a/server/game/cards/14-FotS/DaleSeaworth.js
+++ b/server/game/cards/14-FotS/DaleSeaworth.js
@@ -5,11 +5,11 @@ class DaleSeaworth extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: event => event.card === this && event.playingType === 'mashal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             target: {
                 activePromptTitle: 'Select a location',
-                cardCondition: card => card.location === 'discard pile' && card.getType() === 'location' && card.controller === this.controller
+                cardCondition: card => card.location === 'discard pile' && card.getType() === 'location' && card.isFaction('baratheon') && card.controller === this.controller
             },
             message: '{player} uses {source} to return {target} to hand',
             handler: context => {


### PR DESCRIPTION
* Fixes typo that prevented his reaction from firing
* Properly restricts the ability to Baratheon locations

Fixes #2677 
