### PR TITLE
implement Doubting Septa

### DIFF
--- a/server/game/cards/13.4-BtRK/DoubtingSepta.js
+++ b/server/game/cards/13.4-BtRK/DoubtingSepta.js
@@ -1,0 +1,31 @@
+const DrawCard = require('../../drawcard.js');
+const GameActions = require('../../GameActions');
+
+class DoubtingSepta extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                afterChallenge: event =>
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.winner === this.controller
+            },
+            cost: ability.costs.sacrificeSelf(),
+            target: {
+                cardCondition: card => card.location === 'play area' &&
+                    card.controller === this.controller && 
+                    (card.getType() === 'character' || card.getType() === 'location') &&
+                    card.canGainPower()
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to have {2} gain 1 power', this.controller, this, context.target);
+                this.game.resolveGameAction(
+                    GameActions.gainPower({ card: context.target, amount: 1 })
+                );
+            }
+        });
+    }
+}
+
+DoubtingSepta.code = '13069';
+
+module.exports = DoubtingSepta;


### PR DESCRIPTION
not 100% sure about the target restriction "card.canGainPower()". The card reads "After you win an INT challenge, sacrifice Doubting Septa to choose a character or location you control. That card gains 1 power". I would say the card to choose must be able to gain power else the effect couldn´t resolve fully. Appreciate any feedback!