### PR TITLE
implement shadow of the rose

### DIFF
--- a/server/game/cards/13.5-TB/ShadowOfTheRose.js
+++ b/server/game/cards/13.5-TB/ShadowOfTheRose.js
@@ -1,0 +1,42 @@
+const DrawCard = require('../../drawcard.js');
+
+class ShadowOfTheRose extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            handler: () => {
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    activePromptTitle: 'Select a card with shadow',
+                    cardCondition: card => card.isShadow(),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
+                    source: this
+                });
+            }
+        });
+    }
+
+    cardSelected(player, card) {
+        player.putIntoShadows(card);
+        this.game.addMessage('{0} uses {1} to search their deck and put {2} into shadows',
+            player, this, card);
+        this.returnToHandInsteadOfDiscardPile(player);
+    }
+
+    doneSelecting(player) {
+        this.game.addMessage('{0} uses {1} to search their deck, but does not put any card into shadows',
+            player, this);
+        this.returnToHandInsteadOfDiscardPile(player);
+    }
+
+    returnToHandInsteadOfDiscardPile(player) {
+        if(this.game.anyPlotHasTrait('Summer')) {
+            this.game.addMessage('{0} uses {1} to return {1} to their hand instead of their discard pile', player, this);
+            player.moveCard(this, 'hand');
+        }
+    }
+}
+
+ShadowOfTheRose.code = '13084';
+
+module.exports = ShadowOfTheRose;


### PR DESCRIPTION
not 100% sure if the order of actions happening is correctly implemented this way. the card reads that first you choose the card to put into shadows, then shuffle your deck and then optionally return shadow of the rose to shadows. I do not know if the shuffling of the deck executed by the promptForDeckSearch happens after the complete resolution of the onSelect and onCancel handler functions or not. In any case, i do not think it matters that much if you first return the card to shadows and then shuffle or do it the other way around.
Appreciate any feedback!