### PR TITLE
Make Tunnels of Red Keep STR bonus fixed

### DIFF
--- a/server/game/cards/13.4-BtRK/TunnelsOfTheRedKeep.js
+++ b/server/game/cards/13.4-BtRK/TunnelsOfTheRedKeep.js
@@ -5,16 +5,19 @@ class TunnelsOfTheRedKeep extends DrawCard {
         this.action({
             title: 'Kneel and return to shadows',
             cost: ability.costs.kneelSelf(),
-            max: ability.limit.perPhase(1),
+            message: '{player} kneels {source} to return {source} to shadows',
             handler: context => {
-                context.player.putIntoShadows(this, false);
-                this.game.addMessage('{0} kneels {1} to return it to shadows.', context.player, this);
-                let targetCharacters = context.player.filterCardsInPlay(card => card.getType() === 'character');
-                this.untilEndOfPhase(ability => ({
-                    match: targetCharacters,
-                    effect: ability.effects.dynamicStrength(() => context.player.shadows.length)
-                }));
-            }
+                context.player.putIntoShadows(this, false, () => {
+                    let strBoost = context.player.shadows.length;
+                    let targetCharacters = context.player.filterCardsInPlay(card => card.getType() === 'character');
+                    this.game.addMessage('Then {0} gains +{1} STR for {2}', targetCharacters, strBoost, this);
+                    this.untilEndOfPhase(ability => ({
+                        match: targetCharacters,
+                        effect: ability.effects.modifyStrength(strBoost)
+                    }));
+                });
+            },
+            max: ability.limit.perPhase(1)
         });
     }
 }

--- a/test/server/cards/13.4-BTRK/TunnelsOfTheRedKeep.spec.js
+++ b/test/server/cards/13.4-BTRK/TunnelsOfTheRedKeep.spec.js
@@ -1,0 +1,45 @@
+describe('Tunnels of the Red Keep', function() {
+    integration(function() {
+        describe('kneeling and returning it to shadows', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'A Noble Cause',
+                    'Hedge Knight', 'Tunnels of the Red Keep', 'Penny'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Hedge Knight');
+                this.tunnels = this.player1.findCardByName('Tunnels of the Red Keep');
+                this.shadowCard = this.player1.findCardByName('Penny');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.tunnels);
+                this.player1.clickPrompt('Setup');
+                this.player1.clickCard(this.shadowCard);
+                this.player1.clickPrompt('Setup in shadows');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+                this.completeMarshalPhase();
+
+                this.player1.clickMenu(this.tunnels, 'Kneel and return to shadows');
+            });
+
+            it('grants +1 STR for each card in shadows', function() {
+                // 2 base STR + 2 cards in shadow (including Tunnels)
+                expect(this.character.getStrength()).toBe(4);
+            });
+
+            it('does not modify the STR if cards come out of shadow', function() {
+                this.player1.clickCard(this.shadowCard);
+
+                expect(this.character.getStrength()).toBe(4);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Per rules on lasting effects, the value should be fixed at the time of
initiation. So cards leaving or entering shadows should not affect the
STR bonus.