### PR TITLE
Handle same character chosen for Unexpected Delay

### DIFF
--- a/server/game/cards/05-LoCR/UnexpectedDelay.js
+++ b/server/game/cards/05-LoCR/UnexpectedDelay.js
@@ -1,4 +1,5 @@
-const PlotCard = require('../../plotcard.js');
+const PlotCard = require('../../plotcard');
+const GameActions = require('../../GameActions');
 
 class UnexpectedDelay extends PlotCard {
     setupCardAbilities() {
@@ -10,13 +11,25 @@ class UnexpectedDelay extends PlotCard {
                 choosingPlayer: 'each',
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.power === 0 && card.attachments.length === 0
             },
+            message: {
+                format: '{source} forces {chosenCards} to return to their owner\'s hands',
+                args: { chosenCards: context => this.getChosenCards(context) }
+            },
             handler: context => {
-                for(let selection of context.targets.selections) {
-                    let card = selection.value;
-                    card.owner.returnCardToHand(card);
-                }
+                const uniqueCards = this.getChosenCards(context);
+                this.game.resolveGameAction(
+                    GameActions.simultaneously(
+                        uniqueCards.map(card => GameActions.returnCardToHand({ card }))
+                    ),
+                    context
+                );
             }
         });
+    }
+
+    getChosenCards(context) {
+        const cards = context.targets.selections.map(selection => selection.value);
+        return [...new Set(cards)];
     }
 }
 

--- a/test/server/cards/05-LoCR/UnexpectedDelay.spec.js
+++ b/test/server/cards/05-LoCR/UnexpectedDelay.spec.js
@@ -1,0 +1,38 @@
+describe('Unexpected Delay', function() {
+    integration(function() {
+        describe('when both players choose the same character', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'Unexpected Delay', 'A Noble Cause',
+                    'Cersei Lannister (Core)', 'Cersei Lannister (Core)'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                [this.character, this.dupe] = this.player1.filterCardsByName('Cersei Lannister', 'hand');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.dupe);
+                this.completeSetup();
+
+                this.player1.selectPlot('Unexpected Delay');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickCard(this.character);
+                this.player2.clickCard(this.character);
+            });
+
+            it('only attempts to return the character to hand once', function() {
+                // The single dupe should be sufficient to save the character.
+                expect(this.character.location).toBe('play area');
+                expect(this.dupe.location).toBe('discard pile');
+            });
+        });
+    });
+});


### PR DESCRIPTION
When two or more players choose the same character to be returned to
hand for Unexpected Delay, it should only return that character a single
time. This means if the owner has a single duplicate on the card, it can
be saved.

Fixes #2724 