### PR TITLE
Handle keywords on multiple lines

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -2,7 +2,6 @@ const BaseCard = require('./basecard.js');
 const CardMatcher = require('./CardMatcher.js');
 const ReferenceCountedSetProperty = require('./PropertyTypes/ReferenceCountedSetProperty');
 const StandardPlayActions = require('./PlayActions/StandardActions');
-const AbilityDsl = require('./abilitydsl');
 
 const Icons = ['military', 'intrigue', 'power'];
 
@@ -13,12 +12,6 @@ class DrawCard extends BaseCard {
         this.dupes = [];
         this.attachments = [];
         this.childCards = [];
-        this.icons = new ReferenceCountedSetProperty();
-
-        for(let icon of this.getPrintedIcons()) {
-            this.icons.add(icon);
-        }
-
         this.strengthModifier = 0;
         this.strengthMultiplier = 1;
         this.strengthSet = undefined;
@@ -32,8 +25,6 @@ class DrawCard extends BaseCard {
         this.stealthLimit = 1;
         this.minCost = 0;
         this.eventPlacementLocation = 'discard pile';
-
-        this.setupDuplicateAbility(AbilityDsl);
     }
 
     createSnapshot() {
@@ -59,6 +50,18 @@ class DrawCard extends BaseCard {
         clone.traits = this.traits.clone();
 
         return clone;
+    }
+
+    setupCardTextProperties(ability) {
+        super.setupCardTextProperties(ability);
+
+        this.icons = new ReferenceCountedSetProperty();
+
+        for(let icon of this.getPrintedIcons()) {
+            this.icons.add(icon);
+        }
+
+        this.setupDuplicateAbility(ability);
     }
 
     setupDuplicateAbility(ability) {

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -18,6 +18,55 @@ describe('BaseCard', function () {
         });
     });
 
+    describe('.parseKeywords', function() {
+        it('parses keywords with a parenthesized value', function() {
+            const keywords = BaseCard.parseKeywords('Ambush (1). Bestow (2). Shadow (3).');
+            expect(keywords.length).toBe(3);
+            expect(keywords).toContain('ambush (1)');
+            expect(keywords).toContain('bestow (2)');
+            expect(keywords).toContain('shadow (3)');
+        });
+
+        it('parses non-value keywords', function() {
+            const keywords = BaseCard.parseKeywords('Stealth. Intimidate. Renown. Insight. Terminal. Limited. Pillage.');
+
+            expect(keywords.length).toBe(7);
+            expect(keywords).toContain('stealth');
+            expect(keywords).toContain('intimidate');
+            expect(keywords).toContain('renown');
+            expect(keywords).toContain('insight');
+            expect(keywords).toContain('terminal');
+            expect(keywords).toContain('limited');
+            expect(keywords).toContain('pillage');
+        });
+
+        it('parses no attachment keywords', function() {
+            const keywords = BaseCard.parseKeywords('No attachments. No attachments except <i>Weapon</i>.');
+
+            expect(keywords.length).toBe(2);
+            expect(keywords).toContain('no attachments');
+            expect(keywords).toContain('no attachments except <i>weapon</i>');
+        });
+
+        it('parses keywords on multiple lines', function() {
+            const keywords = BaseCard.parseKeywords(`
+                Shadow (4).\n
+                No attachments except <i>Weapon</i>.\n
+                <b>Action:</b> Until the end of phase, cannot be bypassed by Stealth.
+            `);
+
+            expect(keywords.length).toBe(2);
+            expect(keywords).toContain('shadow (4)');
+            expect(keywords).toContain('no attachments except <i>weapon</i>');
+        });
+
+        it('does not parse keywords that are embedded in abilities', function() {
+            const keywords = BaseCard.parseKeywords('Cannot be bypassed by stealth.');
+
+            expect(keywords).toEqual([]);
+        });
+    });
+
     describe('doAction()', function() {
         describe('when there is no action for the card', function() {
             beforeEach(function() {


### PR DESCRIPTION
Previously, we were only looking at the very first line for keywords.
However, Forest Patrol has keywords on two separate lines.

Now, keyword parsing looks at all lines that don't have a triggered
ability (anything wrapped in \<b\> element). Additionally, initial card
set up based on the card text has been moved to a new
setupCardTextProperties method for slightly better organization.

Fixes #2732 