### PR TITLE
Ensure PlaceToken and LookAtDeck events resolve

### DIFF
--- a/server/game/GameActions/LookAtDeck.js
+++ b/server/game/GameActions/LookAtDeck.js
@@ -10,7 +10,8 @@ class LookAtDeck extends GameAction {
     }
 
     createEvent({ player, lookingAt, context, amount = 1 }) {
-        return this.event('onLookAtDeck', { player, lookingAt, amount }, event => {
+        const actualAmount = Math.min(amount, lookingAt.drawDeck.length);
+        return this.event('onLookAtDeck', { player, lookingAt, amount: actualAmount, desiredAmount: amount }, event => {
             let topCards = event.lookingAt.drawDeck.slice(0, amount);
             context.game.promptForSelect(event.player, {
                 activePromptTitle: `Look at ${event.lookingAt.name}'s deck`,

--- a/server/game/GameActions/PlaceToken.js
+++ b/server/game/GameActions/PlaceToken.js
@@ -10,7 +10,7 @@ class PlaceToken extends GameAction {
     }
 
     createEvent({ card, token, amount = 1 }) {
-        return this.event('onTokenPlaced', { card, token, amount }, event => {
+        return this.event('onTokenPlaced', { card, token, amount, desiredAmount: amount }, event => {
             event.card.modifyToken(event.token, event.amount);
         });
     }

--- a/test/server/GameActions/LookAtDeck.spec.js
+++ b/test/server/GameActions/LookAtDeck.spec.js
@@ -9,7 +9,7 @@ describe('LookAtDeck', function() {
             game: this.gameSpy,
             source: 'SOURCE'
         };
-        this.props = { player: this.playerSpy, lookingAt: this.opponentSpy, amount: 1, context: this.contextSpy };
+        this.props = { player: this.playerSpy, lookingAt: this.opponentSpy, amount: 3, context: this.contextSpy };
     });
 
     describe('allow()', function() {
@@ -43,7 +43,8 @@ describe('LookAtDeck', function() {
             expect(this.event.name).toBe('onLookAtDeck');
             expect(this.event.player).toBe(this.playerSpy);
             expect(this.event.lookingAt).toBe(this.opponentSpy);
-            expect(this.event.amount).toBe(1);
+            expect(this.event.amount).toBe(2);
+            expect(this.event.desiredAmount).toBe(3);
         });
 
         describe('the event handler', function() {

--- a/test/server/GameActions/PlaceToken.spec.js
+++ b/test/server/GameActions/PlaceToken.spec.js
@@ -56,6 +56,7 @@ describe('PlaceToken', function() {
             expect(this.event.card).toBe(this.cardSpy);
             expect(this.event.token).toBe('TOKEN_TYPE');
             expect(this.event.amount).toBe(2);
+            expect(this.event.desiredAmount).toBe(2);
         });
 
         describe('the event handler', function() {

--- a/test/server/cards/07-WotW/LingeringVenom.spec.js
+++ b/test/server/cards/07-WotW/LingeringVenom.spec.js
@@ -1,0 +1,76 @@
+const {Tokens} = require('../../../../server/game/Constants');
+
+describe('Lingering Venom', function() {
+    integration(function() {
+        describe('when losing a challenge', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('martell', [
+                    'A Noble Cause',
+                    'Lingering Venom', 'House Dayne Knight'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('House Dayne Knight', 'hand');
+                this.venom = this.player2.findCardByName('Lingering Venom', 'hand');
+
+                this.player1.clickCard(this.character);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickPrompt('Done');
+
+                this.player2.clickCard(this.venom);
+                this.player2.clickCard(this.character);
+
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.triggerAbility(this.venom);
+            });
+
+            it('places a venom token', function() {
+                expect(this.character.location).toBe('play area');
+                expect(this.venom.tokens[Tokens.venom]).toBe(1);
+            });
+
+            describe('when the number of tokens equal the character STR', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Apply Claim');
+
+                    // Restand the character
+                    this.player1.clickCard(this.character);
+
+                    this.player1.clickPrompt('Military');
+                    this.player1.clickCard(this.character);
+                    this.player1.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    this.player2.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    this.player2.triggerAbility(this.venom);
+                });
+
+                it('kills the character', function() {
+                    expect(this.character.location).toBe('dead pile');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Any event that has an `amount` property needs a corresponding
`desiredAmount` property if used with "Then" abilities. The lack of
`desiredAmount` was preventing Lingering Venom from killing characters
after placing a token.

Fixes #2770 