### PR TITLE
Allow Bloody Cup to be saved

### DIFF
--- a/server/game/cards/13.5-TB/TheBloodyCup.js
+++ b/server/game/cards/13.5-TB/TheBloodyCup.js
@@ -15,7 +15,7 @@ class TheBloodyCup extends DrawCard {
             },
             handler: context => {
                 const loser = context.event.challenge.loser;
-                loser.moveCard(context.target, 'draw deck');
+                loser.moveCardToTopOfDeck(context.target);
             },
             max: ability.limit.perChallenge(1)
         });


### PR DESCRIPTION
moveCard doesn't generate an event covered by dupes, but
moveCardToTopOfDeck does.

Fixes #2757 