### PR TITLE
Allow dupes of facedown card during setup

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -140,7 +140,7 @@ class Player extends Spectator {
         return this.game.allCards.find(playCard => (
             playCard.controller === this &&
             playCard.location === 'play area' &&
-            !playCard.facedown &&
+            (this.game.currentPhase === 'setup' || !playCard.facedown) &&
             playCard !== card &&
             (playCard.code === card.code || playCard.name === card.name) &&
             playCard.owner === this


### PR DESCRIPTION
A check was added when searching for a duplicate that the in-play card
isn't facedown, to ensure facedown attachments under Dothraki Handmaiden
aren't counted. However, all cards in setup are facedown, so it
prevented placing duplicates during setup.