### PR TITLE
Use replacement handler for Meryn Trant

### DIFF
--- a/server/game/cards/15-DotE/SerMerynTrant.js
+++ b/server/game/cards/15-DotE/SerMerynTrant.js
@@ -6,11 +6,15 @@ class SerMerynTrant extends DrawCard {
             when: {
                 onCardDiscarded: event => event.originalLocation === 'hand' && event.card.controller !== this.controller
             },
+            message: {
+                format: '{player} uses {source} to remove {card} from the game',
+                args: { card: context => context.event.card }
+            },
             handler: context => {
-                let card = context.event.card;
-                let player = card.controller;
-                player.moveCard(card, 'out of game');
-                this.game.addMessage('{0} uses {1} to remove {2} from the game', this.controller, this, card);
+                context.event.replaceHandler(event => {
+                    event.cardStateWhenDiscarded = event.card.createSnapshot();
+                    event.card.controller.moveCard(event.card, 'out of game');
+                });
             }
         });
     }


### PR DESCRIPTION
Because Ser Meryn Trant's ability is an interrupt and not a reaction,
and because it uses the word "instead", the ability needs to use a
replacement handler. Otherwise, the card will be moved out of the game
immediately, and then placed in the discard pile from the normal
onCardDiscarded event handler.

Fixes #2850 