### PR TITLE
Fully cancel ability during cost resolution

### DIFF
--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -84,10 +84,18 @@ class AbilityResolver extends BaseStep {
     }
 
     resolveCosts() {
+        if(this.cancelled) {
+            return;
+        }
+
         this.canPayResults = this.ability.resolveCosts(this.context);
     }
 
     waitForCostResolution() {
+        if(this.cancelled) {
+            return;
+        }
+
         this.cancelled = this.canPayResults.some(result => result.resolved && !result.value);
 
         if(!this.canPayResults.every(result => result.resolved)) {


### PR DESCRIPTION
Previously, if /cancel-prompt was used during a cost-related prompt for
an ability, the immediate prompt would be cancelled, but then
AbilityResolver.cancelled would be overridden afterwards. This then
forced the player to continue resolving the ability in a bad state.

Fixes #2866 