### PR TITLE
Add a prompt to handle naming cards

### DIFF
--- a/server/game/cards/04.1-AtSK/RubyOfRhllor.js
+++ b/server/game/cards/04.1-AtSK/RubyOfRhllor.js
@@ -12,14 +12,11 @@ class RubyOfRhllor extends DrawCard {
                     event.challenge.winner === this.controller &&
                     event.challenge.isAttacking(this.parent)
             },
-            handler: () => {
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Name a card',
-                        controls: [
-                            { type: 'card-name', command: 'menuButton', method: 'selectCardName' }
-                        ]
-                    }
+            handler: context => {
+                this.game.promptForCardName({
+                    player: context.player,
+                    onSelect: (player, cardName) => this.selectCardName(player, cardName),
+                    source: context.source
                 });
             }
         });
@@ -35,8 +32,6 @@ class RubyOfRhllor extends DrawCard {
         }
 
         loser.discardCards(matchingCards);
-
-        return true;
     }
 }
 

--- a/server/game/cards/13.3-PoS/TheFaithsDecree.js
+++ b/server/game/cards/13.3-PoS/TheFaithsDecree.js
@@ -5,14 +5,11 @@ class TheFaithsDecree extends DrawCard {
         this.action({
             title: 'Prevent abilities',
             condition: context => context.player.anyCardsInPlay({ type: ['character', 'location'], trait: 'The Seven' }),
-            handler: () => {
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Name a card',
-                        controls: [
-                            { type: 'card-name', command: 'menuButton', method: 'selectCardName' }
-                        ]
-                    },
+            handler: context => {
+                this.game.promptForCardName({
+                    player: context.player,
+                    match: cardData => !['agenda', 'plot'].includes(cardData.type),
+                    onSelect: (player, cardName) => this.selectCardName(player, cardName),
                     source: this
                 });
             }
@@ -20,24 +17,11 @@ class TheFaithsDecree extends DrawCard {
     }
 
     selectCardName(player, cardName) {
-        if(!this.isValidCardName(cardName)) {
-            return false;
-        }
-
-        this.game.addMessage('{0} plays {1} to prevent opponent\'s from triggering {2}', player, this, cardName);
+        this.game.addMessage('{0} plays {1} to prevent opponents from triggering {2}', player, this, cardName);
         this.untilEndOfPhase(ability => ({
             targetController: 'opponent',
             effect: ability.effects.cannotTriggerCardAbilities(ability => ability.card.name === cardName)
         }));
-
-        return true;
-    }
-
-    isValidCardName(cardName) {
-        return Object.values(this.game.cardData).some(card => (
-            card.name === cardName &&
-            !['agenda', 'plot'].includes(card.type)
-        ));
     }
 }
 

--- a/server/game/cards/13.6-LMHR/TheIronThrone.js
+++ b/server/game/cards/13.6-LMHR/TheIronThrone.js
@@ -7,14 +7,11 @@ class TheIronThrone extends DrawCard {
                 onPhaseStarted: () => true
             },
             cost: ability.costs.kneelSelf(),
-            handler: () => {
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Name a card',
-                        controls: [
-                            { type: 'card-name', command: 'menuButton', method: 'selectCardName' }
-                        ]
-                    }
+            handler: context => {
+                this.game.promptForCardName({
+                    player: context.player,
+                    onSelect: (player, cardName) => this.selectCardName(player, cardName),
+                    source: context.source
                 });
             }
         });
@@ -30,7 +27,6 @@ class TheIronThrone extends DrawCard {
                 ability.effects.cannotPutIntoPlay(card => card.name.toLowerCase() === cardName.toLowerCase())
             ]
         }));
-        return true;
     }
 }
 

--- a/server/game/cards/14-FotS/ThePrinceThatWasPromised.js
+++ b/server/game/cards/14-FotS/ThePrinceThatWasPromised.js
@@ -85,33 +85,18 @@ class ThePrinceThatWasPromised extends AgendaCard {
     }
 
     onDecksPrepared() {
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Name a unique character',
-                controls: [
-                    { type: 'card-name', command: 'menuButton', method: 'selectCardName' }
-                ]
-            }
+        this.game.promptForCardName({
+            title: 'Name a unique character',
+            player: this.controller,
+            match: cardData => cardData.type === 'character' && cardData.unique,
+            onSelect: (player, cardName) => this.selectCardName(player, cardName),
+            source: this
         });
     }
 
     selectCardName(player, cardName) {
-        if(!this.isUniqueCharacter(cardName)) {
-            return false;
-        }
-
         this.game.addMessage('{0} names {1} for {2}', player, cardName, this);
         this.selectedCardName = cardName;
-
-        return true;
-    }
-
-    isUniqueCharacter(cardName) {
-        return Object.values(this.game.cardData).some(card => (
-            card.type === 'character' &&
-            card.unique &&
-            card.name === cardName
-        ));
     }
 }
 

--- a/server/game/cards/15-DotE/DragonstoneConvert.js
+++ b/server/game/cards/15-DotE/DragonstoneConvert.js
@@ -5,14 +5,12 @@ class DragonstoneConvert extends DrawCard {
         this.action({
             title: 'Prevent event',
             phase: 'challenge',
-            handler: () => {
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Name an event',
-                        controls: [
-                            { type: 'card-name', command: 'menuButton', method: 'selectCardName' }
-                        ]
-                    },
+            handler: context => {
+                this.game.promptForCardName({
+                    player: context.player,
+                    title: 'Name an event',
+                    match: cardData => cardData.type === 'event',
+                    onSelect: (player, cardName) => this.selectCardName(player, cardName),
                     source: this
                 });
             }
@@ -20,24 +18,11 @@ class DragonstoneConvert extends DrawCard {
     }
 
     selectCardName(player, cardName) {
-        if(!this.isValidCardName(cardName)) {
-            return false;
-        }
-
         this.game.addMessage('{0} uses {1} to prevent events with the title {2} to be played', player, this, cardName);
         this.untilEndOfPhase(ability => ({
             targetController: 'any',
             effect: ability.effects.cannotPlay(card => card.name === cardName)
         }));
-
-        return true;
-    }
-
-    isValidCardName(cardName) {
-        return Object.values(this.game.cardData).some(card => (
-            card.name === cardName &&
-            card.type === 'event'
-        ));
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -13,6 +13,7 @@ const GamePipeline = require('./gamepipeline.js');
 const Phases = require('./gamesteps/Phases');
 const SimpleStep = require('./gamesteps/simplestep.js');
 const ChoosePlayerPrompt = require('./gamesteps/ChoosePlayerPrompt');
+const CardNamePrompt = require('./gamesteps/CardNamePrompt');
 const DeckSearchPrompt = require('./gamesteps/DeckSearchPrompt');
 const MenuPrompt = require('./gamesteps/menuprompt.js');
 const IconPrompt = require('./gamesteps/iconprompt.js');
@@ -645,6 +646,10 @@ class Game extends EventEmitter {
 
     promptWithMenu(player, contextObj, properties) {
         this.queueStep(new MenuPrompt(this, player, contextObj, properties));
+    }
+
+    promptForCardName(properties) {
+        this.queueStep(new CardNamePrompt(this, properties));
     }
 
     promptForIcon(player, card, callback = () => true) {

--- a/server/game/gamesteps/CardNamePrompt.js
+++ b/server/game/gamesteps/CardNamePrompt.js
@@ -1,0 +1,59 @@
+const BaseStep = require('./basestep');
+
+class CardNamePrompt extends BaseStep {
+    constructor(game, {player, source, title, match, onSelect, onCancel}) {
+        super(game);
+
+        this.player = player;
+        this.source = source;
+        this.title = title || 'Name a card';
+        this.match = match || (() => true);
+        this.onSelect = onSelect;
+        this.onCancel = onCancel;
+        this.cards = Object.values(this.game.cardData);
+    }
+
+    continue() {
+        this.game.promptWithMenu(this.player, this, {
+            activePrompt: {
+                menuTitle: this.title,
+                controls: [
+                    { type: 'card-name', command: 'menuButton', method: 'handleSelectCardName' }
+                ]
+            },
+            source: this.source
+        });
+    }
+
+    handleSelectCardName(player, cardName) {
+        if(!cardName || cardName.length === 0) {
+            this.handleCancel();
+            return true;
+        }
+
+        if(!this.isMatch(cardName)) {
+            return false;
+        }
+
+        this.onSelect(player, cardName);
+
+        return true;
+    }
+
+    isMatch(cardName) {
+        return this.cards.some(cardData => (
+            cardData.name === cardName &&
+            this.match(cardData)
+        ));
+    }
+
+    handleCancel() {
+        if(this.onCancel) {
+            this.onCancel();
+        } else {
+            this.game.addAlert('warning', '{0} does not name a card for {1}', this.player, this.source);
+        }
+    }
+}
+
+module.exports = CardNamePrompt;


### PR DESCRIPTION
Previously, card abilities that required you to name a card used basic
menu prompts and did checks on the cards manually. This introduces a
special prompt that makes it easier to limit the card named to given
`match` criteria, and better handles if the player does not name a card.

Fixes #2867 
Closes #2848 