### PR TITLE
Fix Champion's Challenge can be triggered multiple times per phase

### DIFF
--- a/server/game/cards/15-DotE/ChampionsChallenge.js
+++ b/server/game/cards/15-DotE/ChampionsChallenge.js
@@ -6,6 +6,7 @@ class ChampionsChallenge extends PlotCard {
             when: {
                 onChallengeInitiated: event => event.challenge.defendingPlayer === this.controller
             },
+            limit: ability.limit.perPhase(1),
             cost: ability.costs.kneel((card, context) => card.getType() === 'character' && card.getStrength() === this.highestStrength(context.player)),
             message: {
                 format: '{player} uses {source} and kneels {kneeledCard} to end the current challenge',


### PR DESCRIPTION
Fix Champion's Challenge can be triggered multiple times per phase if the character strength condition has been met. The plot says "Limit once per phase" so this restriction should be applied as well.