### PR TITLE
Allow cards to be marshalled into shadows through card effects

### DIFF
--- a/server/game/cards/11.3-SoKL/ValyriansCrew.js
+++ b/server/game/cards/11.3-SoKL/ValyriansCrew.js
@@ -5,6 +5,7 @@ class ValyriansCrew extends DrawCard {
         this.persistentEffect({
             effect: [
                 ability.effects.canMarshal(card => this.isFacedownAttachment(card) && card.getPrintedType() !== 'event'),
+                ability.effects.canMarshalIntoShadows(card => this.isFacedownAttachment(card)),
                 ability.effects.canPlay(card => this.isFacedownAttachment(card) && card.getPrintedType() === 'event')
             ]
         });

--- a/server/game/cards/15-DotE/ArchmaesterMarwyn.js
+++ b/server/game/cards/15-DotE/ArchmaesterMarwyn.js
@@ -12,6 +12,7 @@ class ArchmaesterMarwyn extends DrawCard {
             targetController: 'current',
             effect: [
                 ability.effects.canMarshal(card => card.location === 'conclave'),
+                ability.effects.canMarshalIntoShadows(card => card.location === 'conclave'),
                 ability.effects.canPlay(card => card.location === 'conclave')
             ]
         });

--- a/server/game/cards/15-DotE/DothrakiHandmaiden.js
+++ b/server/game/cards/15-DotE/DothrakiHandmaiden.js
@@ -4,7 +4,10 @@ class DothrakiHandmaiden extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.controller.anyCardsInPlay(card => card.name === 'Daenerys Targaryen'),
-            effect: ability.effects.canMarshal({ type: 'attachment', facedown: true, parent: this })
+            effect: [
+                ability.effects.canMarshal({ type: 'attachment', facedown: true, parent: this }),
+                ability.effects.canMarshalIntoShadows({ type: 'attachment', facedown: true, parent: this})
+            ]
         });
         this.action({
             title: 'Attach facedown attachment',

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -975,6 +975,18 @@ const Effects = {
             }
         };
     },
+    canMarshalIntoShadows: function(predicate) {
+        let playableLocation = new PlayableLocation('marshalIntoShadows', CardMatcher.createMatcher(predicate));
+        return {
+            targetType: 'player',
+            apply: function(player) {
+                player.playableLocations.push(playableLocation);
+            },
+            unapply: function(player) {
+                player.playableLocations = player.playableLocations.filter(l => l !== playableLocation);
+            }
+        };
+    },
     canPlayFromOwn: function(location) {
         return {
             targetType: 'player',


### PR DESCRIPTION
According to my search, this affects the following three cards:
* Archmaester Marwyn
* Valyrian Crew
* Dothraki Handmaiden

Note that the rules are a bit complex here: Similar effects that
have *any* limitation to the card e.g. Maester Gormon do not allow
marshalling into shadows.

This fixes #2932 