### PR TITLE
Prevent Benjen's Cache from revealing card

### DIFF
--- a/server/game/cards/16-TTWDFL/BenjensCache.js
+++ b/server/game/cards/16-TTWDFL/BenjensCache.js
@@ -7,7 +7,7 @@ class BenjensCache extends PlotCard {
             condition: () => !this.controller.plotDiscard.some(card => card.hasTrait('Kingdom')),
             gameAction: GameActions.search({
                 title: 'Select a card',
-                message: '{player} uses {source} to search their deck and add {searchTarget} to their hand',
+                message: '{player} uses {source} to search their deck and add a card to their hand',
                 gameAction: GameActions.addToHand(context => ({
                     card: context.searchTarget
                 }))


### PR DESCRIPTION
Benjen's Cache searches for any card with no conditions, so the player is
not required to reveal the card to prove it matches the search.

Fixes #2946 