### PR TITLE
Remove attackers / defenders declared event

### DIFF
--- a/server/game/cards/03-WotN/Motley.js
+++ b/server/game/cards/03-WotN/Motley.js
@@ -8,8 +8,8 @@ class Motley extends DrawCard {
         });
         this.reaction({
             when: {
-                onAttackersDeclared: event => event.challenge.isAttacking(this.parent),
-                onDefendersDeclared: event => event.challenge.isDefending(this.parent)
+                onDeclaredAsAttacker: event => event.card === this.parent,
+                onDeclaredAsDefender: event => event.card === this.parent
             },
             handler: () => {
                 this.parent.controller.discardAtRandom(1);

--- a/server/game/cards/06.4-TRW/BreakerOfChains.js
+++ b/server/game/cards/06.4-TRW/BreakerOfChains.js
@@ -10,7 +10,7 @@ class BreakerOfChains extends DrawCard {
 
         this.reaction({
             when: {
-                onAttackersDeclared: event => event.challenge.isAttacking(this.parent)
+                onDeclaredAsAttacker: event => event.card === this.parent
             },
             target: {
                 cardCondition: card =>

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -100,8 +100,7 @@ class ChallengeFlow extends BaseStep {
         this.challenge.initiateChallenge();
 
         let events = [
-            { name: 'onChallengeInitiated', params: { challenge: this.challenge } },
-            { name: 'onAttackersDeclared', params: { challenge: this.challenge } }
+            { name: 'onChallengeInitiated', params: { challenge: this.challenge } }
         ];
 
         let attackerEvents = this.declaredAttackers.map(card => {
@@ -164,10 +163,6 @@ class ChallengeFlow extends BaseStep {
             }
         }
 
-        let events = [
-            { name: 'onDefendersDeclared', params: { challenge: this.challenge } }
-        ];
-
         let defenderEvents = defenders.map(card => {
             return { name: 'onDeclaredAsDefender', params: { card: card } };
         });
@@ -176,7 +171,7 @@ class ChallengeFlow extends BaseStep {
             return { name: 'onCardKneeled', params: { player: this.challenge.defendingPlayer, card: card } };
         });
 
-        this.game.raiseAtomicEvent(events.concat(defenderEvents).concat(kneelEvents));
+        this.game.raiseAtomicEvent(defenderEvents.concat(kneelEvents));
 
         defendersToKneel = undefined;
 


### PR DESCRIPTION
Previously, there were aggregate events for when attackers
and defenders were declared in a challenge. This was causing
cards that used the events like Motley and Breaker of Chains
to trigger for characters that were added to the challenge
via an effect (e.g. Azor Ahai).

These cards have been reimplemented to use the singular
events for declaring an attacker or defender (which will not
fire if added by an effect), and the aggregate event has
been removed.

Fixes #2954 