### PR TITLE
Ensure Black Cells is respected for costs

### DIFF
--- a/server/game/costs/KneelCost.js
+++ b/server/game/costs/KneelCost.js
@@ -1,16 +1,20 @@
+const GameActions = require('../GameActions');
+
 class KneelCost {
     constructor() {
         this.name = 'kneel';
     }
 
     isEligible(card) {
-        return ['faction', 'play area'].includes(card.location) && !card.kneeled;
+        return GameActions.kneelCard({ card }).allow();
     }
 
     pay(cards, context) {
-        for(let card of cards) {
-            context.player.kneelCard(card);
-        }
+        context.game.resolveGameAction(
+            GameActions.simultaneously(
+                cards.map(card => GameActions.kneelCard({ card }))
+            )
+        );
     }
 }
 

--- a/server/game/costs/StandCost.js
+++ b/server/game/costs/StandCost.js
@@ -1,16 +1,20 @@
+const GameActions = require('../GameActions');
+
 class StandCost {
     constructor() {
         this.name = 'stand';
     }
 
     isEligible(card) {
-        return card.location === 'play area' && card.kneeled;
+        return GameActions.standCard({ card }).allow();
     }
 
     pay(cards, context) {
-        for(let card of cards) {
-            context.player.standCard(card);
-        }
+        context.game.resolveGameAction(
+            GameActions.simultaneously(
+                cards.map(card => GameActions.standCard({ card }))
+            )
+        );
     }
 }
 


### PR DESCRIPTION
The cost system was put into place before there was an effect
that prevented either kneeling or standing. This updates the
corresponding costs to use game actions to ensure that it
checks that the card can be knelt / stood.

Fixes #2955 