### PR TITLE
Trigger Wylla based on original card state

### DIFF
--- a/server/game/cards/15-DotE/WyllaManderly.js
+++ b/server/game/cards/15-DotE/WyllaManderly.js
@@ -4,8 +4,8 @@ class WyllaManderly extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: event => event.card.controller === this.controller,
-                onSacrificed: event => event.card.controller === this.controller && event.card.getType() === 'character'
+                onCharacterKilled: event => event.cardStateWhenKilled.controller === this.controller,
+                onSacrificed: event => event.cardStateWhenSacrificed.controller === this.controller && event.cardStateWhenSacrificed.getType() === 'character'
             },
             target: {
                 cardCondition: (card, context) => card.location === 'discard pile' && card.controller === this.controller && card !== context.event.card


### PR DESCRIPTION
For any kill or sacrifice events, they should look at the card
state when the event initiated instead of the current card so
that take control doesn't cause the ability to trigger for the
wrong player.

Fixes #2965 