### PR TITLE
Allow Water Dancer's Sword on 0 STR chars

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -215,7 +215,7 @@ class DrawCard extends BaseCard {
     }
 
     hasPrintedStrength() {
-        return !this.facedown && !!this.cardData.strength;
+        return !this.facedown && this.getType() === 'character';
     }
 
     getStrength() {


### PR DESCRIPTION
Previously, the logic to check if a card had a printed
STR value returned false for 0 STR characters due to
it coercing the STR value into a boolean. However, unlike
printed costs, all characters have a printed STR.

Fixes #2964 