### PR TITLE
fix so halder can´t target out of play characters

### DIFF
--- a/server/game/cards/02.4-NMG/Halder.js
+++ b/server/game/cards/02.4-NMG/Halder.js
@@ -9,7 +9,7 @@ class Halder extends DrawCard {
                 (card.getType() === 'attachment' || card.getType() === 'location')
             )),
             target: {
-                cardCondition: card => card.isFaction('thenightswatch') && card.getType() === 'character'
+                cardCondition: card => card.isFaction('thenightswatch') && card.getType() === 'character' && card.location === 'play area'
             },
             handler: (context) => {
                 this.game.addMessage('{0} uses {1} and kneels {2} to give {3} +1 STR until the end of the phase', this.controller, this, context.costs.kneel, context.target);


### PR DESCRIPTION
currently halders ability targets characters that are in out of play areas which leads to the deck, discard and dead pile to pop up and highlight the valid cards. This is a problem and could potentially be abused because now you see your deck and can derive information from this, for example how many characters are in the next 10 cards of your deck. 