### PR TITLE
fix amount of power moved by shyra errol

### DIFF
--- a/server/game/cards/14-FotS/ShyraErrol.js
+++ b/server/game/cards/14-FotS/ShyraErrol.js
@@ -19,7 +19,8 @@ class ShyraErrol extends DrawCard {
                 this.game.resolveGameAction(
                     GameActions.movePower(context => ({
                         from: context.event.card,
-                        to: context.event.card.controller.faction
+                        to: context.event.card.controller.faction,
+                        amount: context.event.card.power
                     })),
                     context
                 );


### PR DESCRIPTION
currently she moves only 1 power as that is the default amount value of the movePower Gameaction