### PR TITLE
Fix The Lost Message interaction w/ 0 cards

### DIFF
--- a/server/game/cards/15-DotE/TheLostMessage.js
+++ b/server/game/cards/15-DotE/TheLostMessage.js
@@ -9,9 +9,9 @@ class TheLostMessage extends PlotCard {
         this.action({
             title: 'Shuffle cards into deck',
             message: '{player} uses {source} to have each player shuffle their hand into their deck',
-            gameAction: GameActions.simultaneously(() => this.game.getPlayers().map(
-                player => GameActions.shuffleIntoDeck({ cards: player.hand })
-            )).then({
+            gameAction: GameActions.shuffleIntoDeck(() => ({
+                cards: flatten(this.game.getPlayers().map(player => player.hand))
+            })).then({
                 message: {
                     format: 'Then {fragments} for {source}',
                     args: { fragments: context => this.getMessageFragments(context) }

--- a/test/server/cards/15-DotE/TheLostMessage.spec.js
+++ b/test/server/cards/15-DotE/TheLostMessage.spec.js
@@ -57,11 +57,14 @@ describe('The Lost Message', function() {
                     }
                 });
 
-                it('shuffles cards into the deck but does not add to hand', function() {
+                it('shuffles cards into the deck then adds equal amounts back to hand', function() {
+                    const player2Hand = [...this.player2Object.hand];
+
                     this.player1.clickMenu(this.plot, 'Shuffle cards into deck');
 
                     expect(this.player1Object.hand).toEqual([]);
-                    expect(this.player2Object.hand).toEqual([]);
+                    expect(this.player2Object.hand.length).toEqual(player2Hand.length);
+                    expect(this.player2Object.hand).not.toEqual(player2Hand);
                 });
             });
         });


### PR DESCRIPTION
It has been ruled for The Lost Message that if one of the players
has 0 cards in hand, the pre-then condition is still considered to
be successful. Therefore, the players with cards in hand should be
able to add cards back to their hand.

Fixes #2983 