### PR TITLE
[bugfix] Fix string interpolation in Dornish Man's wife message

### DIFF
--- a/server/game/cards/06.2-GtR/TheDornishmansWife.js
+++ b/server/game/cards/06.2-GtR/TheDornishmansWife.js
@@ -14,7 +14,7 @@ class TheDornishmansWife extends DrawCard {
 
                 if(this.opponentHasMorePower(context.opponent) && this.controller.canGainGold()) {
                     let gold = this.game.addGold(this.controller, 2);
-                    bonusMessage.push('gain {1} gold', gold);
+                    bonusMessage.push('gain {0} gold', gold);
                 }
 
                 if(this.opponentHasMoreCardsInHand(context.opponent) && this.controller.canGainFactionPower()) {


### PR DESCRIPTION
The message of Dornish Man's Wife used faulty string interpolation,
which resulted e.g. in the following text (copied from game):

hechtlinger uses "The Dornishman's Wife" to choose Harren and gain {1} gold,
2 , and draw 1 card.