### PR TITLE
Fix City of Secrets then clause

### DIFF
--- a/server/game/CardMatcher.js
+++ b/server/game/CardMatcher.js
@@ -64,6 +64,8 @@ class CardMatcher {
                 return card.controller === context.player;
             case 'opponent':
                 return card.controller !== context.player;
+            case 'choosingPlayer':
+                return card.controller === context.choosingPlayer;
         }
 
         return false;


### PR DESCRIPTION
Previously, City of Secrets immediately checked whether the
player had 2 cards in hand after calling the draw method.
However, this method is now asynchronous, so if a player had
fewer than 2 cards in hand before the draw, they would not
be required to discard 2 cards.

Similarly, since the card did not use a proper Then check,
if either player was unable to draw 2 cards, the discard
would still trigger.

Fixes #2971 