### PR TITLE
New Gameoption: Disable chat for spectators

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -88,7 +88,7 @@ class Game extends EventEmitter {
         this.cardVisibility = new CardVisibility(this);
         this.winnerOfDominanceInLastRound = undefined;
         this.prizedKeywordListener = new PrizedKeywordListener(this);
-        this.isChatForSpectatorsEnabled = details.isChatForSpectatorsEnabled;
+        this.isChatForSpectatorsEnabled = details.isChatForSpectatorsEnabled === undefined ? true : details.isChatForSpectatorsEnabled;
 
         for(let player of Object.values(details.players || {})) {
             this.playersAndSpectators[player.user.username] = new Player(player.id, player.user, this.owner === player.user.username, this);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -88,6 +88,7 @@ class Game extends EventEmitter {
         this.cardVisibility = new CardVisibility(this);
         this.winnerOfDominanceInLastRound = undefined;
         this.prizedKeywordListener = new PrizedKeywordListener(this);
+        this.isChatForSpectatorsEnabled = details.isChatForSpectatorsEnabled;
 
         for(let player of Object.values(details.players || {})) {
             this.playersAndSpectators[player.user.username] = new Player(player.id, player.user, this.owner === player.user.username, this);
@@ -609,6 +610,14 @@ class Game extends EventEmitter {
 
                 return;
             }
+        }
+
+        //check if spectators may write messages in the chat
+        //chat input is disabled on the client side, so just in case
+        //somebody messes with the client, the message of a spectator 
+        //will not be written in any case
+        if(player.isSpectator() && !this.isChatForSpectatorsEnabled) {
+            return;
         }
 
         this.gameChat.addChatMessage('{0} {1}', player, message);
@@ -1274,7 +1283,8 @@ class Game extends EventEmitter {
                 useGameTimeLimit: this.useGameTimeLimit,
                 gameTimeLimitStarted: this.timeLimit.timeLimitStarted,
                 gameTimeLimitStartedAt: this.timeLimit.timeLimitStartedAt,
-                gameTimeLimitTime: this.timeLimit.timeLimitInMinutes
+                gameTimeLimitTime: this.timeLimit.timeLimitInMinutes,
+                isChatForSpectatorsEnabled: this.isChatForSpectatorsEnabled
             };
         }
 
@@ -1330,7 +1340,8 @@ class Game extends EventEmitter {
                     lobbyId: spectator.lobbyId,
                     name: spectator.name
                 };
-            })
+            }),
+            isChatForSpectatorsEnabled: this.isChatForSpectatorsEnabled
         };
     }
 

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -749,7 +749,8 @@ class Lobby {
             isMelee: game.isMelee,
             useRookery: game.useRookery,
             useGameTimeLimit: game.useGameTimeLimit,
-            gameTimeLimit: game.gameTimeLimit
+            gameTimeLimit: game.gameTimeLimit,
+            isChatForSpectatorsEnabled: game.isChatForSpectatorsEnabled
         });
         newGame.rematch = true;
 

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -23,6 +23,7 @@ class PendingGame {
         this.gameChat = new GameChat();
         this.useGameTimeLimit = details.useGameTimeLimit;
         this.gameTimeLimit = details.gameTimeLimit;
+        this.isChatForSpectatorsEnabled = details.chatForSpectatorsEnabled;
     }
 
     // Getters
@@ -325,7 +326,8 @@ class PendingGame {
             }),
             useRookery: this.useRookery,
             useGameTimeLimit: this.useGameTimeLimit,
-            gameTimeLimit: this.gameTimeLimit
+            gameTimeLimit: this.gameTimeLimit,
+            isChatForSpectatorsEnabled : this.isChatForSpectatorsEnabled
         };
     }
 
@@ -366,7 +368,8 @@ class PendingGame {
             spectators,
             useRookery: this.useRookery,
             useGameTimeLimit: this.useGameTimeLimit,
-            gameTimeLimit: this.gameTimeLimit
+            gameTimeLimit: this.gameTimeLimit,
+            isChatForSpectatorsEnabled : this.isChatForSpectatorsEnabled
         };
     }
 }


### PR DESCRIPTION
In worldcup games to prevent random people joining the game and spamming the chat, most games are created with a standard password, but opinions differ on which password should be used and it is a real pain in the ass to figure out the "correct" "standard" password... So i thought to add an option to games that disables the chat for spectators to have a greater incentive to host games without passwords. 
Please also look at the client PR!