### PR TITLE
knights of the hollow hill shadows setup

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -903,13 +903,20 @@ class Player extends Spectator {
         });
     }
 
+    canPutIntoShadows(card, playingType = 'put') {
+        return !this.playCardRestrictions.some(restriction => restriction(card, playingType));
+    }
+
     putIntoShadows(card, allowSave = true, callback = () => true) {
-        this.game.applyGameAction('putIntoShadows', card, card => {
-            this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, allowSave: allowSave }, event => {
-                event.cardStateWhenMoved = card.createSnapshot();
-                this.moveCard(card, 'shadows', { allowSave: allowSave }, callback);
+        let playingType = this.game.currentPhase === 'setup' ? 'setup' : 'put';
+        if(this.canPutIntoShadows(card, playingType)) {
+            this.game.applyGameAction('putIntoShadows', card, card => {
+                this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, allowSave: allowSave }, event => {
+                    event.cardStateWhenMoved = card.createSnapshot();
+                    this.moveCard(card, 'shadows', { allowSave: allowSave }, callback);
+                });
             });
-        });
+        }
     }
 
     shuffleCardIntoDeck(card, allowSave = true) {


### PR DESCRIPTION
fix so that the player with knights of the hollow hill can´t setup cards in shadows. I had a look at the stuff for the cannotSetup effect and why that didn´t work for setting up in shadows.