### PR TITLE
Fix Pulling the Strings + At the Gates interaction

### DIFF
--- a/server/game/CardMatcher.js
+++ b/server/game/CardMatcher.js
@@ -11,7 +11,7 @@ class CardMatcher {
             Matcher.anyValue(properties.trait, trait => card.hasTrait(trait)) &&
             Matcher.containsValue(properties.unique, card.isUnique()) &&
             Matcher.containsValue(properties.loyal, card.isLoyal()) &&
-            Matcher.containsValue(properties.limited, card.isLimited()) &&
+            Matcher.containsValue(properties.limited, card.isLimited && card.isLimited()) &&
             Matcher.anyValue(properties.printedCostOrLower, amount => card.hasPrintedCost() && card.getPrintedCost() <= amount) &&
             Matcher.anyValue(properties.printedCostOrHigher, amount => card.hasPrintedCost() && card.getPrintedCost() >= amount) &&
             Matcher.anyValue(properties.printedStrengthOrLower, amount => card.hasPrintedStrength() && card.getPrintedStrength() <= amount) &&

--- a/server/game/cards/01-Core/BuildingOrders.js
+++ b/server/game/cards/01-Core/BuildingOrders.js
@@ -3,8 +3,8 @@ const PlotCard = require('../../plotcard.js');
 class BuildingOrders extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForDeckSearch(this.controller, {
+            handler: context => {
+                this.game.promptForDeckSearch(context.player, {
                     numCards: 10,
                     activePromptTitle: 'Select a card',
                     cardType: ['attachment', 'location'],

--- a/server/game/cards/01-Core/CallingTheBanners.js
+++ b/server/game/cards/01-Core/CallingTheBanners.js
@@ -10,8 +10,8 @@ class CallingTheBanners extends PlotCard {
                     return;
                 }
 
-                let gold = this.game.addGold(this.controller, characterCount);
-                this.game.addMessage('{0} uses {1} to gain {2} gold', this.controller, this, gold);
+                let gold = this.game.addGold(context.player, characterCount);
+                this.game.addMessage('{0} uses {1} to gain {2} gold', context.player, this, gold);
             }
         });
     }

--- a/server/game/cards/01-Core/CountingCoppers.js
+++ b/server/game/cards/01-Core/CountingCoppers.js
@@ -4,10 +4,10 @@ const TextHelper = require('../../TextHelper');
 class CountingCoppers extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(3).length;
+            handler: context => {
+                let cards = context.player.drawCardsToHand(3).length;
                 this.game.addMessage('{0} uses {1} to draw {2} to hand',
-                    this.controller, this, TextHelper.count(cards, 'card'));
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }

--- a/server/game/cards/01-Core/FilthyAccusations.js
+++ b/server/game/cards/01-Core/FilthyAccusations.js
@@ -7,10 +7,9 @@ class FilthyAccusations extends PlotCard {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
                 gameAction: 'kneel'
             },
+            message: '{player} uses {source} to kneel {target}',
             handler: context => {
-                this.controller.kneelCard(context.target);
-
-                this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, context.target);
+                context.player.kneelCard(context.target);
             }
         });
     }

--- a/server/game/cards/01-Core/HeadsOnSpikes.js
+++ b/server/game/cards/01-Core/HeadsOnSpikes.js
@@ -20,13 +20,13 @@ class HeadsOnSpikes extends PlotCard {
                             otherPlayer.moveCard(card, 'dead pile');
                         }
 
-                        if(this.controller.canGainFactionPower()) {
+                        if(context.player.canGainFactionPower()) {
                             powerMessage = ' and gain 2 power for their faction';
-                            this.game.addPower(this.controller, 2);
+                            this.game.addPower(context.player, 2);
                         }
                     }
 
-                    this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand{4}', this.controller, this, card, otherPlayer, powerMessage);
+                    this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand{4}', context.player, this, card, otherPlayer, powerMessage);
                 });
             }
         });

--- a/server/game/cards/01-Core/Rebuilding.js
+++ b/server/game/cards/01-Core/Rebuilding.js
@@ -6,15 +6,15 @@ class Rebuilding extends PlotCard {
             target: {
                 numCards: 3,
                 activePromptTitle: 'Select up to 3 cards',
-                cardCondition: card => this.controller === card.controller && card.location === 'discard pile'
+                cardCondition: (card, context) => context.player === card.controller && card.location === 'discard pile'
             },
             handler: context => {
                 for(let card of context.target) {
-                    this.controller.moveCard(card, 'draw deck');
+                    context.player.moveCard(card, 'draw deck');
                 }
 
-                this.controller.shuffleDrawDeck();
-                this.game.addMessage('{0} uses {1} to shuffle {2} into their deck', this.controller, this, context.target);
+                context.player.shuffleDrawDeck();
+                this.game.addMessage('{0} uses {1} to shuffle {2} into their deck', context.player, this, context.target);
             }
         });
     }

--- a/server/game/cards/01-Core/Reinforcement.js
+++ b/server/game/cards/01-Core/Reinforcement.js
@@ -4,17 +4,17 @@ class Reinforcements extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             target: {
-                cardCondition: card => (
-                    this.controller === card.controller &&
+                cardCondition: (card, context) => (
+                    context.player === card.controller &&
                     card.getPrintedCost() <= 5 &&
                     card.getType() === 'character' &&
                     ['hand', 'discard pile'].includes(card.location) &&
-                    this.controller.canPutIntoPlay(card)
+                    context.player.canPutIntoPlay(card)
                 )
             },
             handler: context => {
-                this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', this.controller, this, context.target, context.target.location);
-                this.controller.putIntoPlay(context.target);
+                this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', context.player, this, context.target, context.target.location);
+                context.player.putIntoPlay(context.target);
             }
         });
     }

--- a/server/game/cards/01-Core/Summons.js
+++ b/server/game/cards/01-Core/Summons.js
@@ -3,8 +3,8 @@ const PlotCard = require('../../plotcard.js');
 class Summons extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForDeckSearch(this.controller, {
+            handler: context => {
+                this.game.promptForDeckSearch(context.player, {
                     numCards: 10,
                     activePromptTitle: 'Select a card',
                     cardType: 'character',

--- a/server/game/cards/02.1-TtB/HereToServe.js
+++ b/server/game/cards/02.1-TtB/HereToServe.js
@@ -3,10 +3,10 @@ const PlotCard = require('../../plotcard.js');
 class HereToServe extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForDeckSearch(this.controller, {
+            handler: context => {
+                this.game.promptForDeckSearch(context.player, {
                     activePromptTitle: 'Select a card',
-                    cardCondition: card => card.hasTrait('Maester') && card.getPrintedCost() <= 3 && this.controller.canPutIntoPlay(card),
+                    cardCondition: card => card.hasTrait('Maester') && card.getPrintedCost() <= 3 && context.player.canPutIntoPlay(card),
                     onSelect: (player, card) => this.cardSelected(player, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this

--- a/server/game/cards/02.2-TRtW/TradingWithThePentoshi.js
+++ b/server/game/cards/02.2-TRtW/TradingWithThePentoshi.js
@@ -4,11 +4,11 @@ class TradingWithThePentoshi extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             cannotBeCanceled: true,
-            handler: () => {
-                for(let opponent of this.game.getOpponents(this.controller)) {
+            handler: context => {
+                for(let opponent of this.game.getOpponents(context.player)) {
                     this.game.addGold(opponent, 3);
                 }
-                this.game.addMessage('Each opponent gains 3 gold from {0}\'s {1}', this.controller, this);
+                this.game.addMessage('Each opponent gains 3 gold from {0}\'s {1}', context.player, this);
             }
         });
     }

--- a/server/game/cards/06.5-OR/WheelsWithinWheels.js
+++ b/server/game/cards/06.5-OR/WheelsWithinWheels.js
@@ -3,10 +3,10 @@ const PlotCard = require('../../plotcard.js');
 class WheelsWithinWheels extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
+            handler: context => {
                 this.cards = undefined;
 
-                this.game.promptForDeckSearch(this.controller, {
+                this.game.promptForDeckSearch(context.player, {
                     numCards: 10,
                     numToSelect: 10,
                     activePromptTitle: 'Select any number of events',
@@ -35,7 +35,7 @@ class WheelsWithinWheels extends PlotCard {
             return { card: card, method: 'resolve', mapCard: true };
         });
 
-        this.game.promptWithMenu(this.controller, this, {
+        this.game.promptWithMenu(player, this, {
             activePrompt: {
                 menuTitle: 'Select a card to draw',
                 buttons: buttons

--- a/server/game/cards/07-WotW/CalledIntoService.js
+++ b/server/game/cards/07-WotW/CalledIntoService.js
@@ -3,26 +3,26 @@ const PlotCard = require('../../plotcard.js');
 class CalledIntoService extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                let topCard = this.controller.drawDeck[0];
+            handler: context => {
+                let topCard = context.player.drawDeck[0];
 
                 if(topCard.getType() === 'character') {
-                    this.controller.putIntoPlay(topCard);
+                    context.player.putIntoPlay(topCard);
                     this.game.addMessage('{0} uses {1} to reveal {2} as the top card of their deck and put it into play',
-                        this.controller, this, topCard);
-                } else if(this.controller.canDraw() || this.controller.canGainGold()) {
+                        context.player, this, topCard);
+                } else if(context.player.canDraw() || context.player.canGainGold()) {
                     let msg = '{0} uses {1} to reveal {2} as the top card of their deck';
                     let gold;
-                    if(this.controller.canDraw()) {
-                        this.controller.drawCardsToHand(1);
+                    if(context.player.canDraw()) {
+                        context.player.drawCardsToHand(1);
                         msg += ', draw it';
                     }
-                    if(this.controller.canGainGold()) {
-                        gold = this.game.addGold(this.controller, 2);
+                    if(context.player.canGainGold()) {
+                        gold = this.game.addGold(context.player, 2);
                         msg += ', gain {3} gold';
                     }
 
-                    this.game.addMessage(msg, this.controller, this, topCard, gold);
+                    this.game.addMessage(msg, context.player, this, topCard, gold);
                 }
             }
         });

--- a/server/game/cards/08.6-SAT/YouWinOrYouDie.js
+++ b/server/game/cards/08.6-SAT/YouWinOrYouDie.js
@@ -4,10 +4,10 @@ const TextHelper = require('../../TextHelper');
 class YouWinOrYouDie extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                let cards = this.controller.drawCardsToHand(2).length;
+            handler: context => {
+                let cards = context.player.drawCardsToHand(2).length;
                 this.game.addMessage('{0} uses {1} to draw {2}',
-                    this.controller, this, TextHelper.count(cards, 'card'));
+                    context.player, this, TextHelper.count(cards, 'card'));
             }
         });
     }

--- a/server/game/cards/10-SoD/AtPrinceDoransBehest.js
+++ b/server/game/cards/10-SoD/AtPrinceDoransBehest.js
@@ -7,7 +7,7 @@ class AtPrinceDoransBehest extends PlotCard {
             cannotBeCanceled: true,
             target: {
                 activePromptTitle: 'Select a plot',
-                cardCondition: card => card.location === 'plot deck' && card.controller === this.controller && !card.notConsideredToBeInPlotDeck,
+                cardCondition: (card, context) => card.location === 'plot deck' && card.controller === context.player && !card.notConsideredToBeInPlotDeck,
                 cardType: 'plot'
             },
             handler: context => {

--- a/server/game/cards/11.1-TSC/ExchangeOfInformation.js
+++ b/server/game/cards/11.1-TSC/ExchangeOfInformation.js
@@ -6,10 +6,11 @@ class ExchangeOfInformation extends PlotCard {
             chooseOpponent: true,
             handler: context => {
                 this.remainingCardTypes = ['character', 'location', 'attachment', 'event'];
-                this.potentialCards = this.controller.searchDrawDeck(10);
+                this.potentialCards = context.player.searchDrawDeck(10);
                 this.selectedCards = [];
                 this.selectingOpponent = context.opponent;
-                this.game.addMessage('{0} uses {1} to choose {2} and reveals {3}', this.controller, this, context.opponent, this.potentialCards);
+                this.initiatingPlayer = context.player;
+                this.game.addMessage('{0} uses {1} to choose {2} and reveals {3}', context.player, this, context.opponent, this.potentialCards);
 
                 let revealFunc = card => this.potentialCards.includes(card);
                 this.game.cardVisibility.addRule(revealFunc);
@@ -42,7 +43,7 @@ class ExchangeOfInformation extends PlotCard {
         let text = ['attachment', 'event'].includes(cardType) ? `an ${cardType}` : `a ${cardType}`;
 
         this.game.promptForSelect(this.selectingOpponent, {
-            activePromptTitle: `Select ${text} for ${this.controller.name}`,
+            activePromptTitle: `Select ${text} for ${this.initiatingPlayer.name}`,
             cardCondition: card => this.potentialCards.includes(card) && card.getType() === cardType,
             onSelect: (player, card) => this.selectCard(player, card),
             onCancel: (player) => this.skipCard(player, cardType),
@@ -65,10 +66,10 @@ class ExchangeOfInformation extends PlotCard {
 
     completeSelection() {
         for(let card of this.selectedCards) {
-            this.controller.moveCard(card, 'hand');
+            this.initiatingPlayer.moveCard(card, 'hand');
         }
-        this.controller.shuffleDrawDeck();
-        this.game.addMessage('{0} adds {1} chosen by {2} to their hand and shuffles their deck', this.controller, this.selectedCards, this.selectingOpponent);
+        this.initiatingPlayer.shuffleDrawDeck();
+        this.game.addMessage('{0} adds {1} chosen by {2} to their hand and shuffles their deck', this.initiatingPlayer, this.selectedCards, this.selectingOpponent);
     }
 }
 

--- a/server/game/cards/12-KotI/HeirToTheIronThrone.js
+++ b/server/game/cards/12-KotI/HeirToTheIronThrone.js
@@ -3,11 +3,11 @@ const PlotCard = require('../../plotcard');
 class HeirToTheIronThrone extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForDeckSearch(this.controller, {
+            handler: context => {
+                this.game.promptForDeckSearch(context.player, {
                     numCards: 10,
                     activePromptTitle: 'Select a character',
-                    cardCondition: card => card.getType() === 'character' && ['Lord', 'Lady'].some(trait => card.hasTrait(trait)) && this.controller.canPutIntoPlay(card),
+                    cardCondition: card => card.getType() === 'character' && ['Lord', 'Lady'].some(trait => card.hasTrait(trait)) && context.player.canPutIntoPlay(card),
                     onSelect: (player, card) => this.cardSelected(player, card),
                     onCancel: player => this.doneSelecting(player),
                     source: this

--- a/server/game/cards/12-KotI/ReturnToTheFields.js
+++ b/server/game/cards/12-KotI/ReturnToTheFields.js
@@ -9,7 +9,7 @@ class ReturnToTheFields extends PlotCard {
                 type: 'select',
                 mode: 'upTo',
                 numCards: 3,
-                cardCondition: card => card.getType() === 'character' && card.location === 'play area' && card.controller === this.controller,
+                cardCondition: (card, context) => card.getType() === 'character' && card.location === 'play area' && card.controller === context.player,
                 gameAction: 'sacrifice'
             },
             handler: (context) => {

--- a/server/game/cards/13.1-AtG/AtTheGates.js
+++ b/server/game/cards/13.1-AtG/AtTheGates.js
@@ -3,8 +3,8 @@ const PlotCard = require('../../plotcard.js');
 class AtTheGates extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForDeckSearch(this.controller, {
+            handler: context => {
+                this.game.promptForDeckSearch(context.player, {
                     activePromptTitle: 'Select a card',
                     cardCondition: card => card.getPrintedCost() <= 1 && card.isLimited(),
                     onSelect: (player, card) => this.cardSelected(player, card),
@@ -15,16 +15,16 @@ class AtTheGates extends PlotCard {
         });
     }
 
-    hasUsedCityPlot() {
+    hasUsedCityPlot(player) {
         return this.game.allCards.some(card => (
-            card.controller === this.controller &&
+            card.controller === player &&
             card.location === 'revealed plots' &&
             card.hasTrait('City')
         ));
     }
 
     cardSelected(player, card) {
-        if(this.hasUsedCityPlot()) {
+        if(this.hasUsedCityPlot(player)) {
             this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
                 player, this, card);
             player.moveCard(card, 'hand');

--- a/server/game/cards/13.2-CoS/ACityBesieged.js
+++ b/server/game/cards/13.2-CoS/ACityBesieged.js
@@ -3,13 +3,13 @@ const PlotCard = require('../../plotcard.js');
 class ACityBesieged extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
+            handler: context => {
                 let numTargets = this.hasUsedCityPlot() ? 2 : 1;
 
-                this.game.promptForSelect(this.controller, {
+                this.game.promptForSelect(context.player, {
                     mode: 'upTo',
                     numCards: numTargets,
-                    activePromptTitle: this.hasUsedCityPlot() ? 'Select up to 2 locations' : 'Select a location',
+                    activePromptTitle: this.hasUsedCityPlot(context.player) ? 'Select up to 2 locations' : 'Select a location',
                     source: this,
                     gameAction: 'kneel',
                     cardCondition: card => card.location === 'play area' &&
@@ -23,16 +23,16 @@ class ACityBesieged extends PlotCard {
 
     targetsSelected(player, cards) {
         for(let card of cards) {
-            this.controller.kneelCard(card);
+            player.kneelCard(card);
         }
 
         this.game.addMessage('{0} uses {1} to kneel {2}', player, this, cards);
         return true;
     }
 
-    hasUsedCityPlot() {
+    hasUsedCityPlot(player) {
         return this.game.allCards.some(card => (
-            card.controller === this.controller &&
+            card.controller === player &&
             card.location === 'revealed plots' &&
             card.hasTrait('City')
         ));

--- a/server/game/cards/13.4-BtRK/CityOfSpiders.js
+++ b/server/game/cards/13.4-BtRK/CityOfSpiders.js
@@ -10,8 +10,8 @@ class CityOfSpiders extends PlotCard {
 
                 this.context = context;
 
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.isCityPlotInControllersUsedPileWithWhenRevealedAbility(card),
+                this.game.promptForSelect(context.player, {
+                    cardCondition: card => this.isCityPlotInControllersUsedPileWithWhenRevealedAbility(card, context.player),
                     cardType: 'plot',
                     activePromptTitle: 'Select a plot',
                     source: this,
@@ -21,8 +21,8 @@ class CityOfSpiders extends PlotCard {
         });
     }
 
-    isCityPlotInControllersUsedPileWithWhenRevealedAbility(card) {
-        return card.location === 'revealed plots' && card.controller === this.controller && card.hasTrait('City') && card.getWhenRevealedAbility();
+    isCityPlotInControllersUsedPileWithWhenRevealedAbility(card, player) {
+        return card.location === 'revealed plots' && card.controller === player && card.hasTrait('City') && card.getWhenRevealedAbility();
     }
 
     onCardSelected(player, card) {

--- a/server/game/cards/13.6-LMHR/ExposeDuplicity.js
+++ b/server/game/cards/13.6-LMHR/ExposeDuplicity.js
@@ -4,6 +4,7 @@ const GameActions = require('../../GameActions');
 class ExposeDuplicity extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
+            message: '{player} uses {source} to discard each card in shadows',
             handler: () => {
                 let cardsInShadows = this.game.allCards.filter(card => card.location === 'shadows');
 
@@ -14,9 +15,6 @@ class ExposeDuplicity extends PlotCard {
                 this.game.resolveGameAction(
                     GameActions.simultaneously(actions)
                 );
-
-                this.game.addMessage('{0} uses {1} to discard each card in shadows',
-                    this.controller, this);
             }
         });
     }

--- a/test/server/cards/13.1-AtG/AtTheGates.spec.js
+++ b/test/server/cards/13.1-AtG/AtTheGates.spec.js
@@ -35,5 +35,65 @@ describe('At The Gates', function() {
                 expect(this.player2Object.getTotalIncome()).toBe(8);
             });
         });
+
+        describe('w/ Pulling the Strings', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'At the Gates', 'Pulling the Strings', 'A Noble Cause', 'City of Spiders',
+                    'Gates of the Moon'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.limitedCard = this.player1.findCardByName('Gates of the Moon');
+
+                this.atTheGates = this.player2.findCardByName('At the Gates');
+
+                this.completeSetup();
+
+                // Draw the limited card back into the deck
+                this.player1.dragCard(this.limitedCard, 'draw deck');
+
+                // Drag At The Gates to used pile to be copied
+                this.player2.dragCard(this.atTheGates, 'revealed plots');
+            });
+
+            describe('when there is no City plot in your used pile', function() {
+                beforeEach(function() {
+                    this.player1.selectPlot('Pulling the Strings');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.clickCard(this.atTheGates);
+
+                    this.player1.clickCard(this.limitedCard);
+                });
+
+                it('puts the card into play', function() {
+                    expect(this.limitedCard.location).toBe('play area');
+                });
+            });
+
+            describe('when there is a City plot in your used pile', function() {
+                beforeEach(function() {
+                    const ownCityPlot = this.player1.findCardByName('City of Spiders');
+                    this.player1.dragCard(ownCityPlot, 'revealed plots');
+
+                    this.player1.selectPlot('Pulling the Strings');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.clickCard(this.atTheGates);
+
+                    this.player1.clickCard(this.limitedCard);
+                });
+
+                it('puts the card into hand', function() {
+                    expect(this.limitedCard.location).toBe('hand');
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Gets rid of `this.controller` within each plot that Pulling the Strings can interact with, so we no longer need to do a fake take-control to initiate the ability. This means that the At The Gates plot being initiated no longer counts as a City plot in your own used pile.