### PR TITLE
Chessclocks

### DIFF
--- a/server/game/ChessClock.js
+++ b/server/game/ChessClock.js
@@ -1,0 +1,98 @@
+class ChessClock {
+    constructor(player, time, delayToStartClock) {
+        this.player = player;
+        this.mainTime = time * 60;
+        this.timeLeft = time * 60;
+        this.mode = 'inactive';
+        this.timerStart = 0; //when the clock is running, this contains the instant on which it started
+        this.paused = false; //has the clock been paused via chat command?
+        this.running = false; //is the clock ticking for the player?
+        this.stateId = 0;
+        this.name = 'ChessClock';
+        this.activated = false; //indicates if the game has started/setup is finished 
+        this.delayToStartClock = delayToStartClock;
+
+        this.player.game.on('onSetupFinished', () => this.activateChessClock());
+    }
+
+    activateChessClock() {
+        this.activated = true;
+    }
+
+    togglePause() {
+        if(this.activated) {
+            this.paused = !this.paused;
+            if(this.paused) {
+                this.stop();
+            }
+        }
+    }
+
+    modify(secs) {
+        this.timeLeft += secs;
+    }
+
+    updateStateId() {
+        this.stateId++;
+    }
+
+    start() {
+        if(this.activated) {
+            if(!this.paused && !this.running) {
+                this.mode = 'down';
+                this.running = true;
+                this.timerStart = Date.now();
+                this.updateStateId();
+            }
+        }
+    }
+
+    stop() {
+        if(this.activated) {
+            if(this.timerStart > 0 && this.running) {
+                this.running = false;
+                this.updateTimeLeft(Math.floor(((Date.now() - this.timerStart) / 1000) + 0.5));
+                this.timerStart = 0;
+                this.updateStateId();
+            }
+            this.mode = 'stop';
+        }
+    }
+
+    timeRanOut() {
+        this.player.game.addMessage('{0}\'s clock has run out', this.player);
+        this.player.game.recordWinner(this.player.game.getOpponents(this.player)[0], 'time');
+        return;
+    }
+
+    updateTimeLeft(secs) {
+        if(this.timeLeft === 0 || secs < 0) {
+            return;
+        }
+        if(secs <= this.delayToStartClock) {
+            return;
+        }
+        
+        secs = secs - this.delayToStartClock;
+        if(this.mode === 'down') {
+            this.modify(-secs);
+            if(this.timeLeft < 0) {
+                this.timeLeft = 0;
+                this.timeRanOut();
+            }
+        }
+    }
+
+    getState() {
+        return {
+            mode: this.mode,
+            timeLeft: this.timeLeft,
+            stateId: this.stateId,
+            mainTime: this.mainTime,
+            name: this.name,
+            delayToStartClock: this.delayToStartClock
+        };
+    }
+}
+
+module.exports = ChessClock;

--- a/server/game/ChessClock.js
+++ b/server/game/ChessClock.js
@@ -20,11 +20,12 @@ class ChessClock {
     }
 
     togglePause() {
-        if(this.activated) {
-            this.paused = !this.paused;
-            if(this.paused) {
-                this.stop();
-            }
+        if(!this.activated) {
+            return;
+        }
+        this.paused = !this.paused;
+        if(this.paused) {
+            this.stop();
         }
     }
 
@@ -37,30 +38,33 @@ class ChessClock {
     }
 
     start() {
-        if(this.activated) {
-            if(!this.paused && !this.running) {
-                this.mode = 'down';
-                this.running = true;
-                this.timerStart = Date.now();
-                this.updateStateId();
-            }
+        if(!this.activated) {
+            return;
+        }
+        if(!this.paused && !this.running) {
+            this.mode = 'down';
+            this.running = true;
+            this.timerStart = Date.now();
+            this.updateStateId();
         }
     }
 
     stop() {
-        if(this.activated) {
-            if(this.timerStart > 0 && this.running) {
-                this.running = false;
-                this.updateTimeLeft(Math.floor(((Date.now() - this.timerStart) / 1000) + 0.5));
-                this.timerStart = 0;
-                this.updateStateId();
-            }
-            this.mode = 'stop';
+        if(!this.activated) {
+            return;
         }
+        if(this.timerStart > 0 && this.running) {
+            this.running = false;
+            this.updateTimeLeft(Math.floor(((Date.now() - this.timerStart) / 1000) + 0.5));
+            this.timerStart = 0;
+            this.updateStateId();
+        }
+        this.mode = 'stop';
     }
 
     timeRanOut() {
         this.player.game.addMessage('{0}\'s clock has run out', this.player);
+        //TODO make this melee friendly
         this.player.game.recordWinner(this.player.game.getOpponents(this.player)[0], 'time');
         return;
     }

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -39,7 +39,9 @@ class ChatCommands {
             '/take-icon': this.removeIcon,
             '/token': this.setToken,
             '/unblank': this.unblank,
-            '/mute-spectators': this.muteSpectators
+            '/mute-spectators': this.muteSpectators,
+            '/pause-clock': this.pauseClock,
+            '/add-chess-clock-time': this.addChessClockTime
         };
     }
 
@@ -511,6 +513,31 @@ class ChatCommands {
             player,
             this.game.muteSpectators ? '' : 'un'
         );
+    }
+
+    pauseClock(player) {
+        this.game.pauseClock();
+
+        this.game.addAlert(
+            'danger',
+            '{0} has {1}paused the clock',
+            player,
+            this.game.clockPaused ? '' : 'un'
+        );
+    }
+
+    addChessClockTime(player, args) {
+        var numberOfSeconds = this.getNumberOrDefault(args[1], 0);
+        if(player) {
+            player.addSecondsToClock(numberOfSeconds);
+
+            this.game.addAlert(
+                'danger',
+                '{0} has added {1} seconds to his/her chess clock',
+                player,
+                numberOfSeconds
+            );
+        }
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -66,6 +66,10 @@ class Game extends EventEmitter {
         this.createdAt = new Date();
         this.useGameTimeLimit = details.useGameTimeLimit;
         this.gameTimeLimit = details.gameTimeLimit;
+        this.useChessClocks = details.useChessClocks;
+        this.chessClockTimeLimit = details.chessClockTimeLimit;
+        this.delayToStartClock = 5;
+        this.clockPaused = false;
         this.timeLimit = new TimeLimit(this);
         this.savedGameId = details.savedGameId;
         this.gameType = details.gameType;
@@ -1225,6 +1229,18 @@ class Game extends EventEmitter {
         return 'game';
     }
 
+    pauseClock() {
+        this.clockPaused = !this.clockPaused;
+        if(this.useChessClocks) {
+            let players = this.getPlayers();
+            for(let player of players) {
+                player.togglePauseChessClock();
+            }
+        }
+
+        //TODO pause time limit clock, not only chess clock
+    }
+
     getSaveState() {
         var players = this.getPlayers().map(player => {
             return {
@@ -1278,7 +1294,9 @@ class Game extends EventEmitter {
                 gameTimeLimitStarted: this.timeLimit.timeLimitStarted,
                 gameTimeLimitStartedAt: this.timeLimit.timeLimitStartedAt,
                 gameTimeLimitTime: this.timeLimit.timeLimitInMinutes,
-                muteSpectators: this.muteSpectators
+                muteSpectators: this.muteSpectators,
+                useChessClocks: this.useChessClocks,
+                chessClockTimeLimit: this.chessClockTimeLimit
             };
         }
 
@@ -1335,7 +1353,8 @@ class Game extends EventEmitter {
                     name: spectator.name
                 };
             }),
-            muteSpectators: this.muteSpectators
+            muteSpectators: this.muteSpectators,
+            useChessClocks: this.useChessClocks
         };
     }
 

--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -23,6 +23,10 @@ class AttachmentPrompt extends UiPrompt {
     setupRestriction(card) {
         return this.game.currentPhase === 'setup' ? card.controller === this.attachmentCard.controller : true;
     }
+
+    getPlayer() {
+        return this.player;
+    }
 }
 
 module.exports = AttachmentPrompt;

--- a/server/game/gamesteps/marshaling/marshalcardsprompt.js
+++ b/server/game/gamesteps/marshaling/marshalcardsprompt.js
@@ -31,6 +31,10 @@ class MarshalCardsPrompt extends UiPrompt {
         this.game.addMessage('{0} has finished marshalling', player);
         this.complete();
     }
+
+    getPlayer() {
+        return this.player;
+    }
 }
 
 module.exports = MarshalCardsPrompt;

--- a/server/game/gamesteps/menuprompt.js
+++ b/server/game/gamesteps/menuprompt.js
@@ -66,6 +66,10 @@ class MenuPrompt extends UiPrompt {
     getButton(method, arg) {
         return this.properties.activePrompt.buttons && this.properties.activePrompt.buttons.find(button => button.method === method && (!button.mapCard || button.card.uuid === arg));
     }
+
+    getPlayer() {
+        return this.player;
+    }
 }
 
 module.exports = MenuPrompt;

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -41,6 +41,10 @@ class FirstPlayerPrompt extends UIPrompt {
 
         this.complete();
     }
+
+    getPlayer() {
+        return this.player;
+    }
 }
 
 module.exports = FirstPlayerPrompt;

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -255,6 +255,10 @@ class SelectCardPrompt extends UiPrompt {
         // the prompt is cancelled.
         this.complete();
     }
+
+    getPlayer() {
+        return this.choosingPlayer;
+    }
 }
 
 module.exports = SelectCardPrompt;

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -15,9 +15,9 @@ class UiPrompt extends BaseStep {
     complete() {
         this.completed = true;
         if(this.getPlayer()) {
-            if(this.getPlayer().stopClock) {
+            // if(this.getPlayer().stopClock) {
                 this.getPlayer().stopClock();
-            }
+            // }
         }
     }
 
@@ -25,14 +25,14 @@ class UiPrompt extends BaseStep {
         for(let player of this.game.getPlayers()) {
             if(this.activeCondition(player)) {
                 player.setPrompt(this.addDefaultCommandToButtons(this.activePrompt(player)));
-                if(player.startClock) {
+                // if(player.startClock) {
                     player.startClock();
-                }
+                // }
             } else {
                 player.setPrompt(this.addDefaultCommandToButtons(this.waitingPrompt(player)));
-                if(player.stopClock) {
+                // if(player.stopClock) {
                     player.stopClock();
-                }
+                // }
             }
         }
     }

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -15,9 +15,7 @@ class UiPrompt extends BaseStep {
     complete() {
         this.completed = true;
         if(this.getPlayer()) {
-            // if(this.getPlayer().stopClock) {
-                this.getPlayer().stopClock();
-            // }
+            this.getPlayer().stopClock();
         }
     }
 
@@ -25,14 +23,10 @@ class UiPrompt extends BaseStep {
         for(let player of this.game.getPlayers()) {
             if(this.activeCondition(player)) {
                 player.setPrompt(this.addDefaultCommandToButtons(this.activePrompt(player)));
-                // if(player.startClock) {
-                    player.startClock();
-                // }
+                player.startClock();
             } else {
                 player.setPrompt(this.addDefaultCommandToButtons(this.waitingPrompt(player)));
-                // if(player.stopClock) {
-                    player.stopClock();
-                // }
+                player.stopClock();
             }
         }
     }

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -15,7 +15,9 @@ class UiPrompt extends BaseStep {
     complete() {
         this.completed = true;
         if(this.getPlayer()) {
-            this.getPlayer().stopClock();
+            if(this.getPlayer().stopClock) {
+                this.getPlayer().stopClock();
+            }
         }
     }
 
@@ -23,10 +25,14 @@ class UiPrompt extends BaseStep {
         for(let player of this.game.getPlayers()) {
             if(this.activeCondition(player)) {
                 player.setPrompt(this.addDefaultCommandToButtons(this.activePrompt(player)));
-                player.startClock();
+                if(player.startClock) {
+                    player.startClock();
+                }
             } else {
                 player.setPrompt(this.addDefaultCommandToButtons(this.waitingPrompt(player)));
-                player.stopClock();
+                if(player.stopClock) {
+                    player.stopClock();
+                }
             }
         }
     }

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -14,14 +14,19 @@ class UiPrompt extends BaseStep {
 
     complete() {
         this.completed = true;
+        if(this.getPlayer()) {
+            this.getPlayer().stopClock();
+        }
     }
 
     setPrompt() {
         for(let player of this.game.getPlayers()) {
             if(this.activeCondition(player)) {
                 player.setPrompt(this.addDefaultCommandToButtons(this.activePrompt(player)));
+                player.startClock();
             } else {
                 player.setPrompt(this.addDefaultCommandToButtons(this.waitingPrompt(player)));
+                player.stopClock();
             }
         }
     }
@@ -55,7 +60,7 @@ class UiPrompt extends BaseStep {
         return { menuTitle: 'Waiting for opponent' };
     }
 
-    continue() {
+    continue() {        
         var completed = this.isComplete();
 
         if(completed) {
@@ -86,6 +91,13 @@ class UiPrompt extends BaseStep {
      * Handler that will be called once isComplete() returns true.
      */
     onCompleted() {
+    }
+
+    /**
+     * Will be implemented in sub classes that have a specific player that is using the prompt
+     */
+    getPlayer() {
+        return undefined;
     }
 }
 

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -749,7 +749,9 @@ class Lobby {
             isMelee: game.isMelee,
             useRookery: game.useRookery,
             useGameTimeLimit: game.useGameTimeLimit,
-            gameTimeLimit: game.gameTimeLimit
+            gameTimeLimit: game.gameTimeLimit,
+            useChessClocks: game.useChessClocks,
+            chessClockTimeLimit: game.chessClockTimeLimit
         });
         newGame.rematch = true;
 

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -24,6 +24,8 @@ class PendingGame {
         this.useGameTimeLimit = details.useGameTimeLimit;
         this.gameTimeLimit = details.gameTimeLimit;
         this.muteSpectators = details.muteSpectators;
+        this.useChessClocks = details.useChessClocks;
+        this.chessClockTimeLimit = details.chessClockTimeLimit;
     }
 
     // Getters
@@ -327,7 +329,9 @@ class PendingGame {
             useRookery: this.useRookery,
             useGameTimeLimit: this.useGameTimeLimit,
             gameTimeLimit: this.gameTimeLimit,
-            muteSpectators: this.muteSpectators
+            muteSpectators: this.muteSpectators,
+            useChessClocks: this.useChessClocks,
+            chessClockTimeLimit: this.chessClockTimeLimit
         };
     }
 
@@ -369,7 +373,9 @@ class PendingGame {
             useRookery: this.useRookery,
             useGameTimeLimit: this.useGameTimeLimit,
             gameTimeLimit: this.gameTimeLimit,
-            muteSpectators: this.muteSpectators
+            muteSpectators: this.muteSpectators,
+            useChessClocks: this.useChessClocks,
+            chessClockTimeLimit: this.chessClockTimeLimit
         };
     }
 }

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -6,8 +6,8 @@ describe('the PlayerOrderPrompt', function() {
         this.waitingPrompt = { active: false };
 
         this.game = jasmine.createSpyObj('game', ['getPlayers', 'getPlayersInFirstPlayerOrder']);
-        this.player1 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt']);
-        this.player2 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt']);
+        this.player1 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
+        this.player2 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
 
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);
         this.game.getPlayersInFirstPlayerOrder.and.returnValue([this.player2, this.player1]);

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -16,9 +16,9 @@ describe('the SelectCardPrompt', function() {
         this.game = jasmine.createSpyObj('game', ['getPlayers', 'getNumberOfPlayers']);
         this.game.getPlayers.and.returnValue([]);
 
-        this.player = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards']);
+        this.player = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards', 'startClock', 'stopClock']);
         this.player.cardsInPlay = [];
-        this.otherPlayer = jasmine.createSpyObj('player2', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards']);
+        this.otherPlayer = jasmine.createSpyObj('player2', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards', 'startClock', 'stopClock']);
         this.card = createCardSpy({ name: 'card', controller: this.player });
 
         this.player.cardsInPlay.push(this.card);

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -2,8 +2,8 @@ const UiPrompt = require('../../../server/game/gamesteps/uiprompt.js');
 
 describe('the UiPrompt', function() {
     beforeEach(function() {
-        this.player1 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
-        this.player2 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
+        this.player1 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
+        this.player2 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'startClock', 'stopClock']);
 
         this.game = jasmine.createSpyObj('game', ['getPlayers']);
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);


### PR DESCRIPTION
Players can now choose to use a chess clock to time their games.
Chess clocks provide a time limit per player. The time will start running if a player has an active prompt and after an initial delay of 5 seconds.
There are also two new chat commands:

- /pause-clock to pause the chess clocks (other time limit not yet implemented) so both clocks will stop running until /pause-clock is called a second time.
- /add-chess-clock-time to add time to the calling players clock (in case someone disconnects and the clock keeps running and players agree to add the lost time)

