### PR TITLE
Add basic support towards overriding cards for playtesting

### DIFF
--- a/server/game/Deck.js
+++ b/server/game/Deck.js
@@ -93,6 +93,9 @@ class Deck {
 
     createCardForType(baseClass, player, cardData) {
         let cardClass = cards[cardData.code] || baseClass;
+        if(cardClass.cardData) {
+            cardData = Object.assign({}, cardData, cardClass.cardData);
+        }
         return new cardClass(player, cardData);
     }
 

--- a/server/game/cards/index.js
+++ b/server/game/cards/index.js
@@ -11,7 +11,7 @@ function getDirectories(srcpath) {
 function loadFiles(directory) {
     let fullPath = path.join(__dirname, directory);
     let files = fs.readdirSync(fullPath).filter(file => {
-        return !fs.statSync(path.join(fullPath, file)).isDirectory();
+        return !fs.statSync(path.join(fullPath, file)).isDirectory() && file.endsWith('.js');
     });
 
     for(let file of files) {


### PR DESCRIPTION
Adds the ability to override stats by defining a `cardData` object on the card implementation class. This object will be merged into the existing card data JSON and only override the pieces of data defined. For example, if you wanted to override Arya Stark's cost, you could define the following:

```javascript
const DrawCard = require('../../drawcard.js');

class AryaStark extends DrawCard {
// full ability definition here
}

AryaStark.code = '01141';
AryaStark.cardData = {
  "cost": 8
};

module.exports = AryaStark;
```

This PR also limits the files loaded as card definitions to only JS files. This will allow server operators to clone a Git repository with just card definitions into the `/server/game/cards/` directory. Because cards are loaded in order by directory name, you can name the directory you clone the repository into `99-overrides` and any card definitions that have the same card code as the main repo will be overridden.

E.g. you define a new version of Arya Stark in your standalone repo as `AryaStark.js` with the following definition:
```javascript
const DrawCard = require('../../drawcard.js');

class AryaStark extends DrawCard {
    setupCardAbilities(ability) {
        this.reaction({
            when: {
                onCardEntersPlay: event => event.card === this
            },
            handler: () => {
                this.game.addMessage('{0} should not be using Arya Stark core', this.controller, this);
            }
        });
    }
}

AryaStark.code = '01141';

module.exports = AryaStark;
```

Then clone that repo into the cards directory with a high pack number:
```bash
cd server/game/cards
git clone git@github.com:my-card-repo 99-overrides
```

Now anyone using Arya Stark (Core) will receive a message when she enters play instead of gaining a duplicate. Because the persistent effect is omitted as well, she will not gain an icon if she gets a duplicate another way.

Please note that while you *could* introduce new cards in this way, it wouldn't be possible to build any decks with those new cards in them currently. This is because the list of cards returned to the client come solely from the `throneteki-json-data` repo currently. A follow up PR will be necessary to allow new cards.

Progress towards #2958