### PR TITLE
Add event game options and list of valid spectators

### DIFF
--- a/server/api/events.js
+++ b/server/api/events.js
@@ -17,8 +17,8 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned } = req.body.event;
-        const event = { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, pods: [] };
+        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
+        const event = { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, pods: [], restrictSpectators, validSpectators };
 
         eventService.create(event)
             .then(e => {
@@ -34,7 +34,7 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned } = req.body.event;
+        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
         const event = {
             id: req.params.id,
             name,
@@ -43,7 +43,9 @@ module.exports.init = function(server, options) {
             eventGameOptions,
             restricted,
             banned,
-            pods: []
+            pods: [],
+            restrictSpectators,
+            validSpectators
         };
 
         eventService.update(event)

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -17,8 +17,8 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, restricted, banned } = req.body.event;
-        const event = { name, useDefaultRestrictedList, restricted, banned, pods: [] };
+        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned } = req.body.event;
+        const event = { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, pods: [] };
 
         eventService.create(event)
             .then(e => {
@@ -34,11 +34,13 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, restricted, banned } = req.body.event;
+        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned } = req.body.event;
         const event = {
             id: req.params.id,
             name,
             useDefaultRestrictedList,
+            useEventGameOptions,
+            eventGameOptions,
             restricted,
             banned,
             pods: []

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1101,6 +1101,13 @@ class Game extends EventEmitter {
             return false;
         }
 
+        //check if the game has an event selected that restricts spectators
+        if(this.event && this.event.restrictSpectators && this.event.validSpectators) {
+            if(!this.event.validSpectators.includes(user.username.toLowerCase())) {
+                return false;
+            }
+        }
+
         this.playersAndSpectators[user.username] = new Spectator(socketId, user);
         this.addAlert('info', '{0} has joined the game as a spectator', user.username);
 

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -159,6 +159,13 @@ class PendingGame {
             }
         }
 
+        //check if the game has an event selected that restricts spectators
+        if(this.event && this.event.restrictSpectators && this.event.validSpectators) {
+            if(!this.event.validSpectators.includes(user.username.toLowerCase())) {
+                return 'You are not a valid spectator for this event';
+            }
+        }
+
         this.addSpectator(id, user);
         this.addMessage('{0} has joined the game as a spectator', user.username);
     }


### PR DESCRIPTION
I made some extensions to the event functionality:
1. I added game options to be set for every game of the event. These options will be set when a user chooses an event in the event dropdown of a new game and will be fixed so the user can´t change these.
2. I added the option to have a list of valid spectators for an event so that judges/streamers can be put on that list and join any game of that event but no regular users not on that list can´t.

(also have a look at the corresponding client PR)

![grafik](https://user-images.githubusercontent.com/6191998/90057778-2da8a200-dce1-11ea-9c45-c48a96b10c3b.png)

![grafik](https://user-images.githubusercontent.com/6191998/90057908-55980580-dce1-11ea-9e00-2769be810dfa.png)
