### PR TITLE
Fix Desert Raider (R) and Prized interaction when entering play from the dead pile

### DIFF
--- a/server/game/cards/17.1-R/DesertRaider.js
+++ b/server/game/cards/17.1-R/DesertRaider.js
@@ -14,9 +14,6 @@ class DesertRaider extends DrawCard {
                                        this.game.currentChallenge.winner === card.controller
             },
             handler: context => {
-                if(this.controller.canPutIntoPlay(this)) {
-                    this.controller.putIntoPlay(this);
-                }
                 this.target = context.target;
 
                 this.game.promptWithMenu(context.player, this, {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1001,7 +1001,7 @@ class Player extends Spectator {
             return;
         }
 
-        if(card.location === 'play area') {
+        if(card.location === 'play area' && targetLocation !== 'play area') {
             var params = {
                 player: this,
                 card: card,


### PR DESCRIPTION
remove unnecessary putIntoPlay in DesertRaider´s handler
prevent cards from entering play when they already are in the play area