### PR TITLE
Fix Randyll Tarly+The Lord of the Crossing interaction

### DIFF
--- a/server/game/GameActions/InitiateChallenge.js
+++ b/server/game/GameActions/InitiateChallenge.js
@@ -2,7 +2,7 @@ const GameAction = require('./GameAction');
 const DeclareAsAttacker = require('./DeclareAsAttacker');
 const BypassByStealth = require('./BypassByStealth');
 
-class InitiateCallenge extends GameAction {
+class InitiateChallenge extends GameAction {
     constructor() {
         super('initiateChallenge');
     }
@@ -24,4 +24,4 @@ class InitiateCallenge extends GameAction {
     }
 }
 
-module.exports = new InitiateCallenge();
+module.exports = new InitiateChallenge();

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -11,6 +11,7 @@ class Challenge {
         this.isSinglePlayer = !properties.defendingPlayer;
         this.defendingPlayer = properties.defendingPlayer || this.singlePlayerDefender();
         this.initiatedAgainstPlayer = this.defendingPlayer;
+        this.isInitiated = false || properties.isInitiated;
         this.challengeType = properties.challengeType;
         this.number = properties.number;
         this.attackers = [];
@@ -40,6 +41,7 @@ class Challenge {
     initiateChallenge() {
         this.attackingPlayer.trackChallenge(this);
         this.defendingPlayer.trackChallenge(this);
+        this.isInitiated = true;
     }
 
     declareAttackers(attackers) {
@@ -95,11 +97,11 @@ class Challenge {
     }
 
     isAttacking(card) {
-        return this.attackers.includes(card);
+        return this.isInitiated && this.attackers.includes(card);
     }
 
     isDefending(card) {
-        return this.defenders.includes(card);
+        return this.isInitiated && this.defenders.includes(card);
     }
 
     isParticipating(card) {
@@ -288,10 +290,12 @@ class Challenge {
         for(let card of this.defenders) {
             card.inChallenge = false;
         }
+        this.isInitiated = false;
     }
 
     cancelChallenge() {
         this.cancelled = true;
+        this.isInitiated = false;
 
         this.resetCards();
 

--- a/test/server/cards/02.3-TKP/TheLordOfTheCrossing.spec.js
+++ b/test/server/cards/02.3-TKP/TheLordOfTheCrossing.spec.js
@@ -1,3 +1,5 @@
+const e = require("express");
+
 describe('The Lord of the Crossing', function() {
     integration(function() {
         beforeEach(function() {
@@ -226,6 +228,67 @@ describe('The Lord of the Crossing', function() {
 
                 it('should reduce Jon Snow\'s strength', function() {
                     expect(this.jon.getStrength()).toBe(3);
+                });
+            });
+        });
+    });
+
+    integration(function() {
+        describe('vs Randyll Tarly', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'The Lord of the Crossing',
+                    'A Noble Cause',
+                    'Randyll Tarly', 'Garden Caretaker', 'Steward at the Wall'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.randyll = this.player1.findCardByName('Randyll Tarly', 'hand');
+                this.powerchud = this.player1.findCardByName('Garden Caretaker', 'hand');
+                this.intriguechud = this.player1.findCardByName('Steward at the Wall', 'hand');
+
+                this.player1.clickCard(this.randyll);
+                this.player1.clickCard(this.powerchud);
+                this.player1.clickCard(this.intriguechud);
+
+                this.completeSetup();
+            });
+
+            describe('when Randyll Tarly attacks in the third challenge', function() {
+                beforeEach(function() {
+                    this.selectFirstPlayer(this.player1);
+
+                    this.completeMarshalPhase();
+
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard(this.intriguechud);
+                    this.player1.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.player2.clickPrompt('Done');
+                    this.skipActionWindow();
+
+                    this.player1.clickPrompt('Power');
+                    this.player1.clickCard(this.powerchud);
+                    this.player1.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.player2.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.player1.clickPrompt('Apply Claim');
+
+                    this.player1.clickPrompt('Military');
+                    this.player1.clickCard(this.randyll);
+                    this.player1.clickPrompt('Done');
+                });
+
+                it('should trigger his str buff reaction', function() {
+                    expect(this.randyll.getStrength()).toBe(7);
+                    expect(this.player1).toHavePrompt('Any reactions?');
+                    expect(this.randyll.kneeled).toBe(true);
+                    this.player1.clickCard(this.randyll);
+                    expect(this.randyll.kneeled).toBe(false);
                 });
             });
         });

--- a/test/server/cards/02.3-TKP/TheLordOfTheCrossing.spec.js
+++ b/test/server/cards/02.3-TKP/TheLordOfTheCrossing.spec.js
@@ -1,5 +1,3 @@
-const e = require("express");
-
 describe('The Lord of the Crossing', function() {
     integration(function() {
         beforeEach(function() {

--- a/test/server/challenge/removefromchallenge.spec.js
+++ b/test/server/challenge/removefromchallenge.spec.js
@@ -17,7 +17,7 @@ describe('Challenge', function() {
         this.defenderCard = new DrawCard(this.defendingPlayer, {});
         spyOn(this.defenderCard, 'getStrength').and.returnValue(3);
 
-        this.challenge = new Challenge(this.gameSpy, { attackingPlayer: this.attackingPlayer, defendingPlayer: this.defendingPlayer, challengeType: 'military' });
+        this.challenge = new Challenge(this.gameSpy, { attackingPlayer: this.attackingPlayer, defendingPlayer: this.defendingPlayer, challengeType: 'military', isInitiated: true });
         this.challenge.addAttackers([this.attackerCard]);
         this.challenge.addDefenders([this.defenderCard]);
     });


### PR DESCRIPTION
this let´s Randyll Tarly trigger to the STR increase from the third crossing challenge again.
characters are now considered to be attacking/defending only when the challenge´s isInitiated flag is true, which is now set after the call to initiateChallenge has been performed. Before, characters were attacking after the promptForAttackers step, which broke a (some?) card interaction like Randyll Tarly and the lord of the crossing