### PR TITLE
Add default restricted list to events

### DIFF
--- a/server/api/events.js
+++ b/server/api/events.js
@@ -8,7 +8,7 @@ module.exports.init = function(server, options) {
 
     server.get('/api/events', wrapAsync(async function(req, res) {
         const events = await eventService.getEvents();
-
+        
         return res.send({ success: true, events });
     }));
 
@@ -17,8 +17,8 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
-        const event = { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, pods: [], restrictSpectators, validSpectators };
+        const { name, useDefaultRestrictedList, defaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
+        const event = { name, useDefaultRestrictedList, defaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, pods: [], restrictSpectators, validSpectators };
 
         eventService.create(event)
             .then(e => {
@@ -34,11 +34,12 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
+        const { name, useDefaultRestrictedList, defaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
         const event = {
             id: req.params.id,
             name,
             useDefaultRestrictedList,
+            defaultRestrictedList,
             useEventGameOptions,
             eventGameOptions,
             restricted,

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -8,7 +8,7 @@ module.exports.init = function(server, options) {
 
     server.get('/api/events', wrapAsync(async function(req, res) {
         const events = await eventService.getEvents();
-        
+
         return res.send({ success: true, events });
     }));
 

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -457,10 +457,16 @@ class Lobby {
             const defaultRestrictedList = restrictedLists[0];
             let restrictedList;
 
+            //when there is no event chosen for the game, use the restricted list that was chosen or the default restricted list (first one in the list)
             if(gameDetails.eventId === 'none') {
                 restrictedList = restrictedLists.find(restrictedList => restrictedList._id === gameDetails.restrictedListId) || defaultRestrictedList;
+            //when there is an event chosen for the game, check if the event uses a custom or a default restricted list
             } else {
-                restrictedList = restrictedLists.find(restrictedList => restrictedList.name === event.name && !event.useDefaultRestrictedList) || defaultRestrictedList;
+                if(event.useDefaultRestrictedList && event.defaultRestrictedList) {
+                    restrictedList = restrictedLists.find(restrictedList => restrictedList.name === event.defaultRestrictedList) || defaultRestrictedList;
+                } else {
+                    restrictedList = restrictedLists.find(restrictedList => restrictedList.name === event.name) || defaultRestrictedList;
+                }
             }
 
             let game = new PendingGame(socket.user, {event, restrictedList, ...gameDetails});


### PR DESCRIPTION
An event was able to choose to use it´s custom RL or the default RL. Now that there are two default RL´s to choose from, original and redesigns, an event needs to be able to choose which one of the default RL´s to use. This PR adds this option to an event.
This PR also changes the way the restricted list for a game is determined when creating a new game. It now looks up the default or custom restricted list of the chosen event.

resolves #3048 (via the [client PR](https://github.com/throneteki/throneteki-client/pull/120) )
resolves #3049 