### PR TITLE
specify which King´s Landing to use in KingsLanding.spec.js

### DIFF
--- a/test/server/cards/11.3-SoKL/KingsLanding.spec.js
+++ b/test/server/cards/11.3-SoKL/KingsLanding.spec.js
@@ -1,10 +1,10 @@
-describe('King\'s Landing', function() {
+describe('King\'s Landing (SoKL)', function() {
     integration(function() {
         describe('when marshalling from the discard pile', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('stark', [
                     'A Noble Cause',
-                    'King\'s Landing', 'The Roseroad', 'Winterfell Crypt', 'Skagos (IDP)'
+                    'King\'s Landing (SoKL)', 'The Roseroad', 'Winterfell Crypt', 'Skagos (IDP)'
                 ]);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);


### PR DESCRIPTION
specify which King´s Landing to use in KingsLanding.spec.js to remove the multiple cards match name warning