### PR TITLE
[bugfix] Add limit of once per challenge to redesignbound for the wall

### DIFF
--- a/server/game/cards/17.1-R/BoundForTheWall.js
+++ b/server/game/cards/17.1-R/BoundForTheWall.js
@@ -19,7 +19,8 @@ class BoundForTheWall extends DrawCard {
                     onSelect: (player, card) => this.onCardSelected(player, card),
                     onCancel: (player) => this.cancelSelection(player)
                 });
-            }
+            },
+            max: ability.limit.perChallenge(1)
         });
     }
 

--- a/server/game/cards/17.1-R/BoundForTheWall.js
+++ b/server/game/cards/17.1-R/BoundForTheWall.js
@@ -1,7 +1,7 @@
 const DrawCard = require('../../drawcard');
 
 class BoundForTheWall extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 afterChallenge: event => event.challenge.isMatch({ winner: this.controller, attackingPlayer: this.controller })


### PR DESCRIPTION
This limit disappeared in the reimplementation. I added exactly the
code that the original implementation is using.