### PR TITLE
Fix the Knight gaining stealth

### DIFF
--- a/server/game/ChallengeMatcher.js
+++ b/server/game/ChallengeMatcher.js
@@ -6,6 +6,7 @@ class ChallengeMatcher {
             Matcher.containsValue(matchers.challengeType, challenge.challengeType) &&
             Matcher.containsValue(matchers.attackingPlayer, challenge.attackingPlayer) &&
             Matcher.containsValue(matchers.defendingPlayer, challenge.defendingPlayer) &&
+            Matcher.containsValue(matchers.initiated, challenge.isInitiated) &&
             Matcher.containsValue(matchers.initiatedAgainstPlayer, challenge.initiatedAgainstPlayer) &&
             Matcher.containsValue(matchers.loser, challenge.loser) &&
             Matcher.containsValue(matchers.winner, challenge.winner) &&

--- a/server/game/cards/02.3-TKP/TheLordOfTheCrossing.js
+++ b/server/game/cards/02.3-TKP/TheLordOfTheCrossing.js
@@ -21,7 +21,7 @@ class TheLordOfTheCrossing extends AgendaCard {
     }
 
     isAttackingDuringChallengeNumber(challengeNumber) {
-        return this.game.isDuringChallenge({ attackingPlayer: this.controller, number: challengeNumber });
+        return this.game.isDuringChallenge({ initiated: true, attackingPlayer: this.controller, number: challengeNumber });
     }
 
     afterChallenge(event) {

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -97,11 +97,11 @@ class Challenge {
     }
 
     isAttacking(card) {
-        return this.isInitiated && this.attackers.includes(card);
+        return this.attackers.includes(card);
     }
 
     isDefending(card) {
-        return this.isInitiated && this.defenders.includes(card);
+        return this.defenders.includes(card);
     }
 
     isParticipating(card) {

--- a/test/server/cards/12-KotI/TheKnight.spec.js
+++ b/test/server/cards/12-KotI/TheKnight.spec.js
@@ -34,6 +34,7 @@ describe('The Knight (KotI)', function() {
             it('gains stealth and renown', function() {
                 expect(this.knight.hasKeyword('Stealth')).toBe(true);
                 expect(this.knight.hasKeyword('Renown')).toBe(true);
+                expect(this.player1).toHavePrompt('Select stealth target for The Knight');
             });
         });
 
@@ -48,6 +49,7 @@ describe('The Knight (KotI)', function() {
             it('does not gains stealth and renown', function() {
                 expect(this.knight.hasKeyword('Stealth')).toBe(false);
                 expect(this.knight.hasKeyword('Renown')).toBe(false);
+                expect(this.player1).not.toHavePrompt('Select stealth target for The Knight');
             });
         });
     });

--- a/test/server/cards/12-KotI/TheKnight.spec.js
+++ b/test/server/cards/12-KotI/TheKnight.spec.js
@@ -1,0 +1,54 @@
+describe('The Knight (KotI)', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('greyjoy', [
+                'Marching Orders',
+                'The Knight (KotI)', 'Hedge Knight'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.knight = this.player1.findCardByName('The Knight');
+            this.otherCharacter = this.player1.findCardByName('Hedge Knight');
+
+            this.player1.clickCard(this.knight);
+            this.player1.clickCard(this.otherCharacter);
+
+            this.player2.clickCard('Hedge Knight');
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when attacking alone', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.knight);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('gains stealth and renown', function() {
+                expect(this.knight.hasKeyword('Stealth')).toBe(true);
+                expect(this.knight.hasKeyword('Renown')).toBe(true);
+            });
+        });
+
+        describe('when not attacking alone', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.knight);
+                this.player1.clickCard(this.otherCharacter);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('does not gains stealth and renown', function() {
+                expect(this.knight.hasKeyword('Stealth')).toBe(false);
+                expect(this.knight.hasKeyword('Renown')).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
A previous fix aimed at Randyl Tarly and Lord of the Crossing
changed when a character was considered attacking. This broke
The Knight's ability to gain stealth before the challenge was
officially initiated.

The attacking / defending check has been reverted, and instead
Lord of the Crossing has been modified to only apply the
strength buff after the challenge has been initiated.

Fixes #3059 