### PR TITLE
Fix Castle Guard target condition

### DIFF
--- a/server/game/EventTrackers/GenericTracker.js
+++ b/server/game/EventTrackers/GenericTracker.js
@@ -10,6 +10,10 @@ class GenericTracker {
         game.on(endingEvent, () => this.clearEvents());
     }
 
+    some(predicate) {
+        return this.events.some(predicate);
+    }
+
     trackEvent(event) {
         this.events.push(event);
     }

--- a/server/game/cards/13.4-BtRK/CastleGuard.js
+++ b/server/game/cards/13.4-BtRK/CastleGuard.js
@@ -1,16 +1,16 @@
 const DrawCard = require('../../drawcard');
-const {CardEntersPlayTracker} = require('../../EventTrackers');
+const GenericTracker = require('../../EventTrackers/GenericTracker');
 
 class CastleGuard extends DrawCard {
     setupCardAbilities() {
-        this.tracker = CardEntersPlayTracker.forPhase(this.game);
+        this.tracker = GenericTracker.forPhase(this.game, 'onCardOutOfShadows');
 
         this.reaction({
             when: {
                 onCardOutOfShadows: event => event.card === this
             },
             target: {
-                cardCondition: (card) => card.location === 'play area' && card !== this && card.getType() === 'character' && this.tracker.hasComeOutOfShadows(card)
+                cardCondition: (card) => card.location === 'play area' && card !== this && card.getType() === 'character' && this.tracker.some(event => event.card === card)
             },
             message: '{player} uses {source} to return {target} to shadows',
             handler: context => {


### PR DESCRIPTION
Check for the onCardOutOfShadows event instead of whether a card
was put into play with the 'outOfShadows' meta-action.

Fixes #3000 