### PR TITLE
Ensure Karhold persistent effect gets recalculated

### DIFF
--- a/server/game/cards/12-KotI/Karhold.js
+++ b/server/game/cards/12-KotI/Karhold.js
@@ -3,6 +3,7 @@ const DrawCard = require('../../drawcard');
 class Karhold extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
+            condition: () => true,
             match: card => ['character', 'location'].includes(card.getType()) && !this.hasWinterPlotRevealed(card.controller),
             targetController: 'any',
             effect: ability.effects.cannotGainPower()


### PR DESCRIPTION
The cards that Karhold is applied to needs to change as new plots are
revealed. Adding an explicit condition to the effect ensures the effect
is continuously recalculated.

Fixes #2783 