### PR TITLE
Automatically complete prompts for fake players

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -30,6 +30,7 @@ class Challenge {
         let dummyPlayer = new Player('', Settings.getUserWithDefaultsSet({ name: 'Dummy Player' }), false, this.game);
         dummyPlayer.initialise();
         dummyPlayer.resetForStartOfRound();
+        dummyPlayer.isFake = true;
         return dummyPlayer;
     }
 

--- a/server/game/gamesteps/menuprompt.js
+++ b/server/game/gamesteps/menuprompt.js
@@ -25,6 +25,10 @@ class MenuPrompt extends UiPrompt {
         }
 
         this.properties = properties;
+
+        if(player.isFake) {
+            this.complete();
+        }
     }
 
     activeCondition(player) {

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -72,6 +72,10 @@ class SelectCardPrompt extends UiPrompt {
         this.revealTargets = properties.revealTargets;
         this.revealFunc = null;
         this.savePreviouslySelectedCards();
+
+        if(choosingPlayer.isFake) {
+            this.complete();
+        }
     }
 
     defaultProperties() {


### PR DESCRIPTION
In single player games, we create a fake defending player during challenges
to avoid special casing every ability to handle a missing defending player.
This leads to a problem on abilities that prompt the defending player, such
as Late Summer Feast, since there's no player to respond to the prompt.

Now the menu and card select prompts will immediately complete themselves
if the player being prompted is the fake player. This may not cover every
case, but it should fix many of the existing hanging prompts.

Fixes #3027 
