### PR TITLE
fix tyrion lannister JS targetLocation so that dupes will be moved

### DIFF
--- a/server/game/cards/19-JS/TyrionLannister.js
+++ b/server/game/cards/19-JS/TyrionLannister.js
@@ -14,6 +14,7 @@ class TyrionLannister extends DrawCard {
 
                 this.atEndOfPhase(ability => ({
                     match: context.target,
+                    targetLocation: ['play area', 'duplicate'],
                     effect: ability.effects.moveToBottomOfDeckIfStillInPlay(true)
                 }));
 


### PR DESCRIPTION
fix tyrion lannister JS targetLocation so that dupes will be moved to the bottom of the deck