### PR TITLE
fix the jousting pavilion + knighted + randyll tarly interaction 

### DIFF
--- a/server/game/cards/09-HoT/JoustingPavilion.js
+++ b/server/game/cards/09-HoT/JoustingPavilion.js
@@ -3,8 +3,7 @@ const DrawCard = require('../../drawcard.js');
 class JoustingPavilion extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.game.isDuringChallenge({ initiated: true, attackingPlayer: this.controller, match: challenge => challenge.attackers.length === 1 }) 
-                || this.game.isDuringChallenge({ initiated: true, defendingPlayer: this.controller, match: challenge => challenge.defenders.length === 1 }),
+            condition: () => this.game.isDuringChallenge({ initiated: true, match: challenge => challenge.hasSingleParticipant(this.controller) }),
             match: card => card.hasTrait('Knight') && card.getType() === 'character' && card.isParticipating(),
             effect: ability.effects.modifyStrength(1)
         });

--- a/server/game/cards/09-HoT/JoustingPavilion.js
+++ b/server/game/cards/09-HoT/JoustingPavilion.js
@@ -3,7 +3,8 @@ const DrawCard = require('../../drawcard.js');
 class JoustingPavilion extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.game.currentChallenge && this.game.currentChallenge.hasSingleParticipant(this.controller),
+            condition: () => this.game.isDuringChallenge({ initiated: true, attackingPlayer: this.controller, match: challenge => challenge.attackers.length === 1 }) 
+                || this.game.isDuringChallenge({ initiated: true, defendingPlayer: this.controller, match: challenge => challenge.defenders.length === 1 }),
             match: card => card.hasTrait('Knight') && card.getType() === 'character' && card.isParticipating(),
             effect: ability.effects.modifyStrength(1)
         });

--- a/test/server/cards/09-HoT/JoustingPavilion.spec.js
+++ b/test/server/cards/09-HoT/JoustingPavilion.spec.js
@@ -1,0 +1,50 @@
+describe('Jousting Pavilion', function() {
+    integration(function() {
+        describe('with knighted Randyll Tarly', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'Fealty',
+                    'A Noble Cause',
+                    'Randyll Tarly (Core)', 'Knighted', 'Jousting Pavilion'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.randyll = this.player1.findCardByName('Randyll Tarly', 'hand');
+                this.knighted = this.player1.findCardByName('Knighted', 'hand');
+                this.jp = this.player1.findCardByName('Jousting Pavilion', 'hand');
+
+                this.player1.clickCard(this.randyll);
+                this.player1.clickCard(this.knighted);
+                this.player1.clickCard(this.jp);
+
+                this.completeSetup();
+                this.player1.clickCard(this.knighted);
+                this.player1.clickCard(this.randyll);
+                expect(this.randyll.getStrength()).toBe(6);
+            });
+
+            describe('when Randyll Tarly attacks alone', function() {
+                beforeEach(function() {
+                    this.selectFirstPlayer(this.player1);
+
+                    this.completeMarshalPhase();
+
+                    this.player1.clickPrompt('Military');
+                    this.player1.clickCard(this.randyll);
+                    this.player1.clickPrompt('Done');
+                });
+
+                it('should trigger his str buff reaction', function() {
+                    expect(this.randyll.getStrength()).toBe(7);
+                    expect(this.player1).toHavePrompt('Any reactions?');
+                    expect(this.randyll.kneeled).toBe(true);
+                    this.player1.clickCard(this.randyll);
+                    expect(this.randyll.kneeled).toBe(false);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
fix the jousting pavilion + knighted + randyll tarly interaction so that the str buff reaction of randyll works
we fixed randyll + lord of the crossing some time ago, but jousting pavilion´s usage of hasSingleParticipant is not enough because without checking for initiated it is already true before randyll gets knelt as an attacker