### PR TITLE
placeCardInPile should invoke card.leavesPlay 

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1026,15 +1026,7 @@ class Player extends Spectator {
                 this.discardCards(card.dupes, false);
             }
         }
-
-        if(['play area', 'active plot'].includes(card.location)) {
-            card.leavesPlay();
-        }
-
-        if(card.location === 'active plot') {
-            this.game.raiseEvent('onCardLeftPlay', { player: this, card: card, cardStateWhenLeftPlay: card.createSnapshot() });
-        }
-
+        
         this.placeCardInPile({ card, location: targetLocation, bottom: options.bottom });
 
         if(['dead pile', 'discard pile', 'revealed plots'].includes(targetLocation)) {
@@ -1043,6 +1035,14 @@ class Player extends Spectator {
     }
 
     placeCardInPile({ card, location, bottom = false }) {
+        if(['play area', 'active plot'].includes(card.location)) {
+            card.leavesPlay();
+        }
+
+        if(card.location === 'active plot') {
+            this.game.raiseEvent('onCardLeftPlay', { player: this, card: card, cardStateWhenLeftPlay: card.createSnapshot() });
+        }
+        
         this.removeCardFromPile(card);
 
         let targetPile = this.getSourceList(location);


### PR DESCRIPTION
placeCardInPile should invoke card.leavesPlay so that the reworked SacrificeCard->PlaceCard interaction leads to cards leaving play correctly
This was noticed on the playtesting server when a Kingsroad got sacrificed for its reduction but entered the discard pile knelt. Turns out, the "standing" of a card entering a non-play area is done in card.leavesPlay