### PR TITLE
Make sacrifice and leave play simultaneous

### DIFF
--- a/server/game/GameActions/SacrificeCard.js
+++ b/server/game/GameActions/SacrificeCard.js
@@ -1,4 +1,5 @@
 const GameAction = require('./GameAction');
+const LeavePlay = require('./LeavePlay');
 const PlaceCard = require('./PlaceCard');
 
 class SacrificeCard extends GameAction {
@@ -7,15 +8,17 @@ class SacrificeCard extends GameAction {
     }
 
     canChangeGameState({ card }) {
-        return card.location === 'play area';
+        return card.location === 'play area' && LeavePlay.allow({ card });
     }
 
     createEvent({ card, player }) {
         player = player || card.controller;
-        return this.event('onSacrificed', { card, player }, event => {
+        const sacrificeEvent = this.event('onSacrificed', { card, player }, event => {
             event.cardStateWhenSacrificed = event.card.createSnapshot();
             event.thenAttachEvent(PlaceCard.createEvent({ card: card, location: 'discard pile' }));
         });
+        const leavePlayEvent = LeavePlay.createEvent({ card });
+        return this.atomic(sacrificeEvent, leavePlayEvent);
     }
 }
 

--- a/server/game/GameActions/SacrificeCard.js
+++ b/server/game/GameActions/SacrificeCard.js
@@ -13,8 +13,12 @@ class SacrificeCard extends GameAction {
 
     createEvent({ card, player }) {
         player = player || card.controller;
-        const sacrificeEvent = this.event('onSacrificed', { card, player }, event => {
-            event.cardStateWhenSacrificed = event.card.createSnapshot();
+        const params = {
+            card,
+            player,
+            snapshotName: 'cardStateWhenSacrificed'
+        };
+        const sacrificeEvent = this.event('onSacrificed', params, event => {
             event.thenAttachEvent(PlaceCard.createEvent({ card: card, location: 'discard pile' }));
         });
         const leavePlayEvent = LeavePlay.createEvent({ card });

--- a/test/server/GameActions/SacrificeCard.spec.js
+++ b/test/server/GameActions/SacrificeCard.spec.js
@@ -28,9 +28,19 @@ describe('SacrificeCard', function() {
             });
         });
 
-        describe('when the card is immune', function() {
+        describe('when the card is immune to sacrifice', function() {
             beforeEach(function() {
-                this.cardSpy.allowGameAction.and.returnValue(false);
+                this.cardSpy.allowGameAction.and.callFake((actionName) => actionName !== 'sacrifice');
+            });
+
+            it('returns false', function() {
+                expect(SacrificeCard.allow(this.props)).toBe(false);
+            });
+        });
+
+        describe('when the card is immune to leaving play', function() {
+            beforeEach(function() {
+                this.cardSpy.allowGameAction.and.callFake((actionName) => actionName !== 'leavePlay');
             });
 
             it('returns false', function() {
@@ -41,17 +51,26 @@ describe('SacrificeCard', function() {
 
     describe('createEvent()', function() {
         beforeEach(function() {
-            this.event = SacrificeCard.createEvent(this.props);
+            this.events = SacrificeCard.createEvent(this.props).getConcurrentEvents();
         });
 
         it('creates a onSacrificed event', function() {
-            expect(this.event.name).toBe('onSacrificed');
-            expect(this.event.card).toBe(this.cardSpy);
-            expect(this.event.player).toBe(this.player1Object);
+            const event = this.events.find(e => e.name === 'onSacrificed');
+            expect(event).toBeDefined();
+            expect(event.card).toBe(this.cardSpy);
+            expect(event.player).toBe(this.player1Object);
+        });
+
+        it('creates an onCardLeftPlay event', function() {
+            const event = this.events.find(e => e.name === 'onCardLeftPlay');
+            expect(event).toBeDefined();
+            expect(event.card).toBe(this.cardSpy);
+            expect(event.allowSave).toBe(false);
         });
 
         describe('the event handler', function() {
             beforeEach(function() {
+                this.event = this.events.find(e => e.name === 'onSacrificed');
                 this.cardSpy.createSnapshot.and.returnValue('snapshot');
                 this.event.executeHandler();
             });


### PR DESCRIPTION
Replaces #3128 

Also switches to using the `snapshotName` event mechanism to record card state.