### PR TITLE
fix the XValuePrompt

### DIFF
--- a/server/game/costs/XValuePrompt.js
+++ b/server/game/costs/XValuePrompt.js
@@ -32,6 +32,10 @@ class XValuePrompt extends BaseStep {
     }
 
     resolveCost(player, xValue) {
+        //if the xValue is undefined, return false will prompt the player again
+        if(!xValue) {
+            return false;
+        }
         //value selected in prompt is of type string
         xValue = typeof(xValue) === 'string' ? parseInt(xValue) : xValue;
 

--- a/server/game/costs/XValuePrompt.js
+++ b/server/game/costs/XValuePrompt.js
@@ -33,7 +33,7 @@ class XValuePrompt extends BaseStep {
 
     resolveCost(player, xValue) {
         //if the xValue is undefined, return false will prompt the player again
-        if(!xValue) {
+        if(!xValue && xValue !== 0) {
             return false;
         }
         //value selected in prompt is of type string


### PR DESCRIPTION
fix the XValuePrompt so that an invalid value chosen in the prompt doesn´t break the gold of the player anymore.

before this fix, an invalid value would set player.gold to undefined and the player wasn´t able to gain any gold anymore