### PR TITLE
hides the source of an MarshalIntoShadowsAction in the alert 

### DIFF
--- a/server/game/PlayActions/MarshalIntoShadowsAction.js
+++ b/server/game/PlayActions/MarshalIntoShadowsAction.js
@@ -40,6 +40,10 @@ class MarshalIntoShadowsAction extends BaseAbility {
             context.player.putIntoShadows(context.source);
         });
     }
+
+    shouldHideSourceInMessage() {
+        return true;
+    }
 }
 
 module.exports = MarshalIntoShadowsAction;

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -269,6 +269,10 @@ class BaseAbility {
     hasMax() {
         return false;
     }
+
+    shouldHideSourceInMessage() {
+        return false;
+    }
 }
 
 module.exports = BaseAbility;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -825,11 +825,11 @@ class Game extends EventEmitter {
     markActionAsTaken(context) {
         if(this.currentActionWindow) {
             if(this.currentActionWindow.currentPlayer !== context.player) {
-                this.addAlert('danger', '{0} uses {1} during {2}\'s turn in the action window', context.player, context.source, this.currentActionWindow.currentPlayer);
+                this.addAlert('danger', '{0} uses {1} during {2}\'s turn in the action window', context.player, context.hideSourceInMessage ? 'a card' : context.source, this.currentActionWindow.currentPlayer);
             }
             this.currentActionWindow.markActionAsTaken(context.player);
         } else if(this.currentPhase !== 'marshal' || this.hasOpenInterruptOrReactionWindow()) {
-            this.addAlert('danger', '{0} uses {1} outside of an action window', context.player, context.source);
+            this.addAlert('danger', '{0} uses {1} outside of an action window', context.player, context.hideSourceInMessage ? 'a card' : context.source);
         }
     }
 

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -75,6 +75,7 @@ class AbilityResolver extends BaseStep {
 
     markActionAsTaken() {
         if(this.ability.isAction()) {
+            this.context.hideSourceInMessage = this.ability.shouldHideSourceInMessage();
             this.game.markActionAsTaken(this.context);
         }
     }

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -11,7 +11,7 @@ describe('AbilityResolver', function() {
         this.game.reportError.and.callFake(error => {
             throw error;
         });
-        this.ability = jasmine.createSpyObj('ability', ['incrementLimit', 'isAction', 'isCardAbility', 'isForcedAbility', 'isPlayableEventAbility', 'needsChoosePlayer', 'outputMessage', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
+        this.ability = jasmine.createSpyObj('ability', ['incrementLimit', 'isAction', 'isCardAbility', 'isForcedAbility', 'isPlayableEventAbility', 'needsChoosePlayer', 'outputMessage', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler', 'shouldHideSourceInMessage']);
         this.ability.isCardAbility.and.returnValue(true);
         this.ability.resolveCosts.and.returnValue([]);
         this.ability.resolveTargets.and.returnValue([]);


### PR DESCRIPTION
hides the source of an MarshalIntoShadowsAction in the alert when doing the action outside of your action window

when marshaling a card into shadows during your opponents reaction window by accident, the marshaling action is outside of your action window and it puts an alert in the game log, stating which card you marshal into shadows and thus spoiling secret information to your opponent