### PR TITLE
only prompt for sacrifice on heir to the iron throne if the card put into play was not a duplicate

### DIFF
--- a/server/game/cards/12-KotI/HeirToTheIronThrone.js
+++ b/server/game/cards/12-KotI/HeirToTheIronThrone.js
@@ -25,8 +25,6 @@ class HeirToTheIronThrone extends PlotCard {
             this.game.queueSimpleStep(() => {
                 this.promptForSacrifice(player);
             });
-        } else {
-            this.game.addMessage('{0} can not sacrifice a character because {1} is put into play as a duplicate', player, card);
         }
     }
 

--- a/server/game/cards/12-KotI/HeirToTheIronThrone.js
+++ b/server/game/cards/12-KotI/HeirToTheIronThrone.js
@@ -18,11 +18,16 @@ class HeirToTheIronThrone extends PlotCard {
 
     cardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to search their deck and put {2} into play', player, this, card);
+        let dupeCard = player.getDuplicateInPlay(card);
         player.putIntoPlay(card);
-
-        this.game.queueSimpleStep(() => {
-            this.promptForSacrifice(player);
-        });
+        //only prompt for sacrifice if the card put into play wasn´t a duplicate
+        if(!dupeCard) {
+            this.game.queueSimpleStep(() => {
+                this.promptForSacrifice(player);
+            });
+        } else {
+            this.game.addMessage('{0} can not sacrifice a character because {1} is put into play as a duplicate', player, card);
+        }
     }
 
     doneSelecting(player) {


### PR DESCRIPTION
new players get confused by this rule. you have to know about it and then cancel the sacrifice manually which in turn leads to a warning in the game log.

fixes #2417