### PR TITLE
Updated BraveCompanions & FreshRecruits logic

### DIFF
--- a/server/Array.js
+++ b/server/Array.js
@@ -47,10 +47,51 @@ function sortByComparison(transform) {
 function sortBy(array, transform) {
     return [...array].sort(sortByComparison(transform));
 }
+/**
+ * Returns the elements of an array that are available for pairing after 
+ * considering all possible pair combinations with another array.
+ *
+ * @param {any[]} array1 The array to find which elements are available on
+ * @param {any[]} array2 The array to compare to
+ * @param {function(any, any)} canPair The function to compair elements from array1 & array2
+ */
+function availableToPair(array1, array2, canPair) {
+    let a1indecies = array1.map((_a1element, index) => index);
+    let available = [];
+    // 'Permutation' results in a list of a1indecies in every possible ordered combination. Eg. [[0,1,2], [0,2,1], ... , [2,1,0]]
+    permutate([], [], a1indecies).every(permutation => {
+        // If every a1index can either: not be paired with an array2 element (meaning its available), 
+        // OR can be paired with the array2 element of that permutation index, then we can add the available array1 elements
+        if(permutation.every((a1index, pindex) => pindex >= array2.length || canPair(array1[a1index], array2[pindex]))) {
+            // Only add array1 elements which are not already on the available list AND are available (same as above)
+            available = available.concat(permutation.filter((a1index, pindex) => !available.includes(array1[a1index]) && pindex >= array2.length).map(a1index => array1[a1index]));
+        }
+        // Exit early (return false) if all array1 elements are available
+        return available.length < array1.length;
+    });
+    return available;
+}
+
+// Each element of 'array' in every possible ordered combination
+function permutate(permutations, current, array) {
+    if(array.length > 0) {
+        array.forEach((e, index) => {
+            var next = [...current];
+            next.push(e);
+            var remaining = [...array];
+            remaining.splice(index, 1);
+            permutate(permutations, next, remaining);
+        });
+    } else {
+        permutations.push(current);
+    }
+    return permutations;
+}
 
 module.exports = {
     flatten,
     flatMap,
     partition,
-    sortBy
+    sortBy,
+    availableToPair
 };

--- a/server/game/cards/11.1-TSC/FreshRecruits.js
+++ b/server/game/cards/11.1-TSC/FreshRecruits.js
@@ -1,8 +1,10 @@
 const DrawCard = require('../../drawcard');
 const GameActions = require('../../GameActions');
+const Array = require('../../../Array');
 
 class FreshRecruits extends DrawCard {
     setupCardAbilities() {
+        const selectableTraits = ['Ranger', 'Builder', 'Steward'];
         this.action({
             title: 'Search deck',
             gameAction: GameActions.search({
@@ -11,7 +13,10 @@ class FreshRecruits extends DrawCard {
                 numToSelect: 3,
                 match: {
                     type: 'character',
-                    condition: (card, context) => this.remainingTraits(context.selectedCards).some(trait => card.hasTrait(trait))
+                    // Checking if the card is already selected || if it has one of the selectable traits && that trait is remaining for selection
+                    condition: (card, context) => context.selectedCards.includes(card) 
+                    || selectableTraits.some(trait => card.hasTrait(trait)) 
+                    && Array.availableToPair(selectableTraits, context.selectedCards, (trait, card) => card.hasTrait(trait)).some(trait => card.hasTrait(trait))
                 },
                 message: '{player} uses {source} to search their deck and add {searchTarget} to their hand',
                 cancelMessage: '{player} uses {source} to search their deck but does not find a card',
@@ -20,50 +25,6 @@ class FreshRecruits extends DrawCard {
                 ))
             })
         });
-    }
-
-    remainingTraits(selectedCards) {
-        const traits = ['Ranger', 'Builder', 'Steward'];
-        let tempCards = selectedCards.slice();
-        for(let i = tempCards.length ; i < traits.length ; i++) {
-            tempCards.push(null);
-        }
-        var remaining = [];
-        this.permutate([], [], tempCards).every(p => {
-            if(p.every((c, i) => !c || c.hasTrait(traits[i]))) {
-                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r === t) && !p[i]));
-            }
-            return remaining.length !== traits.length;
-        });
-        return remaining;
-    }
-
-    permutate(generated, current, remaining) {
-        if(remaining.length > 0) {
-            remaining.forEach((r, index) => {
-                var next = current.slice();
-                next.push(r);
-                var newRemaining = remaining.slice();
-                newRemaining.splice(index, 1);
-                this.permutate(generated, next, newRemaining);
-            });
-        } else {
-            generated.push(current);
-        }
-        return generated;
-    }
-
-    selectCards(player, cards) {
-        for(let card of cards) {
-            player.moveCard(card, 'hand');
-        }
-        this.game.addMessage('{0} plays {1} to search their deck and adds {2} to their hand', player, this, cards);
-        return true;
-    }
-
-    cancelSearch(player) {
-        this.game.addMessage('{0} plays {1} to search their deck, but does not add any cards to their hand', player, this);
-        return true;
     }
 }
 

--- a/server/game/cards/11.1-TSC/FreshRecruits.js
+++ b/server/game/cards/11.1-TSC/FreshRecruits.js
@@ -25,29 +25,29 @@ class FreshRecruits extends DrawCard {
     remainingTraits(selectedCards) {
         const traits = ['Ranger', 'Builder', 'Steward'];
         let tempCards = selectedCards.slice();
-        for(let i=tempCards.length ; i<traits.length ; i++)
+        for(let i = tempCards.length ; i < traits.length ; i++) {
             tempCards.push(null);
+        }
         var remaining = [];
-        this.permutate([],[],tempCards).every(p => {
-            if(p.every((c, i) => !c || c.hasTrait(traits[i]))){
-                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r == t) && !p[i]));
+        this.permutate([], [], tempCards).every(p => {
+            if(p.every((c, i) => !c || c.hasTrait(traits[i]))) {
+                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r === t) && !p[i]));
             }
-            return remaining.length != traits.length;
-        })
+            return remaining.length !== traits.length;
+        });
         return remaining;
     }
 
-    permutate(generated, current, remaining){
-        if(remaining.length > 0){
+    permutate(generated, current, remaining) {
+        if(remaining.length > 0) {
             remaining.forEach((r, index) => {
                 var next = current.slice();
                 next.push(r);
                 var newRemaining = remaining.slice();
                 newRemaining.splice(index, 1);
-                this.permutate(generated, next, newRemaining)
-            })
-        }
-        else {
+                this.permutate(generated, next, newRemaining);
+            });
+        } else {
             generated.push(current);
         }
         return generated;

--- a/server/game/cards/20-HMW/BraveCompanions.js
+++ b/server/game/cards/20-HMW/BraveCompanions.js
@@ -40,7 +40,46 @@ class BraveCompanions extends DrawCard {
 
     remainingTraits(selectedCards) {
         const traits = ['Army', 'Commander', 'Mercenary'];
-        return traits.filter(trait => !selectedCards.some(card => card.hasTrait(trait)));
+        let tempCards = selectedCards.slice();
+        for(let i=tempCards.length ; i<traits.length ; i++)
+            tempCards.push(null);
+        var remaining = [];
+        this.permutate([],[],tempCards).every(p => {
+            if(p.every((c, i) => !c || c.hasTrait(traits[i]))){
+                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r == t) && !p[i]));
+            }
+            return remaining.length != traits.length;
+        })
+        return remaining;
+    }
+
+    permutate(generated, current, remaining){
+        if(remaining.length > 0){
+            remaining.forEach((r, index) => {
+                var next = current.slice();
+                next.push(r);
+                var newRemaining = remaining.slice();
+                newRemaining.splice(index, 1);
+                this.permutate(generated, next, newRemaining)
+            })
+        }
+        else {
+            generated.push(current);
+        }
+        return generated;
+    }
+
+    selectCards(player, cards) {
+        for(let card of cards) {
+            player.moveCard(card, 'hand');
+        }
+        this.game.addMessage('{0} uses {1} to search their deck and adds {2} to their hand', player, this, cards);
+        return true;
+    }
+
+    cancelSearch(player) {
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any cards to their hand', player, this);
+        return true;
     }
 }
 

--- a/server/game/cards/20-HMW/BraveCompanions.js
+++ b/server/game/cards/20-HMW/BraveCompanions.js
@@ -1,9 +1,11 @@
 const DrawCard = require('../../drawcard.js');
 const {Tokens} = require('../../Constants');
 const GameActions = require('../../GameActions');
+const Array = require('../../../Array');
 
 class BraveCompanions extends DrawCard {
     setupCardAbilities(ability) {
+        const selectableTraits = ['Army', 'Commander', 'Mercenary'];
         this.persistentEffect({
             match: card => card === this,
             effect: ability.effects.dynamicStrength(() => this.calculateStrength())
@@ -19,7 +21,10 @@ class BraveCompanions extends DrawCard {
                 numToSelect: 3,
                 match: {
                     type: 'character',
-                    condition: (card, context) => this.remainingTraits(context.selectedCards).some(trait => card.hasTrait(trait))
+                    // Checking if the card is already selected || if it has one of the selectable traits && that trait is remaining for selection
+                    condition: (card, context) => context.selectedCards.includes(card) 
+                        || selectableTraits.some(trait => card.hasTrait(trait)) 
+                        && Array.availableToPair(selectableTraits, context.selectedCards, (trait, card) => card.hasTrait(trait)).some(trait => card.hasTrait(trait))
                 },
                 message: '{player} uses {source} to search their deck and add {searchTarget} to their hand',
                 cancelMessage: '{player} uses {source} to search their deck but does not find a card',
@@ -36,50 +41,6 @@ class BraveCompanions extends DrawCard {
         });
 
         return cards.length;
-    }
-
-    remainingTraits(selectedCards) {
-        const traits = ['Army', 'Commander', 'Mercenary'];
-        let tempCards = selectedCards.slice();
-        for(let i = tempCards.length ; i < traits.length ; i++) {
-            tempCards.push(null);
-        }
-        var remaining = [];
-        this.permutate([], [], tempCards).every(p => {
-            if(p.every((c, i) => !c || c.hasTrait(traits[i]))) {
-                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r === t) && !p[i]));
-            }
-            return remaining.length !== traits.length;
-        });
-        return remaining;
-    }
-
-    permutate(generated, current, remaining) {
-        if(remaining.length > 0) {
-            remaining.forEach((r, index) => {
-                var next = current.slice();
-                next.push(r);
-                var newRemaining = remaining.slice();
-                newRemaining.splice(index, 1);
-                this.permutate(generated, next, newRemaining);
-            });
-        } else {
-            generated.push(current);
-        }
-        return generated;
-    }
-
-    selectCards(player, cards) {
-        for(let card of cards) {
-            player.moveCard(card, 'hand');
-        }
-        this.game.addMessage('{0} uses {1} to search their deck and adds {2} to their hand', player, this, cards);
-        return true;
-    }
-
-    cancelSearch(player) {
-        this.game.addMessage('{0} uses {1} to search their deck, but does not add any cards to their hand', player, this);
-        return true;
     }
 }
 

--- a/server/game/cards/20-HMW/BraveCompanions.js
+++ b/server/game/cards/20-HMW/BraveCompanions.js
@@ -41,29 +41,29 @@ class BraveCompanions extends DrawCard {
     remainingTraits(selectedCards) {
         const traits = ['Army', 'Commander', 'Mercenary'];
         let tempCards = selectedCards.slice();
-        for(let i=tempCards.length ; i<traits.length ; i++)
+        for(let i = tempCards.length ; i < traits.length ; i++) {
             tempCards.push(null);
+        }
         var remaining = [];
-        this.permutate([],[],tempCards).every(p => {
-            if(p.every((c, i) => !c || c.hasTrait(traits[i]))){
-                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r == t) && !p[i]));
+        this.permutate([], [], tempCards).every(p => {
+            if(p.every((c, i) => !c || c.hasTrait(traits[i]))) {
+                remaining = remaining.concat(traits.filter((t, i) => !remaining.some(r => r === t) && !p[i]));
             }
-            return remaining.length != traits.length;
-        })
+            return remaining.length !== traits.length;
+        });
         return remaining;
     }
 
-    permutate(generated, current, remaining){
-        if(remaining.length > 0){
+    permutate(generated, current, remaining) {
+        if(remaining.length > 0) {
             remaining.forEach((r, index) => {
                 var next = current.slice();
                 next.push(r);
                 var newRemaining = remaining.slice();
                 newRemaining.splice(index, 1);
-                this.permutate(generated, next, newRemaining)
-            })
-        }
-        else {
+                this.permutate(generated, next, newRemaining);
+            });
+        } else {
             generated.push(current);
         }
         return generated;


### PR DESCRIPTION
Fixes a bug with Brave Companions (and Fresh Recruits) by updating its logic. It will now correctly highlight the valid cards based on the remaining _**Traits**_ when looking in the deck, even if a card with multiple of those _**Traits**_ is selected. For example, if you find a character with _**Commander. Mercenary.**_, they could be selected as the _**Commander**_ card or the _**Mercenary**_ card, meaning both traits are still available for selection.
This update uses permutation to find all valid combinations of the selected cards against the given traits, and returns the list of remaining traits that can still be selected.
Discord: Deathlysteve#4587 for any queries.