### PR TITLE
add a titleFunc for the onCardReturnedToHand trigger 

### DIFF
--- a/server/game/gamesteps/TriggeredAbilityWindowTitles.js
+++ b/server/game/gamesteps/TriggeredAbilityWindowTitles.js
@@ -3,6 +3,7 @@ const EventToTitleFunc = {
     onCardEntersPlay: event => `${event.card.name} entering play`,
     onCardPowerGained: event => `${event.card.name} gaining power`,
     onCardPowerMoved: event => `power moved from ${event.source.name} to ${event.target.name}`,
+    onCardReturnedToHand: event => `${event.card.name} being returned to hand`,
     onClaimApplied: () => 'to claim effects being applied',
     onCharacterKilled: event => `${event.card.name} being killed`,
     onCharactersKilled: () => 'characters being killed',


### PR DESCRIPTION
add a titleFunc for the onCardReturnedToHand trigger so that the prompt displays which card is being returned to hand when a triggered ability interacts with it
relevant for Golden Company and things like First snow of winter