### PR TITLE
Fix "place on bottom of deck" effects

### DIFF
--- a/server/game/cards/11.4-MoD/MeereeneseMarket.js
+++ b/server/game/cards/11.4-MoD/MeereeneseMarket.js
@@ -1,4 +1,5 @@
 const DrawCard = require('../../drawcard.js');
+const GameActions = require('../../GameActions');
 
 class MeereeneseMarket extends DrawCard {
     setupCardAbilities(ability) {
@@ -14,8 +15,10 @@ class MeereeneseMarket extends DrawCard {
                 cardCondition: card => card.location === 'discard pile'
             },
             handler: context => {
-                let card = context.target;
-                card.owner.moveCardToBottomOfDeck(card);
+                this.game.resolveGameAction(
+                    GameActions.returnCardToDeck(context => ({ card: context.target, bottom: true })),
+                    context
+                );
                 this.game.addMessage('{0} kneels {1} to place {2} on the bottom of {3}\'s deck',
                     this.controller, this, context.target, context.target.owner);
             }

--- a/server/game/cards/12-KotI/StolenMessage.js
+++ b/server/game/cards/12-KotI/StolenMessage.js
@@ -1,3 +1,4 @@
+const GameActions = require('../../GameActions');
 const PlotCard = require('../../plotcard');
 
 class StolenMessage extends PlotCard {
@@ -14,8 +15,10 @@ class StolenMessage extends PlotCard {
             limit: ability.limit.perRound(3),
             handler: context => {
                 this.game.addMessage('{0} uses {1} to place the top card of {2}\'s deck on the bottom of their deck', context.player, this, context.opponent);
-                let topCard = context.opponent.drawDeck[0];
-                context.opponent.moveCardToBottomOfDeck(topCard);
+                this.game.resolveGameAction(
+                    GameActions.placeCard(context => ({ card: context.opponent.drawDeck[0], location: 'draw deck', bottom: true })),
+                    context
+                );
             }
         });
     }

--- a/server/game/cards/14-FotS/AcolyteOfTheFlame.js
+++ b/server/game/cards/14-FotS/AcolyteOfTheFlame.js
@@ -42,9 +42,11 @@ class AcolyteOfTheFlame extends DrawCard {
 
         let topCards = this.context.opponent.drawDeck.slice(0, 2);
         this.game.addMessage('Then {0} places the top 2 cards on the bottom of {1}\'s deck for {2}', this.context.player, this.context.opponent, this);
-        for(let card of topCards) {
-            this.context.opponent.moveCardToBottomOfDeck(card);
-        }
+        this.game.resolveGameAction(
+            GameActions.simultaneously(topCards.map(card => (
+                GameActions.placeCard({ card, location: 'draw deck', bottom: true })
+            )))
+        );
 
         return true;
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -3,6 +3,7 @@ const AllowedChallenge = require('./AllowedChallenge');
 const CardMatcher = require('./CardMatcher');
 const CardTextDefinition = require('./CardTextDefinition');
 const CostReducer = require('./costreducer.js');
+const GameActions = require('./GameActions');
 const PlayableLocation = require('./playablelocation.js');
 const CannotRestriction = require('./cannotrestriction.js');
 const ChallengeRestriction = require('./ChallengeRestriction.js');
@@ -580,7 +581,9 @@ const Effects = {
             unapply: function(card, context) {
                 if(['play area', 'duplicate'].includes(card.location) && context.moveToBottomOfDeckIfStillInPlay.includes(card)) {
                     context.moveToBottomOfDeckIfStillInPlay = context.moveToBottomOfDeckIfStillInPlay.filter(c => c !== card);
-                    card.owner.moveCardToBottomOfDeck(card, allowSave);
+                    context.game.resolveGameAction(
+                        GameActions.returnCardToDeck({ card, allowSave, bottom: true })
+                    );
                     context.game.addMessage('{0} moves {1} to the bottom of its owner\'s deck at the end of the phase because of {2}', context.source.controller, card, context.source);
                 }
             }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -910,10 +910,6 @@ class Player extends Spectator {
         return this.game.resolveGameAction(GameActions.returnCardToDeck({ card, allowSave }));
     }
 
-    moveCardToBottomOfDeck(card, allowSave = true) {
-        return this.game.resolveGameAction(GameActions.returnCardToDeck({ card, allowSave, bottom: true }));
-    }
-
     canPutIntoShadows(card, playingType = 'put') {
         return !this.putIntoShadowsRestrictions.some(restriction => restriction(card, playingType));
     }


### PR DESCRIPTION
Returning a card to the deck assumes that the card is already outside of
the deck. For cards that take the top card of the deck and place it on
bottom, PlaceCard should be used instead.

Fixes #3160 