### PR TITLE
fix the mummers farce attachments so they also check for attachment validity 

### DIFF
--- a/server/game/AttachmentValidityCheck.js
+++ b/server/game/AttachmentValidityCheck.js
@@ -27,7 +27,7 @@ class AttachmentValidityCheck {
     }
 
     filterInvalidAttachments() {
-        let attachmentsInPlay = this.game.filterCardsInPlay(card => card.parent && card.getType() === 'attachment' && !card.isBeingRemoved && !card.facedown);
+        let attachmentsInPlay = this.game.filterCardsInPlay(card => card.parent && card.getType() === 'attachment' && !card.isBeingRemoved);
         return attachmentsInPlay.filter(card => !card.controller.canAttach(card, card.parent));
     }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -326,7 +326,7 @@ class DrawCard extends BaseCard {
             return false;
         }
 
-        if(!this.attachmentRestrictions || this.isAnyBlank()) {
+        if(!this.attachmentRestrictions || this.isAnyBlank() || this.facedown) {
             return card.getType() === 'character';
         }
 

--- a/test/server/cards/20-HMW/AMummersFarce.spec.js
+++ b/test/server/cards/20-HMW/AMummersFarce.spec.js
@@ -67,7 +67,7 @@ describe('A Mummer´s Farce', function() {
                 this.player1.clickCard(this.jinglebell);
             });
 
-            it('the persistent effect of that card should activate once the card enters play', function() {
+            it('the weapon attachments should be discarded because they are invalidly attached', function() {
                 expect(this.jinglebell.location).toBe('play area');
                 expect(this.jinglebell.getStrength()).toBe(1);
                 expect(this.knight2.location).toBe('discard pile');

--- a/test/server/cards/20-HMW/AMummersFarce.spec.js
+++ b/test/server/cards/20-HMW/AMummersFarce.spec.js
@@ -3,7 +3,7 @@ describe('A Mummer´s Farce', function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('tyrell', [
                 'A Mummer\'s Farce',
-                'Late Summer Feast', 'Jinglebell', 'Green-Apple Knight', 'Green-Apple Knight'
+                'Late Summer Feast', 'Jinglebell', 'Green-Apple Knight', 'Green-Apple Knight', 'Warhammer', 'Blessed by the Maiden'
             ]);
             this.player1.selectDeck(deck1);
             this.player2.selectDeck(deck1);
@@ -12,6 +12,8 @@ describe('A Mummer´s Farce', function() {
 
             this.jinglebell = this.player1.findCardByName('Jinglebell');
             [this.knight1, this.knight2] = this.player1.filterCardsByName('Green-Apple Knight', 'hand');
+            this.blessed = this.player1.findCardByName('Blessed by the Maiden');
+            this.warhammer = this.player1.findCardByName('Warhammer');
             this.completeSetup();
 
             this.selectFirstPlayer(this.player1);
@@ -49,6 +51,27 @@ describe('A Mummer´s Farce', function() {
                 //both knights persistent STR buff effects should work
                 expect(this.knight1.getStrength()).toBe(2);
                 expect(this.knight2.getStrength()).toBe(2);
+            });
+        });
+
+        describe('when a fool has a weapon attachment and a facedown attachment attached and gains the no attachments keyword', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.jinglebell);
+                this.player1.clickCard(this.warhammer);
+                this.player1.clickCard(this.jinglebell);
+                //kneel and stand the fool to trigger A Mummer´s Farce
+                this.player1.clickCard(this.jinglebell);
+                this.player1.clickCard(this.jinglebell);
+                expect(this.jinglebell.getStrength()).toBe(4);
+                this.player1.clickCard(this.blessed);
+                this.player1.clickCard(this.jinglebell);
+            });
+
+            it('the persistent effect of that card should activate once the card enters play', function() {
+                expect(this.jinglebell.location).toBe('play area');
+                expect(this.jinglebell.getStrength()).toBe(1);
+                expect(this.knight2.location).toBe('discard pile');
+                expect(this.warhammer.location).toBe('discard pile');
             });
         });
     });


### PR DESCRIPTION
fix the mummers farce attachments so they also check for attachment validity and get discarded when parent fool gains the no attachments keyword