### PR TITLE
fix the father to be a forced interrupt instead of reaction

### DIFF
--- a/server/game/cards/20-HMW/TheFather.js
+++ b/server/game/cards/20-HMW/TheFather.js
@@ -3,7 +3,7 @@ const GameActions = require('../../GameActions');
 
 class TheFather extends PlotCard {
     setupCardAbilities() {
-        this.forcedReaction({
+        this.forcedInterrupt({
             when: {
                 onPhaseEnded: event => event.phase === 'dominance' && this.game.anyCardsInPlay(card => card.getType() === 'character' && card.isUnique())
             },


### PR DESCRIPTION
the father (https://thronesdb.com/card/20054) uses a wrong triggered ability handler at the moment. this leads to timing issues with other reactions/interrupts