### PR TITLE
Fix improved fortification triggering condition and saving

### DIFF
--- a/server/game/cards/06.4-TRW/ImprovedFortifications.js
+++ b/server/game/cards/06.4-TRW/ImprovedFortifications.js
@@ -3,10 +3,16 @@ const DrawCard = require('../../drawcard.js');
 class ImprovedFortifications extends DrawCard {
     setupCardAbilities(ability) {
         this.attachmentRestriction({ type: 'location' });
+        
+        let leftPlayCondition = event => event.allowSave && event.card.canBeSaved() && event.card === this.parent;
         this.interrupt({
             canCancel: true,
             when: {
-                onCardLeftPlay: event => event.card === this.parent && this.parent.canBeSaved()
+                onCardDiscarded: leftPlayCondition,
+                onCardReturnedToHand: leftPlayCondition,
+                onCardRemovedFromGame: leftPlayCondition,
+                onCardReturnedToDeck: leftPlayCondition,
+                onCardPutIntoShadows: leftPlayCondition
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {

--- a/server/game/cards/06.4-TRW/ImprovedFortifications.js
+++ b/server/game/cards/06.4-TRW/ImprovedFortifications.js
@@ -16,7 +16,7 @@ class ImprovedFortifications extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
-                context.event.cancel();
+                context.event.saveCard();
                 this.game.addMessage('{0} sacrifices {1} to save {2}', context.player, this, this.parent);
             }
         });


### PR DESCRIPTION
previously, improved fortification reacted to late for a "would leave play" interrupt. I now used the same triggering condition as dupes (minus the killing part).
furthermore, using context.event.saveCard() should be called, just like for dupes, which in turn calls cancel()