### PR TITLE
Add API endpoint for draft cubes

### DIFF
--- a/server/api/draftCubes.js
+++ b/server/api/draftCubes.js
@@ -1,0 +1,111 @@
+const passport = require('passport');
+
+const { wrapAsync } = require('../util');
+const ServiceFactory = require('../services/ServiceFactory.js');
+
+function validate(draftCube) {
+    let errors = [];
+
+    if(!draftCube.name) {
+        errors.push('name is required');
+    }
+
+    if(!draftCube.packDefinitions || !Array.isArray(draftCube.packDefinitions)) {
+        errors.push('packDefinitions is required');
+    } else {
+        for(const packDefinition of draftCube.packDefinitions) {
+            errors = errors.concat(validatePackDefinition(packDefinition));
+        }
+    }
+
+    return errors;
+}
+
+function validatePackDefinition(packDefinition) {
+    const errors = [];
+
+    if(!packDefinition.rarities || !Array.isArray(packDefinition.rarities)) {
+        errors.push('rarities is required');
+    } else if(packDefinition.rarities.some(rarity => !rarity.name || !rarity.numPerPack || !rarity.cards)) {
+        errors.push('rarities must include name, numPerPack, and cards');
+    }
+
+    return errors;
+}
+
+module.exports.init = function(server, options) {
+    const draftCubesService = ServiceFactory.draftCubeService(options.db);
+
+    server.get('/api/draft-cubes', wrapAsync(async function(req, res) {
+        const draftCubes = await draftCubesService.getAll();
+
+        return res.send({ success: true, draftCubes });
+    }));
+
+    server.post('/api/draft-cubes', passport.authenticate('jwt', { session: false }), wrapAsync(async function(req, res, next) {
+        if(!req.user.permissions || !req.user.permissions.canManageEvents) {
+            return res.status(403).send({ message: 'Forbidden' });
+        }
+
+        const { name, packDefinitions, starterDeck } = req.body.draftCube;
+        const draftCube = { name, packDefinitions, starterDeck };
+
+        const errors = validate(draftCube);
+        if(errors.length !== 0) {
+            res.send({ success: false, message: errors.join('\n') });
+            return next();
+        }
+
+        draftCubesService.create(draftCube)
+            .then(draftCube => {
+                res.send({ success: true, draftCube });
+            })
+            .catch(() => {
+                return res.send({ success: false, message: 'An error occured adding the draft cube' });
+            });
+    }));
+
+    server.put('/api/draft-cubes/:id', passport.authenticate('jwt', { session: false }), wrapAsync(async function(req, res, next) {
+        if(!req.user.permissions || !req.user.permissions.canManageEvents) {
+            return res.status(403).send({ message: 'Forbidden' });
+        }
+
+        const { name, packDefinitions, starterDeck } = req.body.draftCube;
+        const draftCube = {
+            id: req.params.id,
+            name,
+            packDefinitions,
+            starterDeck
+        };
+
+        const errors = validate(draftCube);
+        if(errors.length !== 0) {
+            res.send({ success: false, message: errors.join('\n') });
+            return next();
+        }
+
+        draftCubesService.update(draftCube)
+            .then(draftCube => {
+                res.send({ success: true, draftCube });
+            })
+            .catch(() => {
+                return res.send({ success: false, message: 'An error occured adding the draft cube' });
+            });
+    }));
+
+    server.delete('/api/draft-cubes/:id', passport.authenticate('jwt', { session: false }), wrapAsync(async function(req, res) {
+        if(!req.user.permissions || !req.user.permissions.canManageEvents) {
+            return res.status(403).send({ message: 'Forbidden' });
+        }
+
+        const draftCubeId = req.params.id;
+
+        draftCubesService.delete(draftCubeId)
+            .then(() => {
+                res.send({ success: true, draftCubeId });
+            })
+            .catch(() => {
+                return res.send({ success: false, message: 'An error occured deleting the draft cube' });
+            });
+    }));
+};

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -3,6 +3,37 @@ const passport = require('passport');
 const { wrapAsync } = require('../util');
 const ServiceFactory = require('../services/ServiceFactory.js');
 
+function extractEventFromRequest(req) {
+    const {
+        banned,
+        defaultRestrictedList,
+        draftOptions,
+        eventGameOptions,
+        format,
+        name,
+        restricted,
+        restrictSpectators,
+        useDefaultRestrictedList,
+        useEventGameOptions,
+        validSpectators
+    } = req.body.event;
+    return {
+        id: req.params.id,
+        banned,
+        defaultRestrictedList,
+        draftOptions,
+        eventGameOptions,
+        format,
+        name,
+        pods: [],
+        restricted,
+        restrictSpectators,
+        useDefaultRestrictedList,
+        useEventGameOptions,
+        validSpectators
+    };
+}
+
 module.exports.init = function(server, options) {
     const eventService = ServiceFactory.eventService(options.db);
 
@@ -17,8 +48,7 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, defaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
-        const event = { name, useDefaultRestrictedList, defaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, pods: [], restrictSpectators, validSpectators };
+        const event = extractEventFromRequest(req);
 
         eventService.create(event)
             .then(e => {
@@ -34,20 +64,7 @@ module.exports.init = function(server, options) {
             return res.status(403).send({ message: 'Forbidden' });
         }
 
-        const { name, useDefaultRestrictedList, defaultRestrictedList, useEventGameOptions, eventGameOptions, restricted, banned, restrictSpectators, validSpectators } = req.body.event;
-        const event = {
-            id: req.params.id,
-            name,
-            useDefaultRestrictedList,
-            defaultRestrictedList,
-            useEventGameOptions,
-            eventGameOptions,
-            restricted,
-            banned,
-            pods: [],
-            restrictSpectators,
-            validSpectators
-        };
+        const event = extractEventFromRequest(req);
 
         eventService.update(event)
             .then(e => {

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,6 +1,7 @@
 const account = require('./account');
 const events = require('./events');
 const decks = require('./decks');
+const draftCubes = require('./draftCubes');
 const cards = require('./cards');
 const news = require('./news');
 const user = require('./user');
@@ -10,6 +11,7 @@ const banlist = require('./banlist');
 module.exports.init = function(server, options) {
     account.init(server, options);
     decks.init(server, options);
+    draftCubes.init(server, options);
     cards.init(server, options);
     news.init(server, options);
     user.init(server, options);

--- a/server/services/DraftCubeService.js
+++ b/server/services/DraftCubeService.js
@@ -1,0 +1,56 @@
+const logger = require('../log.js');
+
+class DeckService {
+    constructor(db) {
+        this.draftCubes = db.get('draftCubes');
+    }
+
+    async getAll() {
+        return this.draftCubes.find({})
+            .then(draftCube => {
+                return draftCube;
+            })
+            .catch(err => {
+                logger.error('Error fetching draft cubes', err);
+
+                throw new Error('Error occured fetching draft cubes');
+            });
+    }
+
+    async getById(id) {
+        return this.draftCubes.findOne({ _id: id })
+            .catch(err => {
+                logger.error('Unable to fetch draft cube', err);
+                throw new Error('Unable to fetch draft cube ' + id);
+            });
+    }
+
+    async create(draftCube) {
+        let properties = {
+            name: draftCube.name,
+            packDefinitions: draftCube.packDefinitions,
+            starterDeck: draftCube.starterDeck,
+            lastUpdated: new Date()
+        };
+
+        return this.draftCubes.insert(properties);
+    }
+
+    async update(draftCube) {
+        let properties = {
+            name: draftCube.name,
+            packDefinitions: draftCube.packDefinitions,
+            starterDeck: draftCube.starterDeck,
+            lastUpdated: new Date()
+        };
+
+        return this.draftCubes.update({ _id: draftCube.id }, { '$set': properties });
+    }
+
+    async delete(id) {
+        return this.draftCubes.remove({ _id: id });
+    }
+}
+
+module.exports = DeckService;
+

--- a/server/services/DraftCubeService.js
+++ b/server/services/DraftCubeService.js
@@ -1,6 +1,6 @@
 const logger = require('../log.js');
 
-class DeckService {
+class DraftCubeService {
     constructor(db) {
         this.draftCubes = db.get('draftCubes');
     }
@@ -52,5 +52,5 @@ class DeckService {
     }
 }
 
-module.exports = DeckService;
+module.exports = DraftCubeService;
 

--- a/server/services/ServiceFactory.js
+++ b/server/services/ServiceFactory.js
@@ -4,6 +4,7 @@ const ConfigService = require('./ConfigService');
 const UserService = require('./UserService');
 const BanlistService = require('./BanlistService');
 const EventService = require('./EventService');
+const DraftCubeService = require('./DraftCubeService');
 
 let services = {};
 
@@ -49,5 +50,12 @@ module.exports = {
         }
 
         return services.eventService;
+    },
+    draftCubeService: (db) => {
+        if(!services.draftCubeService) {
+            services.draftCubeService = new DraftCubeService(db);
+        }
+
+        return services.draftCubeService;
     }
 };


### PR DESCRIPTION
Adds API endpoint to manage draft cubes, and allows events to be
configured with a format and draft options.

Progress toward #3206 