### PR TITLE
fix city of spiders by resetting the resolving flag

### DIFF
--- a/server/game/cards/13.4-BtRK/CityOfSpiders.js
+++ b/server/game/cards/13.4-BtRK/CityOfSpiders.js
@@ -37,6 +37,8 @@ class CityOfSpiders extends PlotCard {
             this.game.resolveAbility(whenRevealed, context);
         }
 
+        this.resolving = false;
+        
         return true;
     }
 }


### PR DESCRIPTION
this leads to city of spiders being able to be executed multiple times during a single game

fixes #3113 