### PR TITLE
call clearSelectableCards after forced plot selection so the plot selection works correctly after the plots get recycled

### DIFF
--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -4,10 +4,16 @@ class SelectPlotPrompt extends AllPlayerPrompt {
     completionCondition(player) {
         if(player.mustRevealPlot) {
             player.selectedPlot = player.mustRevealPlot;
+            //explicitly call clearSelectableCards so the selectable cards
+            //get reset for the next plot phase after cards are recycled
+            player.clearSelectableCards();
         } else {
             let selectableCards = player.getSelectableCards();
             if(selectableCards.length === 1) {
                 player.selectedPlot = selectableCards[0];
+                //explicitly call clearSelectableCards so the selectable cards
+                //get reset for the next plot phase after cards are recycled
+                player.clearSelectableCards();
             }
         }
 


### PR DESCRIPTION
fixes #3074 