### PR TITLE
rename gameaction in killcharacters.js to "kill" instead of "killed"

### DIFF
--- a/server/game/gamesteps/killcharacters.js
+++ b/server/game/gamesteps/killcharacters.js
@@ -10,7 +10,7 @@ class KillCharacters extends BaseStep {
 
     continue() {
         let cardsInPlay = this.cards.filter(card => card.location === 'play area');
-        this.game.applyGameAction('killed', cardsInPlay, killable => {
+        this.game.applyGameAction('kill', cardsInPlay, killable => {
             for(let card of killable) {
                 card.markAsInDanger();
             }


### PR DESCRIPTION
rename gameaction in killcharacters.js to "kill" instead of "killed" so cannot be killed effects are properly checked

before this fix you were able to trigger cards like shireen baratheon (core) or jinglebell on a The crone vs Valar Morghulis turn, even though shireen/jinglebell had the cannot be killed effect active