### PR TITLE
Fix Shagwell and other fools with gold giving each-other keywords which have no source

### DIFF
--- a/server/Array.js
+++ b/server/Array.js
@@ -88,10 +88,20 @@ function permutate(permutations, current, array) {
     return permutations;
 }
 
+function countAsMap(array) {
+    let map = new Map();
+    for(let item of array) {
+        let current = map.get(item) || 0;
+        map.set(item, current + 1);
+    }
+    return map;
+}
+
 module.exports = {
     flatten,
     flatMap,
     partition,
     sortBy,
-    availableToPair
+    availableToPair,
+    countAsMap
 };

--- a/server/game/PropertyTypes/KeywordsProperty.js
+++ b/server/game/PropertyTypes/KeywordsProperty.js
@@ -24,6 +24,10 @@ class KeywordsProperty {
         return this.data.contains(value);
     }
 
+    getCount(value) {
+        return this.data.getCountForReference(value);
+    }
+
     getValues() {
         return this.data.getValues();
     }

--- a/server/game/cards/20-HMW/Shagwell.js
+++ b/server/game/cards/20-HMW/Shagwell.js
@@ -1,20 +1,31 @@
 const DrawCard = require('../../drawcard.js');
 const {Tokens} = require('../../Constants');
-const {flatten} = require('../../../Array');
+const Array = require('../../../Array');
 
 class Shagwell extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card.hasTrait('Fool') && card.hasToken(Tokens.gold),
             targetController: 'any',
-            effect: ability.effects.dynamicKeywords(() => this.getFoolKeywords())
+            effect: ability.effects.dynamicKeywords((card, context) => this.getFoolKeywords(card, context))
         });
     }
 
-    getFoolKeywords() {
+    getFoolKeywords(card, context) {
         let cardsWithGold = this.game.filterCardsInPlay(card => card.getType() === 'character' && card.hasToken(Tokens.gold));
-        let keywordsOfCardsWithGold = [...new Set(flatten(cardsWithGold.map(card => card.getKeywords())))];
-        return keywordsOfCardsWithGold;
+        let keywords = [...new Set(Array.flatten(cardsWithGold.map(cwg => this.getKeywordsNotAddedByShagwell(cwg, context))))];
+
+        return keywords;
+    }
+
+    getKeywordsNotAddedByShagwell(card, context) {
+        let dynamicKeywords = context.dynamicKeywords[card.uuid] || [];
+        let effectCount = Array.countAsMap(dynamicKeywords);
+        let currentCount = card.keywords.getValues();
+
+        let keywordsNotAddedByShagwell = currentCount.filter(keyword => card.keywords.getCount(keyword) - (effectCount.get(keyword) || 0) > 0);
+
+        return keywordsNotAddedByShagwell;
     }
 }
 

--- a/test/server/cards/20-HMW/Shagwell.spec.js
+++ b/test/server/cards/20-HMW/Shagwell.spec.js
@@ -1,0 +1,131 @@
+describe('Shagwell', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('tyrell', [
+                'A Mummer\'s Farce',
+                'Late Summer Feast', 'Shagwell', 'Jinglebell', 'Maester Aemon (Core)', 'Veteran Builder', 'Asha Greyjoy (KotI)', 'Polliver'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck1);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.shagwell = this.player1.findCardByName('Shagwell');
+            this.jinglebell = this.player1.findCardByName('Jinglebell');
+            this.noAttach = this.player1.findCardByName('Maester Aemon');
+            this.noAttachExcept = this.player1.findCardByName('Veteran Builder');
+            this.stealthAndPillage = this.player1.findCardByName('Asha Greyjoy');
+            this.pillage = this.player1.findCardByName('Polliver');
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+        });
+
+        describe('when shagwell is alone in play', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.shagwell);
+                this.player1.clickPrompt('Done');
+            });
+            
+            it('should copy his own keywords', function() {
+                expect(this.shagwell.keywords.getCount('Bestow (1)')).toBe(1);
+                this.shagwell.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.getCount('Bestow (1)')).toBe(2);
+            });
+        });
+
+        describe('when shagwell is in play', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.shagwell);
+                this.player1.clickPrompt('1');
+            });
+
+            it('should copy the keywords of a no attachment character', function() {
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('No Attachments')).toBe(false);
+                this.player1.dragCard(this.noAttach, 'play area');
+                this.noAttach.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('No Attachments')).toBe(true);
+            });
+
+            it('should copy the keywords of a no attachment except weapon character', function() {
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('no attachments except <i>weapon</i>')).toBe(false);
+                this.player1.dragCard(this.noAttachExcept, 'play area');
+                this.noAttachExcept.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('no attachments except <i>weapon</i>')).toBe(true);
+            });
+
+            it('should copy the keywords of a pillage and stealth character', function() {
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('pillage')).toBe(false);
+                expect(this.shagwell.keywords.contains('stealth')).toBe(false);
+                this.player1.dragCard(this.stealthAndPillage, 'play area');
+                this.stealthAndPillage.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('pillage')).toBe(true);
+                expect(this.shagwell.keywords.contains('stealth')).toBe(true);
+            });
+
+            it('should only copy one instance of the same keyword whilst on different characters', function() {
+                expect(this.shagwell.keywords.getCount('Bestow (1)')).toBe(2);
+                expect(this.shagwell.keywords.getCount('pillage')).toBe(0);
+                
+                this.player1.dragCard(this.stealthAndPillage, 'play area');
+                this.stealthAndPillage.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.getCount('Bestow (1)')).toBe(2);
+                expect(this.shagwell.keywords.getCount('pillage')).toBe(1);
+
+                this.player1.dragCard(this.pillage, 'play area');
+                this.pillage.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.getCount('Bestow (1)')).toBe(2);
+                expect(this.shagwell.keywords.getCount('pillage')).toBe(1);
+            });
+
+            it('should not copy the keywords of a character that left play while another fool with gold is in play', function() {
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('pillage')).toBe(false);
+                expect(this.shagwell.keywords.contains('stealth')).toBe(false);
+                this.player1.dragCard(this.stealthAndPillage, 'play area');
+                this.stealthAndPillage.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                this.player1.dragCard(this.jinglebell, 'play area');
+                this.jinglebell.modifyToken('gold', 1);
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('pillage')).toBe(true);
+                expect(this.shagwell.keywords.contains('stealth')).toBe(true);
+                expect(this.jinglebell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.jinglebell.keywords.contains('pillage')).toBe(true);
+                expect(this.jinglebell.keywords.contains('stealth')).toBe(true);
+                //source of pillage and stealth leaves play
+                this.player1.dragCard(this.stealthAndPillage, 'discard pile');
+                //update state
+                this.player1.clickCard(this.shagwell);
+                expect(this.shagwell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.shagwell.keywords.contains('pillage')).toBe(false);
+                expect(this.shagwell.keywords.contains('stealth')).toBe(false);
+                expect(this.jinglebell.keywords.contains('Bestow (1)')).toBe(true);
+                expect(this.jinglebell.keywords.contains('pillage')).toBe(false);
+                expect(this.jinglebell.keywords.contains('stealth')).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Situation specified in 3rd point of the Rules FAQ for Shagwell (https://thronesdb.com/card/20045):
`If a character that was giving two or more Fools a keyword via Shagwell's constant effect leaves play or loses that keyword, those characters will lose that keyword too, unless there is another "source". They cannot continue to be each other's only source of that keyword if none of them are gaining it from anywhere else.`

This fix prevents Shagwells ability from adding instances of keywords which were originally obtained from Shagwells ability:
- Gets the current counts of each keyword for the card it is using as a source (eg. a card with 1 or more gold on it)
- Subtracts that with the current counts of each keyword being provided to that card by Shagwells effect. 
- The result is a list of keywords _not_ obtained from Shagwells ability, in which is then added to the total list of keywords Shagwells ability will provide all Fools with 1 or more gold.

I copied most of @EvadLhorg's jasmine test from #3163, with a few extra things added to ensure its true to the FAQ.

If this is approved, close #3163 