### PR TITLE
Fixing bug for "shares a Trait" abilities and added Traits

### DIFF
--- a/server/game/GameActions/ThenAbilityAction.js
+++ b/server/game/GameActions/ThenAbilityAction.js
@@ -18,7 +18,7 @@ class ThenAbilityAction {
                 return;
             }
 
-            let abilityProperties = this.abilityPropertiesFactory(context);
+            let abilityProperties = this.abilityPropertiesFactory(context, event);
             let ability = new ThenClauseAbility(abilityProperties);
             let thenContext = ability.createContext(context, event);
 

--- a/server/game/cards/17.1-R/AMissionInEssos.js
+++ b/server/game/cards/17.1-R/AMissionInEssos.js
@@ -14,13 +14,13 @@ class AMissionInEssos extends DrawCard {
             handler: context => {
                 this.game.resolveGameAction(
                     GameActions.returnCardToHand(context => ({ card: context.target }))
-                        .then(preThenContext => ({
+                        .then((preThenContext, preThenEvent) => ({
                             gameAction: GameActions.search({
                                 title: 'Select a character',
                                 match: {
                                     type: 'character',
-                                    trait: preThenContext.target.getTraits(),
-                                    printedCostOrLower: preThenContext.target.getPrintedCost() - 1
+                                    printedCostOrLower: preThenEvent.cardStateWhenReturned.getPrintedCost() - 1,
+                                    condition: card => card.getTraits().some(trait => preThenEvent.cardStateWhenReturned.hasTrait(trait))
                                 },
                                 message: 'Then {player} uses {source} to search their deck and put {searchTarget} into play',
                                 cancelMessage: 'Then {player} uses {source} to search their deck but does not find a card',

--- a/server/game/cards/20-HMW/Jinglebell.js
+++ b/server/game/cards/20-HMW/Jinglebell.js
@@ -11,7 +11,7 @@ class Jinglebell extends DrawCard {
                 title: 'Select a card',
                 match: {
                     type: 'character',
-                    trait: this.getTraits()
+                    condition: card => card.getTraits().some(trait => this.hasTrait(trait))
                 },
                 message: '{player} uses {source} to search their deck and add {searchTarget} to their hand',
                 cancelMessage: '{player} uses {source} to search their deck but does not find a card',


### PR DESCRIPTION
This should fix a bug with Jinglebell & A Mission in Essos for when Traits are added to that character (eg. The Many-Faced God).

**Jinglebell**: Previously was calculating triggerable traits when Jinglebell entered play (House Frey & Fool only). Now it is calculated when the ability actually triggers.

**A Mission in Essos**: Was checking traits for that character after they were returned to hand, rather than before. I have confirmed with the Design Team that it should take into account that characters card-state whilst in-play for the search condition, and this adjustment does that.