### PR TITLE
fix the princess pass after the refactoring of the loseIcon effect so that the then part of the card triggers in a queued simple step

### DIFF
--- a/server/game/cards/04.5-GoH/ThePrincesPass.js
+++ b/server/game/cards/04.5-GoH/ThePrincesPass.js
@@ -22,18 +22,21 @@ class ThePrincesPass extends DrawCard {
                     this.game.addMessage('{0} kneels {1} to remove {2} {3} icon from {4}',
                         this.controller, this, icon === 'intrigue' ? 'an' : 'a', icon, this.targetCharacter);
 
-                    if(this.targetCharacter.getNumberOfIcons() === 0) {
-                        this.game.promptWithMenu(this.controller, this, {
-                            activePrompt: {
-                                menuTitle: 'Sacrifice ' + this.name + ' to discard ' + this.targetCharacter.name + '?',
-                                buttons: [
-                                    { text: 'Yes', method: 'sacrifice' },
-                                    { text: 'No', method: 'pass' }
-                                ]
-                            },
-                            source: this
-                        });
-                    }
+                    //put the then part in a simple step after the effect above is fully applied
+                    this.game.queueSimpleStep(() => {
+                        if(this.targetCharacter.getNumberOfIcons() === 0) {
+                            this.game.promptWithMenu(this.controller, this, {
+                                activePrompt: {
+                                    menuTitle: 'Sacrifice ' + this.name + ' to discard ' + this.targetCharacter.name + '?',
+                                    buttons: [
+                                        { text: 'Yes', method: 'sacrifice' },
+                                        { text: 'No', method: 'pass' }
+                                    ]
+                                },
+                                source: this
+                            });
+                        }
+                    });                    
                 });
             }
         });


### PR DESCRIPTION
fixes #3263

i think refactoring the `ability.effects.removeIcon(icon)` part so that it now is a gameaction breaks this particular card. the check for 
`if(this.targetCharacter.getNumberOfIcons() === 0) {` returns false as the number of icons is still 1 at that point as the game action hasn´t resolved yet
seems more like a workaround to be honest, other ideas welcome
