### PR TITLE
Do not allow Glamor to resurrect killed parent

### DIFF
--- a/server/game/cards/11.5-IDP/Glamor.js
+++ b/server/game/cards/11.5-IDP/Glamor.js
@@ -21,6 +21,7 @@ class Glamor extends DrawCard {
                 cardCondition: (card, context) => (
                     card.controller === context.player &&
                     card.location === 'dead pile' &&
+                    card !== context.costs.kill &&
                     this.tracker.wasKilledThisPhase(card) &&
                     context.player.canPutIntoPlay(card)
                 )


### PR DESCRIPTION
The text for Glamor says "another character killed this phase", so you cannot
select the card killed as a cost to activate its ability.