### PR TITLE
fix the reaction of the mummers farce so it only triggers on cards that can have weapon attachments

### DIFF
--- a/server/game/cards/20-HMW/AMummersFarce.js
+++ b/server/game/cards/20-HMW/AMummersFarce.js
@@ -12,7 +12,7 @@ class AMummersFarce extends AgendaCard {
 
         this.forcedReaction({
             when: {
-                onCardStood: event => event.card.controller === this.controller && event.card.hasTrait('Fool')
+                onCardStood: event => event.card.controller === this.controller && event.card.hasTrait('Fool') && this.isCardEligibleToHaveFacedownWeaponAttachments(event.card)
             },
             handler: context => {
                 let topCard = context.player.drawDeck[0];
@@ -45,6 +45,12 @@ class AMummersFarce extends AgendaCard {
 
     isFacedownAttachment(card) {
         return card.facedown && card.controller === this.controller && card.getType() === 'attachment' && card.parent.hasTrait('Fool');
+    }
+
+    isCardEligibleToHaveFacedownWeaponAttachments(card) {
+        let noAttachmentKeywords = card.getKeywords().filter(keyword => keyword.startsWith('no attachments'));
+        return noAttachmentKeywords.length === 0 || 
+            (noAttachmentKeywords.length === 1 && noAttachmentKeywords[0] === 'no attachments except <i>weapon</i>');
     }
 }
 


### PR DESCRIPTION
Concerning A Mummer's Farce:

This is from the FAQ what @Odrl wrote:
If a Fool character has the no attachments keyword, the Forced Reaction will not trigger for that character. 

In fact theironthrone tries to resolve the forced reaction and then discards that card immediatly.