### PR TITLE
Allow Ser Rolly Duckfield to save himself if he has the correct trait

### DIFF
--- a/server/game/cards/22-BtB/SerRollyDuckfield.js
+++ b/server/game/cards/22-BtB/SerRollyDuckfield.js
@@ -9,7 +9,7 @@ class SerRollyDuckfield extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && event.card !== this && (event.card.hasTrait('Lord') || event.card.hasTrait('King'))
+                onCharacterKilled: event => event.allowSave && event.card.canBeSaved() && (event.card.hasTrait('Lord') || event.card.hasTrait('King'))
             },
             cost: ability.costs.discardFromHand(),
             limit: ability.limit.perRound(1),


### PR DESCRIPTION
This fixes #3277.