### PR TITLE
Fixing Player Select order for simultaneous multi-target abilities

### DIFF
--- a/server/game/AbilityChoiceSelection.js
+++ b/server/game/AbilityChoiceSelection.js
@@ -7,6 +7,7 @@ class AbilityChoiceSelection {
         this.eligibleChoices = options.eligibleChoices;
         this.targetingType = options.targetingType;
         this.name = options.name;
+        this.subResults = options.subResults;
         this.resolved = false;
         this.cancelled = false;
         this.value = null;

--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -2,6 +2,7 @@ const AbilityTargetMessages = require('./AbilityTargetMessages');
 const AbilityChoiceSelection = require('./AbilityChoiceSelection');
 const CardSelector = require('./CardSelector.js');
 const Messages = require('./Messages');
+const {flatMap} = require('../Array');
 
 class AbilityTarget {
     static create(name, properties) {
@@ -24,6 +25,10 @@ class AbilityTarget {
         this.selector = CardSelector.for(properties);
         this.messages = properties.messages;
         this.ifAble = !!properties.ifAble;
+        this.subTargets = properties.subTargets ? Object.entries(properties.subTargets).map(([name, properties]) => {
+            properties.choosingPlayer = (player, context) => player === context.choosingPlayer;
+            return AbilityTarget.create(name, properties);
+        }) : [];
     }
 
     canResolve(context) {
@@ -31,28 +36,62 @@ class AbilityTarget {
         return this.ifAble || players.length > 0 && players.every(choosingPlayer => {
             context.choosingPlayer = choosingPlayer;
             return this.selector.hasEnoughTargets(context);
-        });
+        }) && this.subTargets.every(subTarget => subTarget.canResolve(context));
     }
 
+    buildPlayerSelection(context) {
+        let eligibleCards = this.selector.getEligibleTargets(context);
+        let subResults = this.subTargets.map(subTarget => subTarget.buildPlayerSelection(context));
+        return new AbilityChoiceSelection({
+            choosingPlayer: context.choosingPlayer,
+            eligibleChoices: eligibleCards,
+            targetingType: this.type,
+            subResults: subResults,
+
+            name: this.name
+        });
+    }
+    
     resolve(context) {
         let results = this.getChoosingPlayers(context).map(choosingPlayer => {
             context.choosingPlayer = choosingPlayer;
-            let eligibleCards = this.selector.getEligibleTargets(context);
-            return new AbilityChoiceSelection({
-                choosingPlayer: choosingPlayer,
-                eligibleChoices: eligibleCards,
-                targetingType: this.type,
-                name: this.name
-            });
+            return this.buildPlayerSelection(context);
         });
 
         for(let result of results) {
             context.game.queueSimpleStep(() => {
-                this.resolveAction(result, context);
+                if(result.subResults.length > 0) {
+                    this.resolveSubActions(result, context);
+                } else {
+                    this.resolveAction(result, context);
+                }
             });
         }
 
         return results;
+    }
+
+    resolveSubActions(result, context) {
+        for(let subTarget of this.subTargets) {
+            let subResult = result.subResults.find(subResult => subResult.name === subTarget.name);
+            context.game.queueSimpleStep(() => {
+                subTarget.resolveAction(subResult, context);
+            });
+        }
+        context.game.queueSimpleStep(() => {
+            context.currentTargetSelection = result;
+            if(result.subResults.some(subResult => subResult.cancelled)) {
+                result.cancel();
+            } else {
+                let subValues = flatMap(result.subResults.filter(subResult => subResult.numValues > 0), subResult => subResult.value);
+                result.resolve(subValues);
+                if(result.numValues === 0) {
+                    this.messages.outputNoneSelected(context.game, context);
+                } else {
+                    this.messages.outputSelected(context.game, context);
+                }
+            }
+        });
     }
 
     getChoosingPlayers(context) {

--- a/server/game/cards/09-HoT/NothingBurnsLikeTheCold.js
+++ b/server/game/cards/09-HoT/NothingBurnsLikeTheCold.js
@@ -1,29 +1,30 @@
 const PlotCard = require('../../plotcard');
 const Messages = require('../../Messages');
+const {flatMap} = require('../../../Array');
 
 class NothingBurnsLikeTheCold extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            targets: {
-                attachment: {
-                    choosingPlayer: 'each',
-                    ifAble: true,
-                    activePromptTitle: 'Select an attachment',
-                    cardCondition: (card, context) => card.location === 'play area' && card.controller === context.choosingPlayer && card.getType() === 'attachment',
-                    gameAction: 'discard',
-                    messages: Messages.eachPlayerTargetingForCardType('attachments')
+            target: {
+                choosingPlayer: 'each',
+                subTargets: {
+                    attachment: {
+                        ifAble: true,
+                        activePromptTitle: 'Select an attachment',
+                        cardCondition: (card, context) => card.location === 'play area' && card.controller === context.choosingPlayer && card.getType() === 'attachment',
+                        gameAction: 'discard'
+                    },
+                    location: {
+                        ifAble: true,
+                        activePromptTitle: 'Select a location',
+                        cardCondition: (card, context) => card.location === 'play area' && card.controller === context.choosingPlayer && card.getType() === 'location' && !card.isLimited(),
+                        gameAction: 'discard'
+                    }
                 },
-                location: {
-                    choosingPlayer: 'each',
-                    ifAble: true,
-                    activePromptTitle: 'Select a location',
-                    cardCondition: (card, context) => card.location === 'play area' && card.controller === context.choosingPlayer && card.getType() === 'location' && !card.isLimited(),
-                    gameAction: 'discard',
-                    messages: Messages.eachPlayerTargetingForCardType('locations')
-                }
+                messages: Messages.eachPlayerTargeting
             },
             handler: context => {
-                let cards = context.targets.selections.map(selection => selection.value).filter(card => !!card);
+                let cards = flatMap(context.targets.selections, selection => selection.value).filter(card => !!card);
                 this.game.discardFromPlay(cards, { allowSave: false });
             }
         });


### PR DESCRIPTION
Mad King's Command & Nothing Burns like the cold both have each player select all cards before moving on to the next player to select. Currently with how `AbilityTarget` is coded, each individual selection will be made, message the chat then move onto the next player. This repeats until all selections are made. 

Realistically, we need these cards to have each player select all cards required (eg. for MKC, select up to 3 characters, 3 attachments, 3 locations and 3 hand/shadow cards), THEN announce those cards in chat & move onto the next player.

I have achieved this by allowing for `SubTarget`'s within an ability target (we can rename this if we think its appropriate). If an ability target has SubTargets configured, it will ask the choosing player for each of those selections, save them & (if configured) message the chat before moving to the next player or continuing to the ability handler.

This should fix #3280