### PR TITLE
Fix interaction between Arianne and Ramsay Snow

### DIFF
--- a/server/game/GameActions/PutIntoPlay.js
+++ b/server/game/GameActions/PutIntoPlay.js
@@ -1,4 +1,5 @@
 const GameAction = require('./GameAction');
+const MoveCardEventGenerator = require('./MoveCardEventGenerator');
 
 class PutIntoPlay extends GameAction {
     constructor() {
@@ -10,11 +11,44 @@ class PutIntoPlay extends GameAction {
         return player.canPutIntoPlay(card);
     }
 
-    createEvent({ player, card, kneeled }) {
+    createEvent({ player, card, kneeled, playingType }) {
         player = player || card.controller;
-        return this.event('__PLACEHOLDER_EVENT__', { player, card }, event => {
-            event.player.putIntoPlay(event.card, 'play', { kneeled });
+
+        let dupeCard = player.getDuplicateInPlay(card);
+
+        if(card.getPrintedType() === 'attachment' && playingType !== 'setup' && !dupeCard) {
+            return this.event('__PLACEHOLDER_EVENT__', { player, card }, event => {
+                event.player.putIntoPlay(event.card, 'play', { kneeled });
+            });
+        }
+
+        const additionalEvents = [];
+        if(card.location === 'shadows') {
+            additionalEvents.push(this.event('onCardOutOfShadows', { player, card, type: dupeCard ? 'dupe' : 'card' }));
+        }
+
+        if(dupeCard && playingType !== 'setup') {
+            return this.atomic(
+                this.event('onDupeEntersPlay', { card, target: dupeCard }, event => {
+                    event.card.controller.removeCardFromPile(event.card);
+                    event.target.addDuplicate(event.card);
+                }),
+                ...additionalEvents
+            );
+        }
+
+        let entersPlayEvent = MoveCardEventGenerator.createEntersPlayEvent({
+            card,
+            isDupe: !!dupeCard,
+            kneeled,
+            player,
+            playingType
         });
+
+        return this.atomic(
+            entersPlayEvent,
+            ...additionalEvents
+        );
     }
 }
 

--- a/test/server/cards/01-Core/ArianneMartell.spec.js
+++ b/test/server/cards/01-Core/ArianneMartell.spec.js
@@ -1,0 +1,39 @@
+describe('Arianne Martell (Core)', function() {
+    integration(function() {
+        describe('vs Ramsay Snow', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('baratheon', [
+                    'A Noble Cause',
+                    'Arianne Martell (Core)', 'Ramsay Snow', 'Hedge Knight'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.arianne = this.player1.findCardByName('Arianne Martell', 'hand');
+                this.otherCharacter = this.player1.findCardByName('Hedge Knight', 'hand');
+                this.player1.clickCard(this.arianne);
+                this.player1.clickCard(this.otherCharacter);
+
+                this.completeSetup();
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+            });
+
+            describe('when Ramsay Snow is put into play using Arianne\'s ability', function() {
+                beforeEach(function() {
+                    this.player1.clickMenu('Arianne Martell', 'Put character into play');
+                    this.player1.clickCard('Ramsay Snow', 'hand');
+                });
+
+                it('does not allow Arianne to be sacrificed', function() {
+                    expect(this.player1).toAllowSelect(this.otherCharacter);
+                    expect(this.player1).not.toAllowSelect(this.arianne);
+                    expect(this.arianne.location).toEqual('hand');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
The `PutIntoPlay` game action now generates the onCardEntersPlay event
directly, rather than wrapping it in a placeholder event. By returning
it directly, the reaction for onCardEntersPlay when Ramsay Snow is put
into play by Arianne Martel now properly happens after Arianne has
returned to hand.

Fixes #3272 