### PR TITLE
White Sword Tower + discard events interaction

### DIFF
--- a/server/game/EventTrackers/EventPlayedTracker.js
+++ b/server/game/EventTrackers/EventPlayedTracker.js
@@ -14,7 +14,7 @@ class EventPlayedTracker {
     }
 
     trackEvent(event) {
-        if(event.source.getType() !== 'event' || this.events.includes(event)) {
+        if(event.source.getType() !== 'event' || this.events.includes(event) || !event.ability.isPlayableEventAbility()) {
             return;
         }
 

--- a/test/server/cards/13.1-AtG/WhiteSwordTower.spec.js
+++ b/test/server/cards/13.1-AtG/WhiteSwordTower.spec.js
@@ -73,5 +73,48 @@ describe('White Sword Tower', function() {
                 });
             });
         });
+
+        describe('vs discard pile event abilities', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'A Noble Cause',
+                    'White Sword Tower', 'Ser Jaime Lannister (LoCR)', 'Viserion (Core)', 'A Dragon Is No Slave', 'Nightmares'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.discardEvent = this.player2.findCardByName('A Dragon Is No Slave', 'hand');
+                this.event = this.player2.findCardByName('Nightmares', 'hand');
+
+                this.player1.clickCard('Ser Jaime Lannister', 'hand');
+                this.player1.clickCard('White Sword Tower', 'hand');
+
+                this.player2.clickCard('Viserion', 'hand');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player2);
+                this.completeMarshalPhase();
+
+                this.player2.dragCard(this.discardEvent, 'discard pile');
+            });
+
+            it('does not count the discard pile event ability as playing a card', function() {
+                let character = this.player2.findCardByName('Viserion', 'play area');
+                this.unopposedChallenge(this.player2, 'Power', character);
+
+                expect(this.player2).toAllowAbilityTrigger(this.discardEvent);
+
+                this.player2.triggerAbility(this.discardEvent);
+
+                // Play event
+                this.player2.clickCard('Nightmares', 'hand');
+                this.player2.clickCard(character);
+
+                expect(character.isAnyBlank()).toBe(true);
+            });
+        });
     });
 });


### PR DESCRIPTION
Event card abilities that are triggered from the discard pile do not count
as playing an event.

Fixes #3211 