### PR TITLE
Fix Baelor Blacktyde vs play from discard

### DIFF
--- a/server/game/cards/13.1-AtG/BaelorBlacktyde.js
+++ b/server/game/cards/13.1-AtG/BaelorBlacktyde.js
@@ -10,7 +10,7 @@ class BaelorBlacktyde extends DrawCard {
 
     hasCopyInDiscard(card) {
         let discardPile = card.controller.discardPile;
-        return discardPile.some(discardedCard => card.isCopyOf(discardedCard));
+        return discardPile.some(discardedCard => card !== discardedCard && card.isCopyOf(discardedCard));
     }
 }
 


### PR DESCRIPTION
If there's a single copy of an event in your discard pile, and you
have an ability that allows playing from the discard pile (e.g.
Annals of Castle Black), then you're allowed to play that card.

Fixes #3100 