### PR TITLE
Removing the forgotten reviewer text

### DIFF
--- a/server/game/gamesteps/GameWonPrompt.js
+++ b/server/game/gamesteps/GameWonPrompt.js
@@ -17,7 +17,6 @@ class GameWonPrompt extends AllPlayerPrompt {
             promptTitle: 'Game Won',
             menuTitle: this.winner === null ? 'Game ends in a draw' : this.winner.name + ' has won the game!',
             buttons: [
-                { arg: 'review', text: 'Open card review page (external page)' },
                 { arg: 'continue', text: 'Continue Playing' },
                 { arg: 'rematch', text: 'Rematch' }
             ]


### PR DESCRIPTION
This was simply missed in the PR from AHaH to Live; just removes the review button on game won.
![image](https://user-images.githubusercontent.com/23492047/213620995-18c115c8-c346-40ca-9f1b-ff9d66c0f3dd.png)
Will find a more permanent solution to this within playtesting so we don't have to keep adding/removing it.