### PR TITLE
Fixing search abilities not filtering valid attachment targets

### DIFF
--- a/server/game/GameActions/PutIntoPlay.js
+++ b/server/game/GameActions/PutIntoPlay.js
@@ -18,9 +18,11 @@ class PutIntoPlay extends GameAction {
         return Message.fragment(message, { card, controller: card.controller, originalLocation: card.location });
     }
 
-    canChangeGameState({ player, card }) {
+    canChangeGameState({ player, card, attachmentTargets }) {
         player = player || card.controller;
-        return card.location !== 'play area' && player.canPutIntoPlay(card);
+        attachmentTargets = attachmentTargets || (() => true);
+        return card.location !== 'play area' && player.canPutIntoPlay(card) 
+            && (card.getType() !== 'attachment' || player.game.anyCardsInPlay(c => player.canAttach(card, c) && attachmentTargets(c)));
     }
 
     createEvent({ player, card, kneeled, playingType, attachmentTargets }) {

--- a/server/game/GameActions/PutIntoPlay.js
+++ b/server/game/GameActions/PutIntoPlay.js
@@ -23,14 +23,14 @@ class PutIntoPlay extends GameAction {
         return card.location !== 'play area' && player.canPutIntoPlay(card);
     }
 
-    createEvent({ player, card, kneeled, playingType }) {
+    createEvent({ player, card, kneeled, playingType, attachmentTargets }) {
         player = player || card.controller;
 
         let dupeCard = player.getDuplicateInPlay(card);
 
         if(card.getPrintedType() === 'attachment' && playingType !== 'setup' && !dupeCard) {
             return this.event('__PLACEHOLDER_EVENT__', { player, card }, event => {
-                event.player.putIntoPlay(event.card, 'play', { kneeled });
+                event.player.putIntoPlay(event.card, 'play', { kneeled, attachmentTargets });
             });
         }
 

--- a/server/game/cards/11.6-DitD/GiftsForTheWidow.js
+++ b/server/game/cards/11.6-DitD/GiftsForTheWidow.js
@@ -12,7 +12,8 @@ class GiftsForTheWidow extends DrawCard {
                 reveal: false,
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
-                    card: context.searchTarget
+                    card: context.searchTarget,
+                    attachmentTargets: card => card.controller === context.player
                 }))
             })
         });

--- a/server/game/cards/11.6-DitD/GiftsForTheWidow.js
+++ b/server/game/cards/11.6-DitD/GiftsForTheWidow.js
@@ -8,7 +8,7 @@ class GiftsForTheWidow extends DrawCard {
             cost: ability.costs.payXGold(() => 0, () => 99),
             gameAction: GameActions.search({
                 title: 'Select an attachment',
-                match: { type: 'attachment', condition: (card, context) => card.hasPrintedCost() && card.getPrintedCost() <= context.xValue && this.canAttachToControlledCharacter(context.player, card) },
+                match: { type: 'attachment', condition: (card, context) => card.hasPrintedCost() && card.getPrintedCost() <= context.xValue },
                 reveal: false,
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
@@ -17,10 +17,6 @@ class GiftsForTheWidow extends DrawCard {
                 }))
             })
         });
-    }
-
-    canAttachToControlledCharacter(player, attachment) {
-        return player.anyCardsInPlay(card => card.getType() === 'character' && player.canAttach(attachment, card));
     }
 }
 

--- a/server/game/cards/13.2-CoS/BlackMarketMerchant.js
+++ b/server/game/cards/13.2-CoS/BlackMarketMerchant.js
@@ -11,7 +11,7 @@ class BlackMarketMerchant extends DrawCard {
             gameAction: GameActions.search({
                 title: 'Select an attachment',
                 topCards: 10,
-                match: { type: 'attachment', printedCostOrLower: 3, controller: 'current', condition: (card, context) => this.canAttachToControlledCharacter(context.player, card) },
+                match: { type: 'attachment', printedCostOrLower: 3, controller: 'current' },
                 reveal: false,
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
@@ -20,10 +20,6 @@ class BlackMarketMerchant extends DrawCard {
                 }))
             })
         });
-    }
-
-    canAttachToControlledCharacter(player, attachment) {
-        return player.anyCardsInPlay(card => card.getType() === 'character' && player.canAttach(attachment, card));
     }
 }
 

--- a/server/game/cards/13.2-CoS/BlackMarketMerchant.js
+++ b/server/game/cards/13.2-CoS/BlackMarketMerchant.js
@@ -11,11 +11,12 @@ class BlackMarketMerchant extends DrawCard {
             gameAction: GameActions.search({
                 title: 'Select an attachment',
                 topCards: 10,
-                match: { type: 'attachment', printedCostOrLower: 3, condition: (card, context) => this.canAttachToControlledCharacter(context.player, card) },
+                match: { type: 'attachment', printedCostOrLower: 3, controller: 'current', condition: (card, context) => this.canAttachToControlledCharacter(context.player, card) },
                 reveal: false,
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
-                    card: context.searchTarget
+                    card: context.searchTarget,
+                    attachmentTargets: card => card.controller === context.player
                 }))
             })
         });

--- a/server/game/cards/17.1-R/GiftsForTheWidow.js
+++ b/server/game/cards/17.1-R/GiftsForTheWidow.js
@@ -11,7 +11,7 @@ class GiftsForTheWidow extends DrawCard {
             ],
             gameAction: GameActions.search({
                 title: 'Select an attachment',
-                match: { type: 'attachment', condition: (card, context) => card.hasPrintedCost() && card.getPrintedCost() <= context.xValue && this.canAttachToControlledCharacter(context.player, card) },
+                match: { type: 'attachment', condition: (card, context) => card.hasPrintedCost() && card.getPrintedCost() <= context.xValue },
                 reveal: false,
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
@@ -20,10 +20,6 @@ class GiftsForTheWidow extends DrawCard {
                 }))
             })
         });
-    }
-
-    canAttachToControlledCharacter(player, attachment) {
-        return player.anyCardsInPlay(card => card.getType() === 'character' && player.canAttach(attachment, card));
     }
 }
 

--- a/server/game/cards/17.1-R/GiftsForTheWidow.js
+++ b/server/game/cards/17.1-R/GiftsForTheWidow.js
@@ -15,7 +15,8 @@ class GiftsForTheWidow extends DrawCard {
                 reveal: false,
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
-                    card: context.searchTarget
+                    card: context.searchTarget,
+                    attachmentTargets: card => card.controller === context.player
                 }))
             })
         });

--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -1,17 +1,18 @@
 const UiPrompt = require('./uiprompt.js');
 
 class AttachmentPrompt extends UiPrompt {
-    constructor(game, player, attachmentCard, playingType) {
+    constructor(game, player, attachmentCard, playingType, targets) {
         super(game);
         this.player = player;
         this.attachmentCard = attachmentCard;
         this.playingType = playingType;
+        this.targets = targets || (() => true);
     }
 
     continue() {
         this.game.promptForSelect(this.player, {
             activePromptTitle: 'Select target for attachment',
-            cardCondition: card => this.player.canAttach(this.attachmentCard, card) && this.setupRestriction(card),
+            cardCondition: card => this.player.canAttach(this.attachmentCard, card) && this.setupRestriction(card) && this.targets(card),
             onSelect: (player, card) => {
                 let targetPlayer = card.controller;
                 targetPlayer.attach(player, this.attachmentCard, card, this.playingType);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -549,6 +549,10 @@ class Player extends Spectator {
             return false;
         }
 
+        if(card.getPrintedType() === 'attachment' && options.attachmentTargets && !this.anyCardsInPlay(options.attachmentTargets)) {
+            return false;
+        }
+
         if(!options.isEffectExpiration && !this.canPlay(card, playingType)) {
             return false;
         }
@@ -598,7 +602,7 @@ class Player extends Spectator {
         var dupeCard = this.getDuplicateInPlay(card);
 
         if(card.getPrintedType() === 'attachment' && playingType !== 'setup' && !dupeCard) {
-            this.promptForAttachment(card, playingType);
+            this.promptForAttachment(card, playingType, options.attachmentTargets);
             return;
         }
 
@@ -842,9 +846,9 @@ class Player extends Spectator {
         }
     }
 
-    promptForAttachment(card, playingType) {
+    promptForAttachment(card, playingType, targets) {
         // TODO: Really want to move this out of here.
-        this.game.queueStep(new AttachmentPrompt(this.game, this, card, playingType));
+        this.game.queueStep(new AttachmentPrompt(this.game, this, card, playingType, targets));
     }
 
     resetChallengesPerformed() {


### PR DESCRIPTION
There is a bug for cards (namely "Black Markey Merchant" and "Gifts for the Widow") which allow the attachment to be put on any character, when the ability specified "character you control". These cards were updated as part of the search/reveal update within AHaH, and this must've been missed.

The resolution here is definitely not the cleanest, but it does the job quickly with what we currently have; I think we need to clean up `GameActions.putIntoPlay` in the future (eg. moving those methods out of `Player` and into GameActions), and this could be a part of that.