### PR TITLE
Fixing RemoveFromChallenge GameAction

### DIFF
--- a/server/game/GameActions/RemoveFromChallenge.js
+++ b/server/game/GameActions/RemoveFromChallenge.js
@@ -30,6 +30,8 @@ class RemoveFromChallenge extends GameAction {
     
             event.card.inChallenge = false;
     
+            event.challenge.challengeContributions.removeParticipants([event.card]);
+    
             event.challenge.calculateStrength();
         });
     }


### PR DESCRIPTION
A bug I noticed during playtesting actually, but is relevant here (primarily for `A Wall of Roses`); It seems that a character removed using the new `GameActions.RemoveFromChallenge` currently still "contributes their STR" to the challenge after removed. This fixes that. I must've simply missed this in AHaH development, whoops!

Also, updating submodule!