### PR TITLE
Fixing Ser Mark Mullendore with events

### DIFF
--- a/server/game/cards/11.4-MoD/SerMarkMullendore.js
+++ b/server/game/cards/11.4-MoD/SerMarkMullendore.js
@@ -14,17 +14,19 @@ class SerMarkMullendore extends DrawCard {
                 condition: context => context.event.revealed.length > 0,
                 gameAction: GameActions.may({
                     title: context => `Put ${context.event.revealed[0].name} into play?`,
-                    message: '{player} {gameAction}',
-                    gameAction: GameActions.simultaneously([
-                        GameActions.putIntoPlay(context => ({
-                            player: context.player,
-                            card: context.event.revealed[0]
-                        })),
-                        GameActions.returnCardToDeck(context => ({
+                    message: {
+                        format: '{player} puts {revealed} into play and returns {source} to the top of their deck',
+                        args: { revealed: context => context.event.revealed[0] }
+                    },
+                    gameAction: GameActions.putIntoPlay(context => ({
+                        player: context.player,
+                        card: context.event.revealed[0]
+                    })).then({
+                        gameAction: GameActions.returnCardToDeck(context => ({
                             allowSave: false,
                             card: context.source
                         }))
-                    ])
+                    })
                 })
             })
         });


### PR DESCRIPTION
Closes #3350 
Incorrect `GameAction` was initially used, primarily as `simultaneous` game action only requires one of any of those actions to change the game state to work. This was both giving the user the option to "put" an event into play, as well as actually "attempting" to put it into play, failing, but still putting Mark on top as it was simultaneous.

The fix was simply running the "put into play" game action first, **then** putting Mark on top (meaning if no card was put into play, Mark **doesn't** get put on top). Since this is all using game actions, the "can the revealed card enter play?" check is automatically made before giving the user the option to put it into play + put Mark on top.