### PR TITLE
Properly allowing The Tattered Prince to be saved + update to GameAction

### DIFF
--- a/server/game/cards/18-FH/TheTatteredPrince.js
+++ b/server/game/cards/18-FH/TheTatteredPrince.js
@@ -1,48 +1,34 @@
 const DrawCard = require('../../drawcard.js');
+const GameActions = require('../../GameActions/index.js');
 const {Tokens} = require('../../Constants');
 
 class TheTatteredPrince extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                onCardPlaced: event => event.location === 'revealed plots' &&
-                        event.player === this.controller
+                onCardPlaced: event => event.location === 'revealed plots' && event.player === this.controller
             },
-            handler: context => {
-                if(!this.hasToken(Tokens.gold)) {
-                    context.player.putIntoShadows(this, false);
-                    this.game.addMessage('{0} is forced by {1} to return {1} to shadows', this.controller, this);
-                    return;
+            gameAction: GameActions.ifCondition({
+                condition: context => context.source.hasToken(Tokens.gold),
+                thenAction: GameActions.choose({
+                    title: context => `Discard 1 gold for ${context.source.name}?`,
+                    choices: {
+                        'Yes': {
+                            message: '{player} chooses to discard a gold from {source}',
+                            gameAction: GameActions.discardToken(context => ({ card: context.source, token: Tokens.gold }))
+                        },
+                        'No': {
+                            message: '{player} chooses to return {source} to shadows',
+                            gameAction: GameActions.putIntoShadows(context => ({ card: context.source }))
+                        }
+                    }
+                }),
+                elseAction: {
+                    message: '{player} is forced to return {source} to shadows',
+                    gameAction: GameActions.putIntoShadows(context => ({ card: context.source }))
                 }
-
-                this.context = context;
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Discard a gold from ' + this.name + '?',
-                        buttons: [
-                            { text: 'Yes', method: 'discardGold' },
-                            { text: 'No', method: 'returnToShadows' }
-                        ]
-                    },
-                    source: this
-                });
-            }
+            })
         });
-    }
-
-    discardGold() {
-        this.modifyToken(Tokens.gold, -1);
-        this.game.addMessage('{0} is forced to discard a gold from {1}', this.controller, this);
-
-        return true;
-    }
-
-    returnToShadows() {
-        this.context.player.putIntoShadows(this, false);
-        this.game.addMessage('{0} uses {1} to return {1} to shadows', this.context.player, this);
-
-        return true;
     }
 }
 

--- a/server/game/gamesteps/AbilityChoicePrompt.js
+++ b/server/game/gamesteps/AbilityChoicePrompt.js
@@ -9,10 +9,11 @@ class AbilityChoicePrompt extends BaseStep {
         this.title = title;
         this.choices = choices;
         this.cancelText = cancelText || 'Done';
-        this.cancelMessage = AbilityMessage.create(cancelMessage || '{choosingPlayer} cancels the resolution of {source} (costs were still paid)', { choosingPlayer: context => context.choosingPlayer });
+        this.cancelMessage = AbilityMessage.create(cancelMessage || { format: '{choosingPlayer} cancels the resolution of {source} (costs were still paid)', type: 'danger' }, { choosingPlayer: context => context.choosingPlayer });
     }
 
     continue() {
+        this.context.choosingPlayer = this.choosingPlayer;
         let buttons = this.choices.map(choice => {
             if(choice.card) {
                 return { card: choice.card, mapCard: true, method: 'chooseAbilityChoice' };
@@ -34,7 +35,6 @@ class AbilityChoicePrompt extends BaseStep {
     chooseAbilityChoice(player, choiceArg) {
         let choice = this.choices.find(choice => choiceArg === choice.card || choiceArg === choice.text);
         if(choice) {
-            this.context.choosingPlayer = this.choosingPlayer;
             this.context.selectedChoice = choice;
             choice.message.output(this.game, this.context);
             this.game.resolveGameAction(choice.gameAction, this.context);


### PR DESCRIPTION
Closes #3351 
Simply allowing The Tattered Prince to be saved by a duplicate, as well as updating his code to GameActions.

Also includes a quick adjustment to the `AbilityChoicePrompt` to ensure that the default `cancelMessage` is presented as a 'danger' message, not a regular message.