### PR TITLE
Fixing non-declared defenders being knelt at defender declaration

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -21,6 +21,7 @@ class Challenge {
         this.declaredAttackers = [];
         this.attackerStrength = 0;
         this.defenders = [];
+        this.declaredDefenders = [];
         this.defenderStrength = 0;
         this.challengeContributions = new ChallengeContributions();
         this.stealthData = [];
@@ -62,6 +63,11 @@ class Challenge {
 
     addAttacker(attacker) {
         this.addAttackers([attacker]);
+    }
+    
+    declareDefenders(defenders) {
+        this.addDefenders(defenders);
+        this.declaredDefenders = this.declaredDefenders.concat(defenders);
     }
 
     addDefenders(defenders) {

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -96,6 +96,7 @@ class Challenge {
         this.attackers = this.attackers.filter(c => c !== card);
         this.declaredAttackers = this.declaredAttackers.filter(c => c !== card);
         this.defenders = this.defenders.filter(c => c !== card);
+        this.declaredDefenders = this.declaredDefenders.filter(c => c !== card);
 
         card.inChallenge = false;
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -143,7 +143,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     illegallyPromptForDefenders() {
-        this.game.addAlert('danger', '{0} does not control enough elibile characters to legally initiate this challenge, but has chosen to continue with declaring defenders anyway', this.challenge.attackingPlayer);
+        this.game.addAlert('danger', '{0} does not control enough eligible characters to legally initiate this challenge, but has chosen to continue with declaring defenders anyway', this.challenge.attackingPlayer);
         this.game.queueStep(this.defenderPrompt);
         return true;
     }
@@ -157,7 +157,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     chooseDefenders(defenders) {
-        this.challenge.addDefenders(defenders);
+        this.challenge.declareDefenders(defenders);
 
         if(this.challenge.declareDefendersFirst) {
             if(defenders.length > 0) {
@@ -175,7 +175,7 @@ class ChallengeFlow extends BaseStep {
             return;
         }
 
-        this.game.resolveGameAction(DeclareDefenders, { cards: this.challenge.defenders, challenge: this.challenge });
+        this.game.resolveGameAction(DeclareDefenders, { cards: this.challenge.declaredDefenders, challenge: this.challenge });
     }
 
     announceDefenderStrength() {


### PR DESCRIPTION
This fix addresses a bug related to the defending player using participation effects (such as My Mind is My Weapon) **before** declaring defenders, and then that character incorrectly being knelt at the defender declaration step.

What should be happening is that *only* declared defenders should be knelt at this stage, and not "currently defending" characters. This fix corrects that by adding a `declaredDefenders` array to challenge, and referencing that instead to decide who to kneel.