### PR TITLE
Ensure game owner joins rematch games

### DIFF
--- a/server/lobby.js
+++ b/server/lobby.js
@@ -762,6 +762,7 @@ class Lobby {
         this.broadcastGameMessage('removegame', game);
 
         let newGame = new PendingGame(game.owner, {
+            name: game.name,
             event: game.event,
             restrictedList: game.restrictedList,
             spectators: game.allowSpectators,
@@ -788,7 +789,7 @@ class Lobby {
         }
 
         this.games[newGame.id] = newGame;
-        newGame.newGame(socket.id, socket.user);
+        newGame.newGame(socket.id, socket.user, null, true);
 
         socket.joinChannel(newGame.id);
         this.sendGameState(newGame);


### PR DESCRIPTION
When we implemented game links last year, we added a "join" flag to the newGame method. This wasn't being passed during rematch games, so the owner of the game was no longer joining the rematch.

Also adds the game name to the rematch game, so we don't get games list in the lobby as "undefined".

Fixes #3360 