### PR TITLE
Fixes to properly check initiated challenge type

### DIFF
--- a/server/game/cards/05-LoCR/OldWyk.js
+++ b/server/game/cards/05-LoCR/OldWyk.js
@@ -6,7 +6,7 @@ class OldWyk extends DrawCard {
         this.reaction({
             when: {
                 onChallengeInitiated: event => event.challenge.attackingPlayer === this.controller &&
-                                               event.challenge.challengeType === 'power' &&
+                                               event.challenge.initiatedChallengeType === 'power' &&
                                                this.anyDrownedGodInDeadPile()
             },
             cost: ability.costs.kneelSelf(),

--- a/server/game/cards/08.1-TAK/DreadfortMaester.js
+++ b/server/game/cards/08.1-TAK/DreadfortMaester.js
@@ -4,7 +4,7 @@ class DreadfortMaester extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onChallengeInitiated: event => event.challenge.attackingPlayer === this.controller && ['military', 'intrigue'].includes(event.challenge.challengeType)
+                onChallengeInitiated: event => event.challenge.attackingPlayer === this.controller && ['military', 'intrigue'].includes(event.challenge.initiatedChallengeType)
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {

--- a/server/game/cards/11.6-DitD/TheBastardsLetter.js
+++ b/server/game/cards/11.6-DitD/TheBastardsLetter.js
@@ -4,7 +4,7 @@ class TheBastardsLetter extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onChallengeInitiated: event => event.challenge.isMatch({ initiatedAgainstPlayer: this.controller, challengeType: 'military' })
+                onChallengeInitiated: event => event.challenge.isMatch({ initiatedAgainstPlayer: this.controller, initiatedChallengeType: 'military' })
             },
             target: {
                 type: 'select',

--- a/server/game/cards/14-FotS/LynCorbray.js
+++ b/server/game/cards/14-FotS/LynCorbray.js
@@ -5,7 +5,7 @@ class LynCorbray extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onChallengeInitiated: event => event.challenge.isMatch({ initiatedAgainstPlayer: this.controller, challengeType: 'power' }) && this.allowGameAction('stand')
+                onChallengeInitiated: event => event.challenge.isMatch({ initiatedAgainstPlayer: this.controller, initiatedChallengeType: 'power' }) && this.allowGameAction('stand')
             },
             message: '{player} uses {source} to stand {source}',
             handler: context => {


### PR DESCRIPTION
Certain cards were still incorrectly referencing current challenge type, rather than initiated challenge type, during the **onChallengeInitiated** check ~ therefore they would incorrectly react to when Storms End (BtB) would change challenge type.

Applying fixes to the following cards:
- Old Wyk
- Dreadfort Maester
- The Bastards Letter
- Lyn Corbray
