### PR TITLE
Implement player elimination + simultaneous win/loss for Melee

### DIFF
--- a/server/game/GameActions/ChooseGameAction.js
+++ b/server/game/GameActions/ChooseGameAction.js
@@ -37,7 +37,7 @@ class ChooseGameAction extends GameAction {
     }
 
     createEvent(context) {
-        return this.event('onChoose', {}, () => {
+        return this.event('onChoose', {}, event => {
             const choosingPlayer = this.playerFunc(context);
             let tempContext = { ...context, choosingPlayer };
             const title = this.title instanceof Function ? this.title(tempContext) : this.title;
@@ -45,7 +45,18 @@ class ChooseGameAction extends GameAction {
             const cancelText = this.cancelText instanceof Function ? this.cancelText(tempContext) : this.cancelText;
             const cancelMessage = this.cancelMessage instanceof Function ? this.cancelMessage(tempContext) : this.cancelMessage;
 
-            context.game.queueStep(new AbilityChoicePrompt({ game: context.game, context, choosingPlayer, title, choices, cancelText, cancelMessage }));
+            context.game.queueStep(new AbilityChoicePrompt({
+                game: context.game,
+                context,
+                choosingPlayer,
+                title,
+                choices,
+                cancelText,
+                cancelMessage,
+                gameActionResolver: gameAction => {
+                    event.thenAttachEvent(gameAction.createEvent(context));
+                }
+            }));
         });
     }
 

--- a/server/game/GameActions/DiscardPower.js
+++ b/server/game/GameActions/DiscardPower.js
@@ -14,7 +14,6 @@ class DiscardPower extends GameAction {
 
         return this.event('onCardPowerDiscarded', { card, power: finalAmount }, event => {
             event.card.power -= event.power;
-            event.card.game.checkWinCondition(event.card.controller);
         });
     }
 }

--- a/server/game/GameActions/GainPower.js
+++ b/server/game/GameActions/GainPower.js
@@ -21,7 +21,6 @@ class GainPower extends GameAction {
     createEvent({ card, amount = 1 }) {
         return this.event('onCardPowerGained', { card, power: amount }, event => {
             event.card.power += event.power;
-            event.card.game.checkWinCondition(event.card.controller);
         });
     }
 }

--- a/server/game/GameActions/MovePower.js
+++ b/server/game/GameActions/MovePower.js
@@ -23,8 +23,6 @@ class MovePower extends GameAction {
         return this.event('onCardPowerMoved', { source: from, target: to, power: appliedPower }, event => {
             event.source.power -= appliedPower;
             event.target.power += appliedPower;
-
-            event.target.game.checkWinCondition(event.target.controller);
         });
     }
 }

--- a/server/game/Message.js
+++ b/server/game/Message.js
@@ -48,7 +48,7 @@ class Message {
             }
             return { code: arg.code, label: arg.name, type: arg.getType(), argType: 'card' };
         } else if(arg instanceof Spectator) {
-            return { name: arg.user.username, argType: 'nonAvatarPlayer' };
+            return { name: arg.name, argType: 'nonAvatarPlayer' };
         } else if(arg instanceof Message) {
             return arg.flatten();
         }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -858,9 +858,8 @@ const Effects = {
             apply: function(player) {
                 player.cannotWinGame = true;
             },
-            unapply: function(player, context) {
+            unapply: function(player) {
                 player.cannotWinGame = false;
-                context.game.checkWinCondition(player);
             }
         };
     },

--- a/server/game/gamesteps/AbilityChoicePrompt.js
+++ b/server/game/gamesteps/AbilityChoicePrompt.js
@@ -2,7 +2,7 @@ const AbilityMessage = require('../AbilityMessage');
 const BaseStep = require('./basestep');
 
 class AbilityChoicePrompt extends BaseStep {
-    constructor({ game, context, choosingPlayer, title, choices, cancelText, cancelMessage }) {
+    constructor({ game, context, choosingPlayer, title, choices, cancelText, cancelMessage, gameActionResolver }) {
         super(game);
         this.context = context;
         this.choosingPlayer = choosingPlayer || this.context.choosingPlayer;
@@ -10,6 +10,7 @@ class AbilityChoicePrompt extends BaseStep {
         this.choices = choices;
         this.cancelText = cancelText || 'Done';
         this.cancelMessage = AbilityMessage.create(cancelMessage || { format: '{choosingPlayer} cancels the resolution of {source} (costs were still paid)', type: 'danger' }, { choosingPlayer: context => context.choosingPlayer });
+        this.gameActionResolver = gameActionResolver || ((gameAction, context) => game.resolveGameAction(gameAction, context));
     }
 
     continue() {
@@ -37,7 +38,7 @@ class AbilityChoicePrompt extends BaseStep {
         if(choice) {
             this.context.selectedChoice = choice;
             choice.message.output(this.game, this.context);
-            this.game.resolveGameAction(choice.gameAction, this.context);
+            this.gameActionResolver(choice.gameAction, this.context);
         }
 
         return true;

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -85,7 +85,6 @@ class KeywordWindow extends BaseStep {
                     let finalParticipants = selectedCards.map(card => participantsWithKeyword.find(participant => participant.card === card));
 
                     this.resolveAbility(ability, finalParticipants);
-                    this.game.checkWinCondition(this.challenge.winner);
 
                     return true;
                 }
@@ -96,8 +95,6 @@ class KeywordWindow extends BaseStep {
             } else {
                 this.resolveAbility(ability, participantsWithKeyword);
             }
-
-            this.game.checkWinCondition(this.challenge.winner);
         }
     }
 

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -8,7 +8,7 @@ const GameFlowWrapper = require('./gameflowwrapper.js');
 
 const ProxiedGameFlowWrapperMethods = [
     'startGame', 'keepStartingHands', 'skipSetupPhase', 'selectFirstPlayer',
-    'completeMarshalPhase', 'completeChallengesPhase', 'completeDominancePhase',
+    'completeMarshalPhase', 'completeChallengesPhase', 'completeDominancePhase', 'completeTaxationPhase',
     'selectPlotOrder', 'completeSetup',
     'skipActionWindow', 'unopposedChallenge'
 ];

--- a/test/server/GameActions/DiscardPower.spec.js
+++ b/test/server/GameActions/DiscardPower.spec.js
@@ -2,7 +2,7 @@ const DiscardPower = require('../../../server/game/GameActions/DiscardPower');
 
 describe('DiscardPower', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['checkWinCondition']);
+        this.gameSpy = jasmine.createSpyObj('game', ['']);
         this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction']);
         this.cardSpy.controller = 'PLAYER_OBJ';
         this.cardSpy.game = this.gameSpy;
@@ -72,10 +72,6 @@ describe('DiscardPower', function() {
                 it('removes power from the card', function() {
                     expect(this.cardSpy.power).toBe(1);
                 });
-
-                it('checks the game for win condition', function() {
-                    expect(this.gameSpy.checkWinCondition).toHaveBeenCalledWith('PLAYER_OBJ');
-                });
             });
         });
 
@@ -99,10 +95,6 @@ describe('DiscardPower', function() {
 
                 it('removes power from the card', function() {
                     expect(this.cardSpy.power).toBe(0);
-                });
-
-                it('checks the game for win condition', function() {
-                    expect(this.gameSpy.checkWinCondition).toHaveBeenCalledWith('PLAYER_OBJ');
                 });
             });
         });

--- a/test/server/GameActions/GainPower.spec.js
+++ b/test/server/GameActions/GainPower.spec.js
@@ -2,7 +2,7 @@ const GainPower = require('../../../server/game/GameActions/GainPower');
 
 describe('GainPower', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['checkWinCondition']);
+        this.gameSpy = jasmine.createSpyObj('game', ['']);
         this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction']);
         this.cardSpy.controller = 'PLAYER_OBJ';
         this.cardSpy.game = this.gameSpy;
@@ -56,10 +56,6 @@ describe('GainPower', function() {
 
             it('adds power to the card', function() {
                 expect(this.cardSpy.power).toBe(3);
-            });
-
-            it('checks the game for win condition', function() {
-                expect(this.gameSpy.checkWinCondition).toHaveBeenCalledWith('PLAYER_OBJ');
             });
         });
     });

--- a/test/server/GameActions/MovePower.spec.js
+++ b/test/server/GameActions/MovePower.spec.js
@@ -2,7 +2,7 @@ const MovePower = require('../../../server/game/GameActions/MovePower');
 
 describe('MovePower', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['checkWinCondition']);
+        this.gameSpy = jasmine.createSpyObj('game', ['']);
         this.fromCardSpy = jasmine.createSpyObj('from', ['allowGameAction']);
         this.fromCardSpy.controller = 'FROM_PLAYER_OBJ';
         this.fromCardSpy.game = this.gameSpy;
@@ -97,10 +97,6 @@ describe('MovePower', function() {
 
             it('adds the amount of power removed to the to card', function() {
                 expect(this.toCardSpy.power).toBe(1);
-            });
-
-            it('checks the game for win condition', function() {
-                expect(this.gameSpy.checkWinCondition).toHaveBeenCalledWith('TO_PLAYER_OBJ');
             });
         });
     });

--- a/test/server/GameActions/PlaceToken.spec.js
+++ b/test/server/GameActions/PlaceToken.spec.js
@@ -2,7 +2,7 @@ const PlaceToken = require('../../../server/game/GameActions/PlaceToken');
 
 describe('PlaceToken', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['checkWinCondition']);
+        this.gameSpy = jasmine.createSpyObj('game', ['']);
         this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction', 'modifyToken']);
         this.cardSpy.location = 'play area';
         this.props = { card: this.cardSpy, token: 'TOKEN_TYPE', amount: 2 };

--- a/test/server/integration/WinningAndLosing.spec.js
+++ b/test/server/integration/WinningAndLosing.spec.js
@@ -139,5 +139,72 @@ describe('Winning and losing', function() {
                 });
             });
         });
+
+        describe('winning the game', function() {
+            describe('when a single player reaches 15 power', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', ['A Noble Cause', 'A Game of Thrones', { name: 'Hedge Knight', count: 60 }]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.player3.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.completeSetup();
+
+                    // Set player 1 to 14 power and select plot that will give them gold to win dominance
+                    this.player1Object.faction.power = 14;
+                    this.player1.selectPlot('A Noble Cause');
+                    this.player2.selectPlot('A Game of Thrones');
+                    this.player3.selectPlot('A Game of Thrones');
+
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.selectTitle('Master of Ships');
+                    this.player2.selectTitle('Master of Whispers');
+                    this.player3.selectTitle('Master of Laws');
+
+                    this.completeMarshalPhase();
+                    this.completeChallengesPhase();
+                });
+
+                it('wins the game for that player', function() {
+                    expect(this.game.winner).toBe(this.player1Object);
+                });
+            });
+
+            describe('when a multiple players reach 15 power simultaneously', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', ['Valar Morghulis', 'A Noble Cause', { name: 'Jon Arryn', count: 60 }]);
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.player3.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.player1.clickCard('Jon Arryn', 'hand');
+                    this.completeSetup();
+
+                    this.player1Object.faction.power = 14;
+                    this.player3Object.faction.power = 14;
+                    this.player1.selectPlot('Valar Morghulis');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.player3.selectPlot('A Noble Cause');
+
+                    this.selectFirstPlayer(this.player2);
+
+                    this.player2.clickPrompt('Draw 2 cards');
+                    this.player3.clickPrompt('Gain 1 power');
+                    this.player1.clickPrompt('Gain 1 power');
+                });
+
+                it('wins the game for that player', function() {
+                    expect(this.player2).toHavePrompt('Select the winning player');
+                    this.player2.clickPrompt('player3');
+
+                    expect(this.game.winner).toBe(this.player3Object);
+                });
+            });
+        });
     });
 });

--- a/test/server/integration/WinningAndLosing.spec.js
+++ b/test/server/integration/WinningAndLosing.spec.js
@@ -1,0 +1,143 @@
+describe('Winning and losing', function() {
+    integration({ isMelee: true }, function() {
+        beforeEach(function() {
+            // Enable losing / winning prompts
+            this.game.disableWonPrompt = false;
+        });
+
+        describe('losing the game', function() {
+            describe('when a player draws their last card', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', ['A Noble Cause', { name: 'Hedge Knight', count: 60 }]);
+                    const losingDeck = this.buildDeck('stark', ['A Noble Cause', { name: 'Hedge Knight', count: 9 }]);
+
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(deck);
+                    this.player3.selectDeck(losingDeck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.completeSetup();
+
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.selectTitle('Master of Ships');
+                    this.player2.selectTitle('Master of Coin');
+                    this.player3.selectTitle('Master of Laws');
+                });
+
+                it('eliminates the player', function() {
+                    expect(this.player3Object.eliminated).toBe(true);
+                });
+
+                it('does not prompt eliminated players further', function() {
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickPrompt('Done');
+
+                    expect(this.player3).not.toHavePrompt('Marshal your cards');
+                    // Player 1's turn on the challenges phase
+                    expect(this.player1).toHavePromptButton('Military');
+                });
+            });
+
+            describe('when the first player draws their last card', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', ['A Noble Cause', { name: 'Hedge Knight', count: 60 }]);
+                    const losingDeck = this.buildDeck('stark', ['A Noble Cause', { name: 'Hedge Knight', count: 9 }]);
+
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(losingDeck);
+                    this.player3.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.completeSetup();
+
+                    this.selectFirstPlayer(this.player2);
+
+                    this.player2.selectTitle('Master of Coin');
+                    this.player3.selectTitle('Master of Laws');
+                    this.player1.selectTitle('Master of Ships');
+                });
+
+                it('the next clockwise player becomes first player', function() {
+                    expect(this.player2Object.firstPlayer).toBe(false);
+                    expect(this.player3Object.firstPlayer).toBe(true);
+                    expect(this.game.getFirstPlayer()).toBe(this.player3Object);
+                });
+            });
+
+            describe('when all but one player draws their last card', function() {
+                beforeEach(function() {
+                    const deck = this.buildDeck('stark', ['A Noble Cause', { name: 'Hedge Knight', count: 60 }]);
+                    const losingDeck = this.buildDeck('stark', ['A Noble Cause', { name: 'Hedge Knight', count: 9 }]);
+
+                    this.player1.selectDeck(losingDeck);
+                    this.player2.selectDeck(deck);
+                    this.player3.selectDeck(losingDeck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.completeSetup();
+
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.selectTitle('Master of Ships');
+                    this.player2.selectTitle('Master of Coin');
+                    this.player3.selectTitle('Master of Laws');
+                });
+
+                it('the remaining player wins the game', function() {
+                    expect(this.game.winner).toBe(this.player2Object);
+                });
+            });
+
+            describe('when all players draw their last card', function() {
+                beforeEach(function() {
+                    const losingDeck = this.buildDeck('stark', ['A Noble Cause', 'A Noble Cause', 'A Noble Cause', { name: 'Hedge Knight', count: 9 }]);
+                    const deck = this.buildDeck('stark', ['A Noble Cause', 'A Noble Cause', 'A Noble Cause', { name: 'Hedge Knight', count: 11 }]);
+
+                    this.player1.selectDeck(deck);
+                    this.player2.selectDeck(losingDeck);
+                    this.player3.selectDeck(deck);
+                    this.startGame();
+                    this.keepStartingHands();
+
+                    this.completeSetup();
+
+                    this.player1.selectPlot('A Noble Cause');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.player3.selectPlot('A Noble Cause');
+
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.selectTitle('Master of Ships');
+                    this.player2.selectTitle('Master of Coin');
+                    this.player3.selectTitle('Master of Laws');
+
+                    // Player 2 is eliminated early
+                    expect(this.player2Object.eliminated).toBe(true);
+
+                    this.completeMarshalPhase();
+                    this.completeChallengesPhase();
+                    this.completeTaxationPhase();
+
+                    this.player1.selectPlot('A Noble Cause');
+                    this.player3.selectPlot('A Noble Cause');
+
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.selectTitle('Master of Ships');
+                    this.player3.selectTitle('Master of Laws');
+                });
+
+                it('has the first player choose the winner', function() {
+                    expect(this.player1).toHavePrompt('Select the winning player');
+                    this.player1.clickPrompt('player3');
+
+                    expect(this.game.winner).toBe(this.player3Object);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Ensures eliminated players aren't prompted
* First player chooses winner when multiple players would win simultaneously, or all remaining players would be eliminated simultaneously
* Fixes simultaneous resolution of choose game action (used in Jon Arryn, the best way to test simul-win)

Progress towards #1237 