### PR TITLE
fix SerDavenLannister reaction triggering when opponent has no cards …

### DIFF
--- a/server/game/cards/24-TSoW/SerDavenLannister.js
+++ b/server/game/cards/24-TSoW/SerDavenLannister.js
@@ -5,7 +5,10 @@ class SerDavenLannister extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardPowerGained: event => event.card === this
+                onCardPowerGained: (event, context) => event.card === this
+                    // TODO strictly speaking this check should not be done in the 'when' condition, but when checking targets
+                    // SEE ALSO GreatWyk (12017), which have the same triggering restriction (not implemented yet)
+                    && context.game.getOpponents(context.player).every(opponent => opponent.hand.length > 0)
             },
             message: '{player} uses {source} to have each opponent choose and discard 1 card from their hand',
             limit: ability.limit.perRound(2),


### PR DESCRIPTION
Ser Daven Lannister reaction can be triggered only if each opponent has at least one card in hand, due to the "choose" restriction.
Ideally, the check should be done when checking legality of targets. In this case, the number of targets is equal to the number of opponents and each opponent must choose exactly one target.