### PR TITLE
fix OneTwoThree giving insight to all eligible targets instead to the…

### DIFF
--- a/server/game/cards/24-TSoW/OneTwoThree.js
+++ b/server/game/cards/24-TSoW/OneTwoThree.js
@@ -26,7 +26,7 @@ class OneTwoThree extends DrawCard {
                     message: '{player} plays {source} to have {target} gain insight until the end of the phase',
                     gameAction: GameActions.genericHandler(context => {
                         this.untilEndOfPhase(ability => ({
-                            match: context.targets.insight,
+                            match: context.target,
                             effect: ability.effects.addKeyword('insight')
                         }));
                     })


### PR DESCRIPTION
Steps to reproduce: declare an INT challenge with N characters (N > 1), win the challenge and use One, Two, Three on one of the participating character. N cards will be drawn for Insight.
The implementation of "Protectors of The Realm" (00002), which have a similar effect, declares only context.target as "match", instead of One, Two, Three which declares context.targets.insight, matching all eligible targets.