### PR TITLE
fix WardensOfTheEast weird interactions with card moving in and out f…

### DIFF
--- a/server/game/cards/23-AHaH/Sweetrobin.js
+++ b/server/game/cards/23-AHaH/Sweetrobin.js
@@ -5,7 +5,7 @@ class Sweetrobin extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCardRevealed: event => (!event.card.hasPrintedCost() || (event.card.hasPrintedCost() && event.card.getPrintedCost() <= event.card.owner.getTotalInitiative())) && ['hand', 'draw deck', 'shadows'].includes(event.card.location)
+                onCardRevealed: event => event.card.hasPrintedCost() && event.card.getPrintedCost() <= event.card.owner.getTotalInitiative() && ['hand', 'draw deck', 'shadows'].includes(event.card.location)
             },
             limit: ability.limit.perPhase(1),
             message: {

--- a/server/game/cards/23-AHaH/Sweetrobin.js
+++ b/server/game/cards/23-AHaH/Sweetrobin.js
@@ -5,7 +5,7 @@ class Sweetrobin extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCardRevealed: event => event.card.hasPrintedCost() && event.card.getPrintedCost() <= event.card.owner.getTotalInitiative() && ['hand', 'draw deck', 'shadows'].includes(event.card.location)
+                onCardRevealed: event => (!event.card.hasPrintedCost() || (event.card.hasPrintedCost() && event.card.getPrintedCost() <= event.card.owner.getTotalInitiative())) && ['hand', 'draw deck', 'shadows'].includes(event.card.location)
             },
             limit: ability.limit.perPhase(1),
             message: {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1452,7 +1452,7 @@ const Effects = {
             targetType: 'player',
             apply: function(player, context) {
                 const shadows = player.shadows;
-                const revealFunc = reveal => shadows.includes(reveal);
+                const revealFunc = reveal => player.shadows.includes(reveal);
 
                 context.revealShadows = context.revealShadows || {};
                 context.revealShadows[player.name] = {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1451,18 +1451,17 @@ const Effects = {
         return {
             targetType: 'player',
             apply: function(player, context) {
-                const shadows = player.shadows;
                 const revealFunc = reveal => player.shadows.includes(reveal);
 
                 context.revealShadows = context.revealShadows || {};
                 context.revealShadows[player.name] = {
                     revealFunc,
-                    revealed: shadows
+                    controller: player
                 };
                 context.game.cardVisibility.addRule(revealFunc);
 
                 context.game.resolveGameAction(GameActions.revealCards({
-                    cards: shadows,
+                    cards: player.shadows,
                     player,
                     revealWithMessage: false,
                     highlight: false,
@@ -1470,10 +1469,7 @@ const Effects = {
                 }), context);
             },
             reapply: function(player, context) {
-                const shadows = player.shadows;
-                const newReveals = shadows.filter(card => !context.revealShadows[player.name].revealed.includes(card));
-
-                context.revealShadows[player.name].revealed = shadows;
+                const newReveals = player.shadows.filter(card => !context.revealShadows[player.name].controller.shadows.includes(card));
 
                 // Only trigger reveal event for newly revealed cards
                 if(newReveals.length > 0) {

--- a/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
+++ b/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
@@ -48,7 +48,6 @@ describe('Wardens of the East', function () {
                 });
 
                 it('card should be revealed again', function () {
-                    debugger;
                     expect(this.aVeryLargeShadow1.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(true);
                 });
 

--- a/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
+++ b/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
@@ -22,7 +22,6 @@ describe('Wardens of the East', function () {
             [this.sweetRobin] = this.player2.filterCardsByName('Sweetrobin', 'hand');
 
             this.player1.player.gold = 10;
-            this.player2.player.gold = 10;
 
             this.player1.clickCard(this.aVeryLargeShadow11);
             this.player1.clickCard(this.aVeryLargeShadow12);
@@ -74,7 +73,6 @@ describe('Wardens of the East', function () {
                         })
 
                         it('card should be removed from play', function () {
-                            debugger;
                             expect(this.aVeryLargeShadow13.location).toBe('out of game');
                         });
                     });

--- a/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
+++ b/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
@@ -7,7 +7,7 @@ describe('Wardens of the East', function () {
             ]);
             const deck2 = this.buildDeck('baratheon', [
                 'Expose Duplicity',
-                'A Very Large Shadow', 'A Very Large Shadow', 'A Very Large Shadow'
+                'A Very Large Shadow', 'A Very Large Shadow', 'Sweetrobin'
             ]);
 
             this.player1.selectDeck(deck1);
@@ -17,47 +17,66 @@ describe('Wardens of the East', function () {
 
             this.selectFirstPlayer(this.player1);
 
-            [this.aVeryLargeShadow1, this.aVeryLargeShadow2, this.aVeryLargeShadow3] = this.player1.filterCardsByName('A Very Large Shadow', 'hand');
+            [this.aVeryLargeShadow11, this.aVeryLargeShadow12, this.aVeryLargeShadow13] = this.player1.filterCardsByName('A Very Large Shadow', 'hand');
+            [this.aVeryLargeShadow21, this.aVeryLargeShadow22] = this.player2.filterCardsByName('A Very Large Shadow', 'hand');
+            [this.sweetRobin] = this.player2.filterCardsByName('Sweetrobin', 'hand');
 
             this.player1.player.gold = 10;
+            this.player2.player.gold = 10;
 
-            this.player1.clickCard(this.aVeryLargeShadow1);
-            this.player1.clickCard(this.aVeryLargeShadow2);
+            this.player1.clickCard(this.aVeryLargeShadow11);
+            this.player1.clickCard(this.aVeryLargeShadow12);
         });
 
         it('should reveal first card marshalled into shadows', function () {
-            expect(this.aVeryLargeShadow1.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(true);
+            expect(this.aVeryLargeShadow11.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow11, this.player2)).toBe(true);
         });
 
         it('should reveal cards marshalled into shadows after the first', function () {
-            expect(this.aVeryLargeShadow2.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow2, this.player2)).toBe(true);
+            expect(this.aVeryLargeShadow12.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow12, this.player2)).toBe(true);
         });
 
         describe('when card leaves shadows area', function () {
             beforeEach(function () {
-                this.player1.clickCard(this.aVeryLargeShadow1);
+                this.player1.clickCard(this.aVeryLargeShadow11);
             });
 
             it('should hide card going from shadows into hand', function () {
-                expect(this.aVeryLargeShadow1.location === 'hand' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(false);
+                expect(this.aVeryLargeShadow11.location === 'hand' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow11, this.player2)).toBe(false);
             });
 
             describe('when card from hand goes back to shadow', function () {
                 beforeEach(function () {
-                    this.player1.clickCard(this.aVeryLargeShadow1);
+                    this.player1.clickCard(this.aVeryLargeShadow11);
                 });
 
                 it('card should be revealed again', function () {
-                    expect(this.aVeryLargeShadow1.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(true);
+                    expect(this.aVeryLargeShadow11.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow11, this.player2)).toBe(true);
                 });
 
                 describe('when another card is marshalled into shadows', function () {
                     beforeEach(function () {
-                        this.player1.clickCard(this.aVeryLargeShadow3);
+                        this.player2.dragCard(this.sweetRobin, 'play area');
+                        this.player1.clickCard(this.aVeryLargeShadow13);
                     });
 
                     it('card should be revealed', function () {
-                        expect(this.aVeryLargeShadow3.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow3, this.player2)).toBe(true);
+                        expect(this.aVeryLargeShadow13.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow13, this.player2)).toBe(true);
+                    });
+
+                    it('should correctly satisfy reaction condition of sweetrobin', function () {
+                        expect(this.player2.currentPrompt().menuTitle).toBe('Any interrupts?');
+                    });
+
+                    describe('when sweetrobin interrupt is triggered', function () {
+                        beforeEach(function () {
+                            this.player2.clickCard(this.sweetRobin);
+                        })
+
+                        it('card should be removed from play', function () {
+                            debugger;
+                            expect(this.aVeryLargeShadow13.location).toBe('out of game');
+                        });
                     });
                 });
             });

--- a/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
+++ b/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
@@ -1,0 +1,67 @@
+describe('Wardens of the East', function () {
+    integration(function () {
+        beforeEach(function () {
+            const deck1 = this.buildDeck('baratheon', [
+                'Wardens of the East',
+                'A Very Large Shadow', 'A Very Large Shadow', 'A Very Large Shadow'
+            ]);
+            const deck2 = this.buildDeck('baratheon', [
+                'Expose Duplicity',
+                'A Very Large Shadow', 'A Very Large Shadow', 'A Very Large Shadow'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.skipSetupPhase();
+
+            this.selectFirstPlayer(this.player1);
+
+            [this.aVeryLargeShadow1, this.aVeryLargeShadow2, this.aVeryLargeShadow3] = this.player1.filterCardsByName('A Very Large Shadow', 'hand');
+
+            this.player1.player.gold = 10;
+
+            this.player1.clickCard(this.aVeryLargeShadow1);
+            this.player1.clickCard(this.aVeryLargeShadow2);
+        });
+
+        it('should reveal first card marshalled into shadows', function () {
+            expect(this.aVeryLargeShadow1.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(true);
+        });
+
+        it('should reveal cards marshalled into shadows after the first', function () {
+            expect(this.aVeryLargeShadow2.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow2, this.player2)).toBe(true);
+        });
+
+        describe('when card leaves shadows area', function () {
+            beforeEach(function () {
+                this.player1.clickCard(this.aVeryLargeShadow1);
+            });
+
+            it('should hide card going from shadows into hand', function () {
+                expect(this.aVeryLargeShadow1.location === 'hand' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(false);
+            });
+
+            describe('when card from hand goes back to shadow', function () {
+                beforeEach(function () {
+                    this.player1.clickCard(this.aVeryLargeShadow1);
+                });
+
+                it('card should be revealed again', function () {
+                    debugger;
+                    expect(this.aVeryLargeShadow1.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow1, this.player2)).toBe(true);
+                });
+
+                describe('when another card is marshalled into shadows', function () {
+                    beforeEach(function () {
+                        this.player1.clickCard(this.aVeryLargeShadow3);
+                    });
+
+                    it('card should be revealed', function () {
+                        expect(this.aVeryLargeShadow3.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow3, this.player2)).toBe(true);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
+++ b/test/server/cards/23-AHaH/WardensOfTheEast.spec.js
@@ -3,23 +3,30 @@ describe('Wardens of the East', function () {
         beforeEach(function () {
             const deck1 = this.buildDeck('baratheon', [
                 'Wardens of the East',
-                'A Very Large Shadow', 'A Very Large Shadow', 'A Very Large Shadow'
+                'A Very Large Shadow', 'A Very Large Shadow', 'A Very Large Shadow', 'Silence (KotI)', 'Catspaw'
             ]);
             const deck2 = this.buildDeck('baratheon', [
                 'Expose Duplicity',
-                'A Very Large Shadow', 'A Very Large Shadow', 'Sweetrobin'
+                'Sweetrobin'
             ]);
 
             this.player1.selectDeck(deck1);
             this.player2.selectDeck(deck2);
-            this.startGame();
-            this.skipSetupPhase();
 
-            this.selectFirstPlayer(this.player1);
+            this.startGame();
+
+            this.keepStartingHands();
 
             [this.aVeryLargeShadow11, this.aVeryLargeShadow12, this.aVeryLargeShadow13] = this.player1.filterCardsByName('A Very Large Shadow', 'hand');
-            [this.aVeryLargeShadow21, this.aVeryLargeShadow22] = this.player2.filterCardsByName('A Very Large Shadow', 'hand');
-            [this.sweetRobin] = this.player2.filterCardsByName('Sweetrobin', 'hand');
+            this.silence = this.player1.findCardByName('Silence (KotI)', 'hand');
+            this.catspaw = this.player1.findCardByName('Catspaw', 'hand');
+            this.sweetrobin = this.player2.findCardByName('Sweetrobin', 'hand');
+
+            this.player1.clickCard(this.silence);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
 
             this.player1.player.gold = 10;
 
@@ -55,26 +62,19 @@ describe('Wardens of the East', function () {
 
                 describe('when another card is marshalled into shadows', function () {
                     beforeEach(function () {
-                        this.player2.dragCard(this.sweetRobin, 'play area');
-                        this.player1.clickCard(this.aVeryLargeShadow13);
+                        this.player2.dragCard(this.sweetrobin, 'play area');
+                        this.player1.clickCard(this.catspaw);
+                        this.player1.clickPrompt('Marshal into shadows');
                     });
 
                     it('card should be revealed', function () {
-                        expect(this.aVeryLargeShadow13.location === 'shadows' && this.game.cardVisibility.isVisible(this.aVeryLargeShadow13, this.player2)).toBe(true);
+                        expect(this.catspaw.location).toBe('shadows');
+                        expect(this.game.cardVisibility.isVisible(this.catspaw, this.player2)).toBe(true);
                     });
 
                     it('should correctly satisfy reaction condition of sweetrobin', function () {
-                        expect(this.player2.currentPrompt().menuTitle).toBe('Any interrupts?');
-                    });
-
-                    describe('when sweetrobin interrupt is triggered', function () {
-                        beforeEach(function () {
-                            this.player2.clickCard(this.sweetRobin);
-                        })
-
-                        it('card should be removed from play', function () {
-                            expect(this.aVeryLargeShadow13.location).toBe('out of game');
-                        });
+                        expect(this.player2).toHavePrompt('Any interrupts?');
+                        expect(this.player2).toAllowAbilityTrigger(this.sweetrobin);
                     });
                 });
             });


### PR DESCRIPTION
Steps to reproduce: with Wardens of the East out and a Scheme plot revealed, marshall 2x "A very large Shadow" in the shadows, then bring one of them out and back to hand. Notice that the card is still revealed, even though it is not in the shadow anymore. From this point, if that copy of "A very large Shadow" is marshalled again in the shadow, it remains revealed, but if other cards are marshalled in the shadow then those cards will remain facedown (even in the shadow area).

Problem is caused by the definition of the "revealFunc" that is bound to a very specific "snapshot" of the shadow zone of that player. When effect is applyed again (reApply method) the shadow zone changes, but the revealedFunc continues to track the content of the snapshotted shadow zone.

With the fix, the "revealFunc" bounds to the player itself, so that a card is revealed only if belongs to the shadow area of that player at the time the revealFunc is appied. This way, when "A very large Shadow" goes back in hand from shadow zone, it is not revealed anymore, and when a new card is put in the shadow zone it is revealed as well.

Note: the "revealShadows" effect is only used by card WardensOfTheEast (for now)