### PR TITLE
investigation on blood of the dragon and house manderly knight wrong …

### DIFF
--- a/server/game/cards/01-Core/TheWall.js
+++ b/server/game/cards/01-Core/TheWall.js
@@ -22,6 +22,7 @@ class TheWall extends DrawCard {
             }
         });
         this.persistentEffect({
+            condition: () => this.location === 'play area',
             match: (card) => card.isFaction('thenightswatch') && card.getType() === 'character',
             effect: ability.effects.modifyStrength(1)
         });

--- a/server/game/cards/02.4-NMG/BloodOfTheDragon.js
+++ b/server/game/cards/02.4-NMG/BloodOfTheDragon.js
@@ -3,6 +3,7 @@ const PlotCard = require('../../plotcard.js');
 class BloodOfTheDragon extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
+            condition: () => this.game.getPlayers().some(player => player.activePlot && player.activePlot === this),
             match: card => card.getType() === 'character' && !card.hasTrait('Dragon'),
             targetController: 'any',
             effect: ability.effects.killByStrength(-1)

--- a/test/server/cards/02.4-NMG/BloodOfTheDragon.spec.js
+++ b/test/server/cards/02.4-NMG/BloodOfTheDragon.spec.js
@@ -1,0 +1,57 @@
+describe('BloodOfTheDragon', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('stark', [
+                'The Long Winter', 'Late Summer Feast',
+                'House Manderly Knight'
+            ]);
+            const deck2 = this.buildDeck('targaryen', [
+                'Blood of the Dragon',
+                'Expose Duplicity',
+                'House Manderly Knight'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.houseManderlyKnight = this.player1.findCardByName('House Manderly Knight', 'hand');
+            this.player1.clickCard(this.houseManderlyKnight);
+
+            this.completeSetup();
+
+            this.player1.selectPlot('The Long Winter');
+            this.player2.selectPlot('Blood of the Dragon');
+
+            this.selectFirstPlayer(this.player1);
+        });
+
+        it('should House Manderly Knight be alive', function() {
+            expect(this.houseManderlyKnight.location === 'play area').toBe(true);
+        });
+
+        it('should House Manderly Knight have strenght 2', function() {
+            expect(this.houseManderlyKnight.getStrength()).toBe(2);
+        });
+
+        describe('when new plots are revealed', function() {
+            beforeEach(function() {
+                //End marshall phase
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+                //End challenge phase
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+            });
+
+            it('should House Manderly Knight be alive', function() {
+                expect(this.houseManderlyKnight.location === 'play area').toBe(true);
+            });
+
+            it('should House Manderly Knight have strenght 1', function() {
+                expect(this.houseManderlyKnight.getStrength()).toBe(1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
... interaction

As pointed out by deadmeat, there is a wrong interaction between House Manderly Knight and Blood of the Dragon plot.
I wroted a test case to reproduce it and investigated on the reason.

The problem is that Blood of the Dragon doesn't have an explicit "condition" in the definition of the persistent effect, in opposition to House Manderly Knight. 
This means that the effect of the Plot is not considered to be "stateDependent", while the effect on the Knight is.

This in turn cause the `reapplyStateDependentEffects` of the `effectengine` to recalculate the effect of the Knight (when the Winter plot cease to be revaled) and the condition on knight cause the effect to be cancelled (`reapply` method in `effect.js`).
As a consequence, the strength of Knight is reduced by 2 and an event is raised (`modifyStrength` method in `drawcard.js`). That event kills the Knight.

By making the Plot also conditional, his effect is recalculated (and so cancelled) in the same event handler that is cancelling the effect of the Knight. As a result, when the `onCardStrengthChanged` event is processed by the game, the strenght of the Knight has switched back to 1.

The change proposed by me solves the problem, but still I think is not so correct. I mean, the condition for a plot to be the revealed plot for a persistent effect to be active should be a default, without the need of an explicit definition (unless stated otherwise). Maybe the method `persistentEffect` of the class `PlotCard` should be overridden to add the condition (if not present) to the properties? Any other thoughts?

Thank you :) 

