### PR TITLE
Fixing Ashemark, and any other GameActions checking cardStateWhenInitialised

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -87,7 +87,7 @@ class BaseAbility {
             this.canResolvePlayer(context) &&
             this.canPayCosts(context) &&
             this.canResolveTargets(context) &&
-            this.allowedGameAction(context)
+            this.isGameActionAllowed(context)
         );
     }
 
@@ -232,7 +232,7 @@ class BaseAbility {
      * 
      * @returns {Boolean}
      */
-    allowedGameAction(context) {
+    isGameActionAllowed(context) {
         return this.executeWithTemporaryContext(context, 'effect', () => this.gameAction.allow(context));
     }
 

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -11,7 +11,8 @@ describe('CardAction', function () {
         this.otherPlayerSpy = jasmine.createSpyObj('player', ['canTrigger']);
         this.otherPlayerSpy.canTrigger.and.returnValue(true);
 
-        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'isAnyBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'isAnyBlank', 'createSnapshot']);
+        this.cardSpy.createSnapshot.and.returnValue(this.cardSpy);
         this.handlerSpy = jasmine.createSpy('handler');
 
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -4,7 +4,7 @@ const Event = require('../../../server/game/event.js');
 describe('CardForcedReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'removeListener', 'registerAbility', 'resolveGameAction']);
-        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isAnyBlank' , 'createSnapshot']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isAnyBlank', 'createSnapshot']);
         this.cardSpy.location = 'play area';
         this.cardSpy.createSnapshot.and.returnValue(this.cardSpy);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -4,8 +4,9 @@ const Event = require('../../../server/game/event.js');
 describe('CardForcedReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'removeListener', 'registerAbility', 'resolveGameAction']);
-        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isAnyBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isAnyBlank' , 'createSnapshot']);
         this.cardSpy.location = 'play area';
+        this.cardSpy.createSnapshot.and.returnValue(this.cardSpy);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -4,8 +4,9 @@ const Event = require('../../../server/game/event.js');
 describe('CardReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'queueStep', 'removeListener', 'registerAbility', 'resolveGameAction']);
-        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getPrintedType', 'isAnyBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getPrintedType', 'isAnyBlank', 'createSnapshot']);
         this.cardSpy.location = 'play area';
+        this.cardSpy.createSnapshot.and.returnValue(this.cardSpy);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {


### PR DESCRIPTION
Closes: #3374 

This is a minor engine tweak to the `canResolve` logic of `baseAbility`; there are scenarios, such as Ashemark, where an ability will need access to it's source's state before initialisation, and thus to ensure that GameActions are properly implemented, we need to include `cardStateWhenInitialised` in any `allowed` checks made against it.

This adjustment here tries to take a generalised approach, by pulling the `this.gameAction.allowed(context)` into the temporary context builder, and within that builder adding a temporary snapshot of the source, if the ability **has** a source.

@ystros, if you can think of any issues this may cause, let me know. Will leave this for you to merge as I like a second set of eyes for any engine changes.