### PR TITLE
Fix hero

### DIFF
--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -39,7 +39,7 @@ class AbilityTarget {
         }) && this.subTargets.every(subTarget => subTarget.canResolve(context));
     }
 
-    getEligibleCards(context){
+    getEligibleCards(context) {
         const selector = CardSelector.for({ context, ...this.properties });
 
         return this.getChoosingPlayers(context).reduce((targets, choosingPlayer) => {

--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -39,6 +39,17 @@ class AbilityTarget {
         }) && this.subTargets.every(subTarget => subTarget.canResolve(context));
     }
 
+    getEligibleCards(context){
+        const selector = CardSelector.for({ context, ...this.properties });
+
+        return this.getChoosingPlayers(context).reduce((targets, choosingPlayer) => {
+            context.choosingPlayer = choosingPlayer;
+            return targets.concat(selector.getEligibleTargets(context)).concat(this.subTargets.reduce((targets, subTarget) => {
+                return subTarget.getEligibleTargets(context);
+            }, []));
+        }, []);
+    }
+
     buildPlayerSelection(context) {
         // Creating the selector once the target is being selected for effects such as keywords with a changing target amount
         this.selector = CardSelector.for({ context, ...this.properties });

--- a/server/game/cards/24-TSoW/Hero.js
+++ b/server/game/cards/24-TSoW/Hero.js
@@ -11,13 +11,11 @@ class Hero extends DrawCard {
                     && this.controller.hand.length < event.challenge.loser.hand.length
             },
             target: {
-                cardCondition: { or: [{ type: 'character', trait: 'Army', location: 'play area' }, { name: 'Grey Worm', location: 'play area' }] }
+                cardCondition: { or: [{ type: 'character', trait: 'Army' }, { name: 'Grey Worm' }] }
             },
             limit: ability.limit.perPhase(2),
             message: '{player} uses {source} to stand {target}',
-            handler: context => {
-                this.game.resolveGameAction(GameActions.standCard(context => ({ card: context.target })), context);
-            }
+            gameAction: GameActions.standCard(context => ({ card: context.target }))
         });
     }
 }

--- a/server/game/cards/24-TSoW/Hero.js
+++ b/server/game/cards/24-TSoW/Hero.js
@@ -11,7 +11,7 @@ class Hero extends DrawCard {
                     && this.controller.hand.length < event.challenge.loser.hand.length
             },
             target: {
-                cardCondition: { or: [{type: 'character', trait: 'Army'}, { name: 'Grey Worm' }] }
+                cardCondition: { or: [{ type: 'character', trait: 'Army', location: 'play area' }, { name: 'Grey Worm', location: 'play area' }] }
             },
             limit: ability.limit.perPhase(2),
             message: '{player} uses {source} to stand {target}',

--- a/test/server/cards/24-TSoW/Hero.spec.js
+++ b/test/server/cards/24-TSoW/Hero.spec.js
@@ -1,0 +1,104 @@
+describe('Hero', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('targaryen', [
+                'Trading with the Pentoshi',
+                'Hero', 'Dothraki Outriders'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck1);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.hero = this.player1.findCardByName('Hero');
+            this.dothrakiOutriders = this.player1.findCardByName('Dothraki Outriders');
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.player1.player.gold += 8;
+
+            this.player1.clickCard(this.hero);
+        });
+
+        describe('when Hero wins a challenge in which he is participating', function() {
+            beforeEach(function() {
+                // marshall dothraki outriders
+                this.player1.clickCard(this.dothrakiOutriders);
+                // end marshall phase
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+                // military challenge with hero
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.hero);
+                this.player1.clickPrompt('Done');
+                // no actions
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
+                // no defense
+                this.player2.clickPrompt('Done');
+                // no actions
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
+            });
+
+            it('should not ask for hero reaction, because there are no kneeling armies to stand', function() {
+                expect(this.player1).not.toHavePrompt('Any reactions?');
+            });
+        });
+
+        describe('when Hero wins a challenge in which he is participating', function() {
+            beforeEach(function() {
+                // end marshall phase
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+                // military challenge with hero
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.hero);
+                this.player1.clickPrompt('Done');
+                // no actions
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
+                // no defense
+                this.player2.clickPrompt('Done');
+                // no actions
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
+            });
+
+            it('should not ask for hero reaction, because there are no armies in play area to stand', function() {
+                expect(this.player1).not.toHavePrompt('Any reactions?');
+            });
+        });
+
+        describe('when Hero wins a challenge in which he is participating', function() {
+            beforeEach(function() {
+                // marshall dothraki outriders
+                this.player1.clickCard(this.dothrakiOutriders);
+                // end marshall phase
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+                // military challenge with hero and dothraki outriders
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.hero);
+                this.player1.clickCard(this.dothrakiOutriders);
+                this.player1.clickPrompt('Done');
+                // no actions
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
+                // no defense
+                this.player2.clickPrompt('Done');
+                // no actions
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
+            });
+
+            it('should ask for hero reaction, because there are a kneeling army to stand', function() {
+                expect(this.player1).toHavePrompt('Any reactions?');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Ok, this is huge :) I'll convert this to draft because it is an intervention on the engine made by one of the newcomers, needs a deep review. 

I'll try to explain at my best what I did and why.

Lets start with `baseAbility`. Each `baseAbility` has a `gameAction` which is constructed through method `buildGameAction`. In this method there is a guard which throws `'Cannot use gameAction with abilities with choices'`. This guard is essential because, without it, targeted abilities wouldn't be registered to any `AbilityWindow`. Why? Because when an ability is registered to a window (thorugh method `registerAbility` of `BaseAbilityWindow`) a check is made if ability `canResolve`, which means (method `canResolve` of `baseAbility`) it `meetsRequirements`, `canResolvePlayer`, other checks, and finally `this.gameAction.allow`. Here is the problem: at the time this check is made, no target has been yet chosen and resolved. So, the `gameAction.allow` method will always throw an exception if the ability requires targets, because the context won't have the target resolution. 
Take for example the `StandCard` game action: the `canChangeGameState` checks need to checks card `location` and `kneeled` flag, but if no `card` is provided a `Cannot read properties of undefined` TypeError is thrown.
So, the guard in `buildGameAction` method ensures that abilities which requires targets will be constructed with a `HandlerGameActionWrapper`, which overrides the `allow` method to always be true. 

This is, in my opinion, the conceptual problem: if an ability requires targets, it will always be allowed, even when the ability won't produce any state change. This is the reason why `Aggo` (for example) needs to check in the `cardCondition` of its `target` if the card is in the play area, even though, conceptually speaking, its effect (`handler`) is to stand the target, and this can only be done for cards in play area. And there is also another problem with `Aggo`: if there is only one Bloodrider character in play area which is already standing, `Aggo`'s Action would be available for trigger, even though it should not (because it wouldn't produce any state change).

In my proposal, I removed the guard in the method `buildGameAction`: now targeted abilities can be constructed with an explicit GameAction given in the properties. To address the problem explained up, I changed also the `canResolve` method in `baseAbility`, defining a new check `canAlterGameState` in substitution of the previous `gameAction.allow` check. If there are no targets then we simply check `gameAction.allow` like before - not sure if the temporary context is needed though, for now I used it.
If however the ability has one or more targets, then, for each target, we collect the potential cards that could be chosen for that target, and then check, for each of those cards, if the `gameAction` allow a stateChange if that card is chosen for that target. 
Notice that `canAlterGameState` checks is made after the `canResolveTargets` check, so we can assume each target can be satisfied. This means that if a target is optional / isAble / etc... and have 0 cards eligible for choice, it is still allowed even if, from a rules perspective, maybe it shouldn't (checking). The interested condition is `eligibleCards.length <= 0` in the `canAlterGameStateForSome` method definition. Without that condition, some tests fail. Investigating on this.

With this change, now Hero can be fixed by defining directly the `gameAction` instead of wrapping it inside an handler. This is a more elegant solution in my opinion, because there is less boiler plate code. I wrote three test case for Hero:
a) checking if Hero Reaction is prompted when there is a kneeling army in play
b) checking if Hero Reaction is not prompted when there is a standing army in play
c) checking if Hero Reaction is not prompted when there are no armies in play

Discuss :D 


