### PR TITLE
Fixing keywords to check canResolve before resolve

### DIFF
--- a/server/game/ChallengeKeywordAbility.js
+++ b/server/game/ChallengeKeywordAbility.js
@@ -23,7 +23,10 @@ class ChallengeKeywordAbility extends BaseAbility {
     }
 
     meetsRequirements(context) {
-        return context.source.allowGameAction(this.title, context) && this.meetsKeywordRequirements(context) && this.getTriggerAmount(context) > 0;
+        return context.source.hasKeyword(this.title) 
+            && context.source.allowGameAction(this.title, context) 
+            && this.meetsKeywordRequirements(context) 
+            && this.getTriggerAmount(context) > 0;
     }
 }
 

--- a/server/game/gamesteps/ChallengeKeywordsWindow.js
+++ b/server/game/gamesteps/ChallengeKeywordsWindow.js
@@ -14,7 +14,7 @@ class ChallengeKeywordsWindow extends BaseStep {
             let context = new AbilityContext({ player, game: this.game, challenge: this.challenge, source: card });
             context.resolved = [];
             return { card: card, context: context };
-        })
+        });
     }
 
     resolveAbility(ability, participants) {

--- a/server/game/gamesteps/ChallengeKeywordsWindow.js
+++ b/server/game/gamesteps/ChallengeKeywordsWindow.js
@@ -1,4 +1,5 @@
 const { sortBy } = require('underscore');
+const AbilityContext = require('../AbilityContext.js');
 const BaseStep = require('./basestep');
 
 class ChallengeKeywordsWindow extends BaseStep {
@@ -6,6 +7,14 @@ class ChallengeKeywordsWindow extends BaseStep {
         super(game);
         this.challenge = challenge;
         this.resolvedAbilities = [];
+    }
+
+    buildContexts(cards, player) {
+        return cards.map(card => {
+            let context = new AbilityContext({ player, game: this.game, challenge: this.challenge, source: card });
+            context.resolved = [];
+            return { card: card, context: context };
+        })
     }
 
     resolveAbility(ability, participants) {
@@ -26,6 +35,7 @@ class ChallengeKeywordsWindow extends BaseStep {
         for(let participant of participants) {
             this.game.queueSimpleStep(() => {
                 participant.context.resolved = this.resolvedAbilities.filter(resolved => resolved.ability.title === ability.title);
+                // Check this a second time; primarily in case a previous trigger has affected whether it can resolve (eg. additional triggers with Assault).
                 if(!ability.canResolve(participant.context)) {
                     return;
                 }

--- a/server/game/gamesteps/InitiatingKeywordsWindow.js
+++ b/server/game/gamesteps/InitiatingKeywordsWindow.js
@@ -1,5 +1,4 @@
 const ChallengeKeywordsWindow = require('./ChallengeKeywordsWindow');
-const AbilityContext = require('../AbilityContext.js');
 const GameKeywords = require('../gamekeywords.js');
 
 const initiatingKeywords = ['stealth', 'assault'];
@@ -7,15 +6,13 @@ const initiatingKeywords = ['stealth', 'assault'];
 class InitiatingKeywordsWindow extends ChallengeKeywordsWindow {
     constructor(game, challenge) {
         super(game, challenge);
-        this.attackingCardsWithContext = challenge.declaredAttackers.map(card => {
-            return { card: card, context: new AbilityContext({ player: this.challenge.attackingPlayer, game: this.game, challenge: this.challenge, source: card }) };
-        });
+        this.attackingCardsWithContext = this.buildContexts(challenge.declaredAttackers, this.challenge.attackingPlayer);
     }
 
     continue() {
         for(let keyword of initiatingKeywords) {
             let ability = GameKeywords[keyword];
-            let attackersWithKeyword = this.attackingCardsWithContext.filter(attacker => attacker.card.hasKeyword(keyword));
+            let attackersWithKeyword = this.attackingCardsWithContext.filter(attacker => ability.canResolve(attacker.context));
 
             if(attackersWithKeyword.length > 0) {
                 this.resolveAbility(ability, attackersWithKeyword);

--- a/server/game/gamesteps/ResolutionKeywordsWindow.js
+++ b/server/game/gamesteps/ResolutionKeywordsWindow.js
@@ -1,7 +1,6 @@
 const {sortBy} = require('../../Array');
 
 const ChallengeKeywordsWindow = require('./ChallengeKeywordsWindow');
-const AbilityContext = require('../AbilityContext.js');
 const GameKeywords = require('../gamekeywords.js');
 
 const resolutionKeywords = ['insight', 'intimidate', 'pillage', 'renown'];
@@ -9,9 +8,7 @@ const resolutionKeywords = ['insight', 'intimidate', 'pillage', 'renown'];
 class ResolutionKeywordsWindow extends ChallengeKeywordsWindow {
     constructor(game, challenge) {
         super(game, challenge);
-        this.winnerCardsWithContext = challenge.getWinnerCards().map(card => {
-            return { card: card, context: new AbilityContext({ player: this.challenge.winner, game: this.game, challenge: this.challenge, source: card }) };
-        });
+        this.winnerCardsWithContext = this.buildContexts(challenge.getWinnerCards(), this.challenge.winner);
         this.firstPlayer = game.getFirstPlayer();
         this.remainingKeywords = resolutionKeywords;
     }
@@ -67,7 +64,7 @@ class ResolutionKeywordsWindow extends ChallengeKeywordsWindow {
 
     applyKeyword(keyword) {
         let ability = GameKeywords[keyword];
-        let participantsWithKeyword = this.winnerCardsWithContext.filter(participant => participant.card.hasKeyword(keyword));
+        let participantsWithKeyword = this.winnerCardsWithContext.filter(participant => ability.canResolve(participant.context));
 
         if(participantsWithKeyword.length === 0) {
             return;


### PR DESCRIPTION
Primarily addressing an issue where players who have the `keywordSettings.chooseCards` option set would be receiving a prompt to trigger intimidate order when winning on defence. This fix correctly uses the `canResolve` of each keyword before determining which cards *can* trigger, as well as previously checking it in-between each application.