### PR TITLE
Updating TheBlackfish to GameAction & added limit

### DIFF
--- a/server/game/cards/03-WotN/TheBlackfish.js
+++ b/server/game/cards/03-WotN/TheBlackfish.js
@@ -1,3 +1,4 @@
+const GameActions = require('../../GameActions/index.js');
 const DrawCard = require('../../drawcard.js');
 
 class TheBlackfish extends DrawCard {
@@ -13,13 +14,11 @@ class TheBlackfish extends DrawCard {
                 afterChallenge: event =>
                     event.challenge.winner === this.controller &&
                     event.challenge.challengeType === 'military' &&
-                    event.challenge.isAttackerTheWinner() &&
-                    this.controller.canDraw()
+                    event.challenge.isAttackerTheWinner()
             },
-            handler: () => {
-                this.controller.drawCardsToHand(1);
-                this.game.addMessage('{0} uses {1} to draw a card', this.controller, this);
-            }
+            limit: ability.limit.perPhase(1),
+            message: '{player} uses {source} to draw 1 card',
+            gameAction: GameActions.drawCards(context => ({ player: context.player, amount: 1, source: this }))
         });
     }
 }

--- a/test/server/effects/doesNotKneelAsAttacker.spec.js
+++ b/test/server/effects/doesNotKneelAsAttacker.spec.js
@@ -57,7 +57,6 @@ describe('doesNotKneelAsAttacker', function() {
 
                 // Both the Wolf King and Blackfish effects should keep him standing
                 this.unopposedChallenge(this.player1, 'Military', this.character);
-                this.player1.clickPrompt('Pass');
                 this.player1.clickPrompt('Continue');
 
                 expect(this.character.kneeled).toBe(false);


### PR DESCRIPTION
Closes: #3383 

Title says it all.
Also includes an alteration to the `doesNotKneelAsAttacker.spec.js` as Blackfish now *correctly* does not trigger if the player has no cards in their deck (GameActions actually doing it's job!). Clicking "Pass" on his ability is no longer necessary.