### PR TITLE
- fix proposal to Arya Stark duplicates not working sometimes

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -71,6 +71,7 @@ class DrawCard extends BaseCard {
             abilitySourceType: 'game',
             canCancel: true,
             cannotBeCanceled: true,
+            ignoreEventCosts: true,
             location: 'duplicate',
             when: {
                 onCharacterKilled: dupeCondition,


### PR DESCRIPTION
close #3385 but review needed because it is an engine-level fix.

After investigation, I've found another way to reproduce the problem which doesn't use any trigger restriction.

If Player 1 has `Arya Stark (Core)` with a facedown event as dupe (for example: `Nightmares`) and gold less than the cost of the event (for example: 0 gold), then dupe cannot be used.

That's because during the duplicate ability setup (method `setupDuplicateAbility` of `drawcard`) a new `CardInterrupt` instance is constructed. This class inherits from `TriggeredAbility` which has, in the constructor, a logic for which if the `card.printedType` is `'event'` and the caller doesn't explicitly said to `ignoreEventCosts`, then all three `Costs.playEvent` are added to the cost. As a result, when duplicate ability is setup on `Nightmares`, its costs became 4 in total: `ability.costs.discardDuplicate()` (from `drawCard` `setupDuplicateAbility` method) and three `Costs.playEvent`. If the controller of `Arya` cannot pay one of this 4 costs (for example, because it has no gold or if it has a trigger restriction) then the duplicate interrupt cannot be triggered.

The fix consist in adding the property `ignoreEventCosts: true` when the `setupDuplicateAbility` method is called: could it work?

Tested locally with and without the fix, and it worked in all cases. I didn't add a test case to `Arya Stark` spec file, though. Let me know if it is better to add a test case for this interaction, and if it is correct to add a test case for `Arya` spec or for a more generic spec file, like `Duplicates`.

 Thank you :)