### PR TITLE
Fix pyromancers cache gained ability not working

### DIFF
--- a/server/game/CardTextDefinition.js
+++ b/server/game/CardTextDefinition.js
@@ -5,7 +5,7 @@ class CardTextDefinition {
     }
 
     action(properties) {
-        this.actionDefinitions.push(properties);
+        this.actionDefinitions.push(Object.assign({isGained: true}, properties));
     }
 
     apply(card) {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -29,6 +29,8 @@ const EventRegistrar = require('./eventregistrar.js');
  *                other than the card's controller. Defaults to false.
  * clickToActivate - boolean that indicates the action should be activated when
  *                   the card is clicked.
+ * isGained     - boolean indicating whether the action is printed or gained through
+ *                  other effect
  */
 class CardAction extends BaseAbility {
     constructor(game, card, properties) {
@@ -42,6 +44,7 @@ class CardAction extends BaseAbility {
 
         this.game = game;
         this.card = card;
+        this.isGained = !!properties.isGained;
         this.title = properties.title;
         this.max = properties.max;
         this.phase = this.buildPhase(properties);
@@ -123,8 +126,8 @@ class CardAction extends BaseAbility {
             return false;
         }
 
-        if(this.card.isAnyBlank()) {
-            return false ;
+        if(this.card.isAnyBlank() && !this.isGained) {
+            return false;
         }
 
         if(this.condition && !this.condition(context)) {


### PR DESCRIPTION
progress #2377

see also #3300 

I'm opening this as DPR because it is an engine tweak. It is very limited and with low impact in my opinion.
Tested and it solves the problem with Pyromancer Cache.

A little explanation: most of (if not all) blanking effects acts on _printed text_. This is why a _gained text_ (as opposed to _printed text_) is not affected by blanking effects.

So the idea is to add the boolean property `isGained` to the `CardAction` class and use this new flag in the method `meetRequirements` of the same class so that the requirement is not met if card is blanked and action is printed (_not gained_).
Adding a card text through effect is done with an instance of `CardTextDefinition`, so I added the default property `isGained: true` in the `action` method.

