### PR TITLE
Fixing Harlaw Scout to be a reaction, not interrupt

### DIFF
--- a/server/game/cards/24-TSoW/HarlawScout.js
+++ b/server/game/cards/24-TSoW/HarlawScout.js
@@ -3,7 +3,7 @@ const GameActions = require('../../GameActions/index.js');
 
 class HarlawScout extends DrawCard {
     setupCardAbilities(ability) {
-        this.interrupt({
+        this.reaction({
             when: {
                 'onCardDiscarded:aggregate': event => 
                     event.events.some(discardEvent => 


### PR DESCRIPTION
Very simple fix here which was noticed on the Playtesting server; causing triggering issues for `cardStateWhenDiscarded` being undefined, which is caused by this incorrectly being an **Interrupt**, when the card is actually a **Reaction**.