### PR TITLE
Fixing TheFowlerTwins to only apply on the next challenge initiated

### DIFF
--- a/server/game/ChallengeMatcher.js
+++ b/server/game/ChallengeMatcher.js
@@ -16,6 +16,7 @@ class ChallengeMatcher {
             Matcher.anyValue(matchers.attackingAlone, card => (card.isAttacking() || card.isDeclaredAsAttacker()) && challenge.attackers.length === 1) && 
             Matcher.anyValue(matchers.defendingAlone, card => card.isDefending() && challenge.defenders.length === 1) &&
             Matcher.containsValue(matchers.number, () => challenge.number) &&
+            Matcher.containsValue(matchers.totalNumber, () => challenge.totalNumber) &&
             Matcher.containsValue(matchers.unopposed, () => challenge.isUnopposed()) &&
             Matcher.anyValue(matchers.by5, value => (challenge.strengthDifference >= 5) === value) &&
             Matcher.anyValue(matchers.match, func => func(challenge)) &&

--- a/server/game/cards/10-SoD/ToTheSpears.js
+++ b/server/game/cards/10-SoD/ToTheSpears.js
@@ -10,7 +10,7 @@ class ToTheSpears extends DrawCard {
             condition: () => this.controller.getNumberOfUsedPlots() >= 3,
             message: '{player} plays {source} to have each martell character they control not kneel when declared as an attacker during the next challenge they initiate this phase',
             handler: context => {
-                let currentNumber = Math.max(this.tracker.filter({ attackingPlayer: context.player }).map(challenge => challenge.number));
+                let currentNumber = Math.max(...this.tracker.filter({ attackingPlayer: context.player }).map(challenge => challenge.number), 0);
                 let martellCharacters = context.player.filterCardsInPlay(card => card.getType() === 'character' && card.isFaction('martell'));
 
                 this.untilEndOfPhase(ability => ({

--- a/server/game/cards/10-SoD/ToTheSpears.js
+++ b/server/game/cards/10-SoD/ToTheSpears.js
@@ -8,18 +8,16 @@ class ToTheSpears extends DrawCard {
         this.action({
             title: 'Have characters not kneel next challenge',
             condition: () => this.controller.getNumberOfUsedPlots() >= 3,
+            message: '{player} plays {source} to have each martell character they control not kneel when declared as an attacker during the next challenge they initiate this phase',
             handler: context => {
-                let numInitiated = this.tracker.count({ attackingPlayer: context.player });
+                let currentNumber = Math.max(this.tracker.filter({ attackingPlayer: context.player }).map(challenge => challenge.number));
                 let martellCharacters = context.player.filterCardsInPlay(card => card.getType() === 'character' && card.isFaction('martell'));
 
                 this.untilEndOfPhase(ability => ({
-                    condition: () => this.tracker.count({ attackingPlayer: context.player }) <= numInitiated,
+                    condition: () => this.game.isDuringChallenge({ number: currentNumber + 1 }),
                     match: martellCharacters,
                     effect: ability.effects.doesNotKneelAsAttacker()
                 }));
-
-                this.game.addMessage('{0} plays {1} to have each {2} character they control not kneel during the next challenge they initiate this phase',
-                    context.player, this, 'martell');
             }
         });
     }

--- a/server/game/cards/13.2-CoS/TheFowlerTwins.js
+++ b/server/game/cards/13.2-CoS/TheFowlerTwins.js
@@ -13,7 +13,7 @@ class TheFowlerTwins extends DrawCard {
             limit: ability.limit.perPhase(1),
             message: '{player} uses {source} to force {target} to be declared as a participant in the next challenge initated this phase',
             handler: context => {
-                let currentTotalNumber = Math.max(this.tracker.challenges.map(challenge => challenge.totalNumber));
+                let currentTotalNumber = Math.max(...this.tracker.challenges.map(challenge => challenge.totalNumber), 0);
                 
                 this.untilEndOfPhase(ability => ({
                     condition: () => this.game.isDuringChallenge({ totalNumber: currentTotalNumber + 1 }),

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -17,6 +17,7 @@ class Challenge {
         this.challengeType = properties.challengeType;
         this.declareDefendersFirst = false;
         this.number = properties.number;
+        this.totalNumber = properties.totalNumber;
         this.attackers = [];
         this.declaredAttackers = [];
         this.attackerStrength = 0;

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -90,7 +90,8 @@ class ChallengePhase extends Phase {
             attackingPlayer: attackingPlayer,
             defendingPlayer: defendingPlayer,
             challengeType: challengeType,
-            number: this.tracker.count({ attackingPlayer }) + 1
+            number: this.tracker.count({ attackingPlayer }) + 1,
+            totalNumber: this.tracker.count({}) + 1
         });
         this.game.currentChallenge = challenge;
         this.game.currentChallengeStep = new ChallengeFlow(this.game, challenge);


### PR DESCRIPTION
Closes #3425 

The primary issue as to why this is being improved upon (eg. not just copying To The Spears logic) is outlined in the following comment: https://github.com/throneteki/throneteki/issues/3425#issuecomment-1728637728

This is resolved by tracking the "total number" of each challenge being initiated during the challenges phase (regardless of player), and checking that total number is incremented by 1; this should ensure TFT is active during `onChallengeInitiation`, as well as during the challenge itself, but never before or after those points.
Additionally, this also updates **To The Spears!** to use this new logic, even though that card is currently fine - consistency is key! :)