### PR TITLE
Minor fix to condition of To The Spear's effect

### DIFF
--- a/server/game/cards/10-SoD/ToTheSpears.js
+++ b/server/game/cards/10-SoD/ToTheSpears.js
@@ -14,7 +14,7 @@ class ToTheSpears extends DrawCard {
                 let martellCharacters = context.player.filterCardsInPlay(card => card.getType() === 'character' && card.isFaction('martell'));
 
                 this.untilEndOfPhase(ability => ({
-                    condition: () => this.game.isDuringChallenge({ number: currentNumber + 1 }),
+                    condition: () => this.game.isDuringChallenge({ attackingPlayer: context.player, number: currentNumber + 1 }),
                     match: martellCharacters,
                     effect: ability.effects.doesNotKneelAsAttacker()
                 }));


### PR DESCRIPTION
Ensures To The Spears only applies during the next challenge initiated by that player, rather than any player; granted, this would not have actually cause any issues, but should be correct regardless for consistency!