### PR TITLE
Updating Bonds of Chivalry to GameAction

### DIFF
--- a/server/game/GameActions/AddToChallenge.js
+++ b/server/game/GameActions/AddToChallenge.js
@@ -13,15 +13,14 @@ class AddToChallenge extends GameAction {
     }
 
     canChangeGameState({ card }) {
-        return !card.isParticipating();
+        return card.game.isDuringChallenge() && card.getType() === 'character' && card.location === 'play area' && !card.isParticipating();
     }
 
     createEvent({ card, player }) {
-        const challenge = card.game.currentChallenge;
         player = player || card.controller;
         const eventProps = {
             card,
-            challenge,
+            challenge: card.game.currentChallenge,
             player
         };
         return this.event('onAddedToChallenge', eventProps, event => {

--- a/server/game/GameActions/AddToChallenge.js
+++ b/server/game/GameActions/AddToChallenge.js
@@ -1,0 +1,33 @@
+const GameAction = require('./GameAction');
+const Message = require('../Message');
+
+class AddToChallenge extends GameAction {
+    constructor() {
+        super('addToChallenge');
+    }
+
+    message({ card, player, context }) {
+        player = player || card.controller;
+        const playerMessage = player === context.player ? 'their' : Message.fragment('{player}\'s', { player });
+        return Message.fragment('has {card} participate in the challenge on {player} side', { card, player: playerMessage });
+    }
+
+    canChangeGameState({ card }) {
+        return !card.isParticipating();
+    }
+
+    createEvent({ card, player }) {
+        const challenge = card.game.currentChallenge;
+        player = player || card.controller;
+        const eventProps = {
+            card,
+            challenge,
+            player
+        };
+        return this.event('onAddedToChallenge', eventProps, event => {
+            event.challenge.addParticipantToSide(event.player, event.card);
+        });
+    }
+}
+
+module.exports = new AddToChallenge();

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -1,4 +1,5 @@
 const AbilityAdapter = require('./AbilityAdapter');
+const AddToChallenge = require('./AddToChallenge');
 const AddToHand = require('./AddToHand');
 const CancelEffects = require('./CancelEffects');
 const CheckReserve = require('./CheckReserve');
@@ -42,6 +43,7 @@ const StandCard = require('./StandCard');
 const TakeControl = require('./TakeControl');
 
 const GameActions = {
+    addToChallenge: props => new AbilityAdapter(AddToChallenge, props),
     addToHand: props => new AbilityAdapter(AddToHand, props),
     cancelEffects: props => new AbilityAdapter(CancelEffects, props),
     checkReserve: props => new AbilityAdapter(CheckReserve, props),


### PR DESCRIPTION
It was noticed on the Playtesting server that this is a bit outdated in abilities which react to a card standing; reactions should trigger _after_ the full ability is resolved - in this case, after the new character has been chosen to participate. BoC has been updated to properly reflect this logic through the use of GameActions.

This is mostly an update I am looking to pull through to the playtesting server, but since it's only updating an already-released card, thought it best to instead push to live. :)