### PR TITLE
Fixing missed adjustments in Bonds of Chivalry

### DIFF
--- a/server/game/GameActions/KneelCard.js
+++ b/server/game/GameActions/KneelCard.js
@@ -1,8 +1,13 @@
+const Message = require('../Message');
 const GameAction = require('./GameAction');
 
 class KneelCard extends GameAction {
     constructor() {
         super('kneel');
+    }
+
+    message({ card }) {
+        return Message.fragment('kneels {card}', { card });
     }
 
     canChangeGameState({ card }) {

--- a/server/game/cards/11.4-MoD/BondsOfChivalry.js
+++ b/server/game/cards/11.4-MoD/BondsOfChivalry.js
@@ -29,8 +29,7 @@ class BondsOfChivalry extends DrawCard {
                                             GameActions.kneelCard(context => ({ card: context.target })),
                                             GameActions.addToChallenge(context => ({ card: context.target }))
                                         ]),
-                                        // message: 'Then, {player} kneels {target} to have it participate in the challenge on their side'
-                                        message: '{player} {gameAction}'
+                                        message: 'Then, {player} kneels {target} to have it participate in the challenge on their side'
                                     }
                                 }), context
                             );


### PR DESCRIPTION
This was a little mistake by me whilst testing the message format for `AddToChallenge`; corrected the message for the "Then" portion of BoC.
Additionally, added a message for `KneelCard`, just in case for the future (since it was super simple).