### PR TITLE
Fixing A Cask of Ale

### DIFF
--- a/server/game/cards/14-FotS/ACaskOfAle.js
+++ b/server/game/cards/14-FotS/ACaskOfAle.js
@@ -6,7 +6,7 @@ class ACaskOfAle extends DrawCard {
         this.reaction({
             when: {
                 afterChallenge: event => (event.challenge.isMatch({ winner: this.controller, challengeType: 'power' }) 
-                    && this.game.allCards.some(card => (card.location === 'active plot', 'faction', 'play area' && card.getPower()>0)))
+                    && this.game.allCards.some(card => (card.location === 'active plot', 'faction', 'play area' && card.getPower() > 0)))
             },
             target: {
                 mode: 'exactly',
@@ -57,11 +57,11 @@ class ACaskOfAle extends DrawCard {
         this.game.addMessage('{0} plays {1} to move {2} power from {3} to {4}', this.context.player, this, amount, this.fromCard, this.toCard);
 
         this.game.resolveGameAction(
-            GameActions.movePower(context => ({
+            GameActions.movePower({
                 from: this.fromCard,
                 to: this.toCard,
                 amount
-            })),
+            }),
             this.context
         );
 

--- a/server/game/cards/14-FotS/ACaskOfAle.js
+++ b/server/game/cards/14-FotS/ACaskOfAle.js
@@ -5,55 +5,70 @@ class ACaskOfAle extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: event => event.challenge.isMatch({ winner: this.controller, challengeType: 'power' })
+                afterChallenge: event => (event.challenge.isMatch({ winner: this.controller, challengeType: 'power' }) 
+                    && this.game.allCards.some(card => (card.location === 'active plot', 'faction', 'play area' && card.getPower()>0)))
             },
-            targets: {
-                from: {
-                    activePromptTitle: 'Select card with power',
-                    cardCondition: card => ['active plot', 'faction', 'play area'].includes(card.location) && card.power > 0,
-                    cardType: ['attachment', 'character', 'faction', 'location', 'plot']
-                },
-                to: {
-                    activePromptTitle: 'Select card to place power',
-                    cardCondition: (card, context) => (
-                        ['active plot', 'faction', 'play area'].includes(card.location) &&
-                        (!context.targets.from || card !== context.targets.from && card.controller === context.targets.from.controller)
-                    ),
-                    cardType: ['attachment', 'character', 'faction', 'location', 'plot']
-                }
+            target: {
+                mode: 'exactly',
+                numCards: 2,
+                activePromptTitle: 'Select 2 cards',
+                singleController: true,
+                cardCondition: card => ['active plot', 'faction', 'play area'].includes(card.location),
+                cardType: ['attachment', 'character', 'faction', 'location', 'plot'],
+                gameAction: 'movePower'
             },
             handler: context => {
                 this.context = context;
-                if(context.targets.from.power > 1) {
-                    this.game.promptWithMenu(context.player, this, {
-                        activePrompt: {
-                            menuTitle: 'Choose amount of power',
-                            buttons: [
-                                { text: '2', arg: 2, method: 'selectPowerAmount' },
-                                { text: '1', arg: 1, method: 'selectPowerAmount' }
-                            ]
-                        },
-                        source: this
-                    });
-                    return;
-                }
-
-                this.selectPowerAmount(context.player, 1);
+                this.game.promptForSelect(context.player, {
+                    activePromptTitle: 'Select card with power',
+                    source: this,
+                    cardCondition: card => context.target.includes(card) && card.getPower() > 0,
+                    cardType: ['attachment', 'character', 'faction', 'location', 'plot'],
+                    onSelect: (player, card) => this.fromCardSelected(player, card),
+                    onCancel: (player) => this.cancelSelection(player)
+                });
             }
         });
     }
+    fromCardSelected(player, fromCard) {
+        this.fromCard = fromCard;
+        this.toCard = this.context.target.find(card => card !== fromCard);
+
+        if(fromCard.power > 1) {
+            this.game.promptWithMenu(this.context.player, this, {
+                activePrompt: {
+                    menuTitle: 'Choose amount of power',
+                    buttons: [
+                        { text: '2', arg: 2, method: 'selectPowerAmount' },
+                        { text: '1', arg: 1, method: 'selectPowerAmount' }
+                    ]
+                },
+                source: this
+            });
+            return true;
+        }
+
+        this.selectPowerAmount(this.context.player, 1);
+
+        return true;
+    }
 
     selectPowerAmount(player, amount) {
-        this.game.addMessage('{0} plays {1} to move {2} power from {3} to {4}', this.context.player, this, amount, this.context.targets.from, this.context.targets.to);
+        this.game.addMessage('{0} plays {1} to move {2} power from {3} to {4}', this.context.player, this, amount, this.fromCard, this.toCard);
 
         this.game.resolveGameAction(
             GameActions.movePower(context => ({
-                from: context.targets.from,
-                to: context.targets.to,
+                from: this.fromCard,
+                to: this.toCard,
                 amount
             })),
             this.context
         );
+
+        return true;
+    }
+    cancelSelection(player) {
+        this.game.addAlert('danger', '{0} cancels the resolution of {1}', player, this);
 
         return true;
     }

--- a/server/game/cards/14-FotS/ACaskOfAle.js
+++ b/server/game/cards/14-FotS/ACaskOfAle.js
@@ -6,7 +6,7 @@ class ACaskOfAle extends DrawCard {
         this.reaction({
             when: {
                 afterChallenge: event => (event.challenge.isMatch({ winner: this.controller, challengeType: 'power' }) 
-                    && this.game.allCards.some(card => (card.location === 'active plot', 'faction', 'play area' && card.getPower() > 0)))
+                    && this.game.allCards.some(card => (['active plot', 'faction', 'play area'].includes(card.location) && card.getPower() > 0)))
             },
             target: {
                 mode: 'exactly',


### PR DESCRIPTION
Changed the event so you first have to select the two cards from the same controller and then which card you are moving the power from. You are apparently also supposed to be able to select two cards without power if you for some reason want the event to not resolve, because it is a referential target, but you can't play the event if there is no power in play.