### PR TITLE
Crone Forgotten By History Interaction

### DIFF
--- a/server/game/cards/08.3-Km/ForgottenByHistory.js
+++ b/server/game/cards/08.3-Km/ForgottenByHistory.js
@@ -8,7 +8,8 @@ class ForgottenByHistory extends DrawCard {
             cost: ability.costs.kneelFactionCard(),
             target: {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
-                                       card.getPrintedCost() <= card.controller.faction.power
+                                       card.getPrintedCost() <= card.controller.faction.power &&
+                                       card.allowGameAction('returnCardToDeck')
             },
             handler: context => {
                 context.target.owner.shuffleCardIntoDeck(context.target);

--- a/server/game/cards/13.5-TB/TheBloodyCup.js
+++ b/server/game/cards/13.5-TB/TheBloodyCup.js
@@ -7,7 +7,8 @@ class TheBloodyCup extends DrawCard {
                 afterChallenge: event => event.challenge.isMatch({ winner: this.controller, unopposed: true })
             },
             target: {
-                cardCondition: (card, context) => card.location === 'play area' && card.getType() === 'character' && card.controller === context.event.challenge.loser
+                cardCondition: (card, context) => card.location === 'play area' && card.getType() === 'character' && card.controller === context.event.challenge.loser &&
+                                                  card.allowGameAction('returnCardToDeck')
             },
             message: {
                 format: '{player} plays {source} to place {target} on top of {loser}\'s deck',


### PR DESCRIPTION
Closes: #3440
I added the condition when selecting targets, this way you also can't play the event if there is no valid target. I also added this condition in Bloody Cup, because it now let's you select invalid targets on Crone turn. Not sure if this is okay solution for this, but if it is I can add it on some other events that I know also work like that.