### PR TITLE
Events rework

### DIFF
--- a/server/game/AtomicEvent.js
+++ b/server/game/AtomicEvent.js
@@ -5,6 +5,7 @@ class AtomicEvent {
         this.childEvents = [];
         this.attachedEvents = [];
         this.params = {};
+        this.order = 0;
     }
 
     get resolved() {
@@ -77,8 +78,13 @@ class AtomicEvent {
     }
 
     executeHandler() {
-        for (let event of this.childEvents.sort((a, b) => a.order - b.order)) {
-            event.executeHandler();
+        this.queue = this.getConcurrentEvents().sort((a, b) => a.order - b.order);
+
+        for (let event of this.queue) {
+            event.createSnapshot();
+            if (!event.invalid) {
+                event.handler(event);
+            }
         }
     }
 

--- a/server/game/AtomicEvent.js
+++ b/server/game/AtomicEvent.js
@@ -46,6 +46,24 @@ class AtomicEvent {
         }
     }
 
+    replace(newEvent) {
+        if (this.parent) {
+            this.parent.replaceChildEvent(this, newEvent);
+        } else {
+            throw new Error('Cannot replace an event without a parent!');
+        }
+    }
+
+    replaceChildEvent(childEvent, newEvent) {
+        const index = this.childEvents.findIndex((e) => e == childEvent);
+
+        if (index >= 0) {
+            childEvent.parent = null;
+            this.childEvents.splice(index, 1);
+            this.addChildEvent(newEvent);
+        }
+    }
+
     replaceHandler(handler) {
         if (this.childEvents.length !== 0) {
             this.childEvents[0].replaceHandler(handler);

--- a/server/game/CompositeEvent.js
+++ b/server/game/CompositeEvent.js
@@ -1,4 +1,4 @@
-const uuid = require('uuid');
+import uuid from 'uuid';
 const ReservedEventParamKeys = [
     'attachedEvents',
     'cancelled',

--- a/server/game/CompositeEvent.js
+++ b/server/game/CompositeEvent.js
@@ -19,6 +19,7 @@ class CompositeEvent extends Event {
         return [...this.childEventsMap.values()];
     }
 
+    // Required for Event constructor
     set childEvents(val) {
         return;
     }
@@ -55,15 +56,6 @@ class CompositeEvent extends Event {
                 this.setChildEvent(name, newEvent);
                 return;
             }
-        }
-    }
-
-    emitTo(emitter, suffix) {
-        let fullName = suffix ? `${this.name}:${suffix}` : this.name;
-        emitter.emit(fullName, this);
-
-        for (let event of this.childEvents) {
-            event.emitTo(emitter, suffix);
         }
     }
 

--- a/server/game/CompositeEvent.js
+++ b/server/game/CompositeEvent.js
@@ -1,0 +1,230 @@
+const uuid = require('uuid');
+const ReservedEventParamKeys = [
+    'attachedEvents',
+    'cancelled',
+    'childEvents',
+    'handler',
+    'name',
+    'params',
+    'parent',
+    'postHandlers',
+    'cardStateWhenEventCreated'
+];
+
+class CompositeEvent {
+    constructor(name, params = {}, postHandler = () => true) {
+        const { isFullyResolved, ...otherParams } = params;
+
+        this.name = name;
+        this.cancelled = false;
+        this.invalid = false;
+        this.handler = () => true;
+        this.postHandlers = [postHandler];
+        this.childEventsMap = new Map();
+        this.attachedEvents = [];
+        this.params = otherParams;
+        this.isFullyResolved = isFullyResolved || (() => true);
+
+        this.assignParamProperties(otherParams);
+
+        if (this.params.card && this.params.card.createSnapshot) {
+            this.cardStateWhenEventCreated = this.params.card.createSnapshot();
+        }
+
+        // ISSUE: Properties within primaryEvent & innerEvents need to be shared, rather than sharing all properties within here.
+        // eg. If innerEvent[0].automaticSaveWithDupe is being fetched, and is undefined, then it should search primaryEvent & the
+        //     other innerEvents for an automaticSaveWithDupe that isn't undefined. If none exist, it's actually undefined.
+
+        // Proxy allows property gets/sets to be obtained from & propogated to inner events
+        // return new Proxy(this, {
+        //     get: function(target, prop) {
+        //         const value = target[prop];
+        //         if(value) {
+        //             return value;
+        //         }
+        //         // Get the property, starting at the primary event, then looping through inner events
+        //         for(const event of target.childEvents) {
+        //             const property = event[prop];
+        //             if(property) {
+        //                 return property;
+        //             }
+        //         }
+        //         return undefined;
+        //     },
+        //     set: function(target, prop, value) {
+        //         // Find if the property exists already & set, starting at the primary event, then looping through inner events
+        //         for(const event of target.childEvents) {
+        //             const property = event[prop];
+        //             if(property) {
+        //                 event[prop] = value;
+        //                 return true;
+        //             }
+        //         }
+        //         // Otherwise, set property on composite event
+        //         return true;
+        //     }
+        // });
+    }
+
+    assignParamProperties(params) {
+        let reservedKeys = ReservedEventParamKeys.filter((key) => !!params[key]);
+        if (reservedKeys.length !== 0) {
+            throw new Error(
+                `Event '${this.name}' cannot have params with keys: ${reservedKeys.map((key) => `'${key}'`).join(', ')}`
+            );
+        }
+
+        Object.assign(this, params);
+    }
+
+    get childEvents() {
+        return [...this.childEventsMap.values()];
+    }
+
+    get resolved() {
+        return (
+            !this.cancelled &&
+            this.isFullyResolved(this) &&
+            this.childEvents.every((event) => event.resolved)
+        );
+    }
+
+    addChildEvent(event) {
+        // Add un-named inner event (with uuid as name)
+        this.setChildEvent(uuid.v1(), event);
+    }
+
+    setChildEvent(name, event) {
+        this.params = Object.assign({}, event.params, this.params);
+        Object.assign(this, this.params);
+
+        event.parent = this;
+        this.childEventsMap.set(name, event);
+    }
+
+    replaceChildEvent(name, event) {
+        if (this.childEventsMap.has(name)) {
+            this.childEventsMap.get(name).parent = null;
+            this.setChildEvent(name, event);
+        }
+    }
+
+    emitTo(emitter, suffix) {
+        let fullName = suffix ? `${this.name}:${suffix}` : this.name;
+        emitter.emit(fullName, this);
+
+        for (let event of this.childEvents) {
+            event.emitTo(emitter, suffix);
+        }
+    }
+
+    allowAutomaticSave() {
+        return this.allowSave && this.automaticSaveWithDupe && !!this.card;
+    }
+
+    saveCard() {
+        if (!this.card || this.cancelled) {
+            return;
+        }
+
+        this.card.game.saveCard(this.card);
+        this.cancel();
+    }
+
+    cancel() {
+        this.cancelled = true;
+
+        for (let event of this.childEvents) {
+            // Disassociate the child with the parent so that indirect calls to
+            // onChildCancelled are not made. This will prevent an infinite loop.
+            event.parent = null;
+            event.cancel();
+        }
+
+        this.childEventsMap.clear();
+
+        if (this.parent) {
+            this.parent.onChildCancelled(this);
+        }
+    }
+
+    checkExecuteValidity() {
+        // When the card in which the event affects is moved before the event can start resolving, it should not execute (but is also not cancelled)
+        if (
+            this.params.card &&
+            this.cardStateWhenEventCreated &&
+            this.params.card.location !== this.cardStateWhenEventCreated.location
+        ) {
+            this.invalid = true;
+        }
+
+        for (let event of this.childEvents) {
+            event.checkExecuteValidity();
+        }
+    }
+
+    executeHandler() {
+        if (this.params.card && this.params.card.createSnapshot && this.params.snapshotName) {
+            this[this.params.snapshotName] = this.params.card.createSnapshot();
+        }
+
+        for (let event of this.childEvents) {
+            event.executeHandler();
+        }
+    }
+
+    executePostHandler() {
+        for (let postHandler of this.postHandlers) {
+            postHandler(this);
+        }
+    }
+
+    onChildCancelled(event) {
+        const childEventEntry = [...this.childEventsMap.entries()].find(
+            ([, value]) => value === event
+        );
+        if (childEventEntry) {
+            this.childEventsMap.delete(childEventEntry[0]);
+        }
+        this.cancel();
+    }
+
+    getConcurrentEvents() {
+        return this.childEvents.reduce(
+            (concurrentEvents, event) => {
+                return concurrentEvents.concat(event.getConcurrentEvents());
+            },
+            [this]
+        );
+    }
+
+    getPrimaryEvents() {
+        return [this];
+    }
+
+    thenAttachEvent(event) {
+        this.attachedEvents.push(event);
+    }
+
+    thenExecute(func) {
+        this.postHandlers.push(func);
+        return this;
+    }
+
+    clearAttachedEvents() {
+        for (let event of this.attachedEvents) {
+            this.addChildEvent(event);
+        }
+        this.attachedEvents = [];
+    }
+
+    toString() {
+        if (this.childEvents.length !== 0) {
+            return `composite(${this.name} > ${this.childEvents.map((e) => e.toString()).join(' + ')})`;
+        }
+
+        return `composite(${this.name})`;
+    }
+}
+
+module.exports = CompositeEvent;

--- a/server/game/CompositeEvent.js
+++ b/server/game/CompositeEvent.js
@@ -81,6 +81,10 @@ class CompositeEvent {
         return [...this.childEventsMap.values()];
     }
 
+    get childEvent() {
+        return Object.fromEntries(this.childEventsMap.entries());
+    }
+
     get resolved() {
         return (
             !this.cancelled &&
@@ -102,10 +106,21 @@ class CompositeEvent {
         this.childEventsMap.set(name, event);
     }
 
-    replaceChildEvent(name, event) {
-        if (this.childEventsMap.has(name)) {
-            this.childEventsMap.get(name).parent = null;
-            this.setChildEvent(name, event);
+    replace(newEvent) {
+        if (this.parent) {
+            this.parent.replaceChildEvent(this, newEvent);
+        } else {
+            throw new Error('Cannot replace an event without a parent!');
+        }
+    }
+
+    replaceChildEvent(childEvent, newEvent) {
+        for (const [name, event] of this.childEventsMap.entries()) {
+            if (event == childEvent) {
+                childEvent.parent = null;
+                this.setChildEvent(name, newEvent);
+                return;
+            }
         }
     }
 
@@ -184,6 +199,7 @@ class CompositeEvent {
             ([, value]) => value === event
         );
         if (childEventEntry) {
+            childEventEntry[1].parent = null;
             this.childEventsMap.delete(childEventEntry[0]);
         }
         this.cancel();

--- a/server/game/CompositeEvent.js
+++ b/server/game/CompositeEvent.js
@@ -227,4 +227,4 @@ class CompositeEvent {
     }
 }
 
-module.exports = CompositeEvent;
+export default CompositeEvent;

--- a/server/game/GameActions/DeclareDefenders.js
+++ b/server/game/GameActions/DeclareDefenders.js
@@ -15,19 +15,17 @@ class DeclareDefenders extends GameAction {
         };
         return this.event('onDefendersDeclared', eventParams, (event) => {
             for (let card of event.cards) {
-                const defendEventParams = { card, challenge: event.challenge };
-                event.thenAttachEvent(
-                    this.event('onDeclaredAsDefender', defendEventParams, (defendEvent) => {
-                        if (
-                            !defendEvent.card.kneeled &&
-                            defendEvent.card.kneelsAsDefender(defendEvent.challenge.challengeType)
-                        ) {
-                            defendEvent.thenAttachEvent(
-                                KneelCard.createEvent({ card: defendEvent.card })
-                            );
-                        }
-                    })
-                );
+                const declareAsDefenderEvent = this.event('onDeclaredAsDefender', {
+                    card,
+                    challenge: event.challenge
+                });
+                if (!card.kneeled && card.kneelsAsDefender(event.challenge.challengeType)) {
+                    event.thenAttachEvent(
+                        this.atomic(declareAsDefenderEvent, KneelCard.createEvent({ card }))
+                    );
+                } else {
+                    event.thenAttachEvent(declareAsDefenderEvent);
+                }
             }
         });
     }

--- a/server/game/GameActions/GameAction.js
+++ b/server/game/GameActions/GameAction.js
@@ -1,4 +1,5 @@
 import AtomicEvent from '../AtomicEvent.js';
+import CompositeEvent from '../CompositeEvent.js';
 import Event from '../event.js';
 
 /**
@@ -58,6 +59,14 @@ class GameAction {
 
     event(name, params, handler) {
         return new Event(name, params, handler);
+    }
+
+    composite(name, params, ...events) {
+        const compositeEvent = new CompositeEvent(name, params);
+        for (const event of events) {
+            compositeEvent.addChildEvent(event);
+        }
+        return compositeEvent;
     }
 
     atomic(...events) {

--- a/server/game/GameActions/Kill.js
+++ b/server/game/GameActions/Kill.js
@@ -1,7 +1,7 @@
 import GameAction from './GameAction.js';
+import MoveCardEventGenerator from './MoveCardEventGenerator.js';
 import Message from '../Message.js';
 import LeavePlay from './LeavePlay.js';
-import PlaceCard from './PlaceCard.js';
 
 class Kill extends GameAction {
     constructor() {
@@ -13,30 +13,15 @@ class Kill extends GameAction {
     }
 
     canChangeGameState({ card }) {
-        return card.location === 'play area' && card.getType() === 'character';
+        return (
+            card.location === 'play area' &&
+            card.getType() === 'character' &&
+            LeavePlay.allow({ card })
+        );
     }
 
-    createEvent({ card, player, allowSave = true, isBurn = false }) {
-        const params = {
-            card,
-            player: player || card.controller,
-            allowSave,
-            isBurn,
-            snapshotName: 'cardStateWhenKilled'
-        };
-        const event = this.event('onCharacterKilled', params, (event) => {
-            event.thenAttachEvent(
-                PlaceCard.createEvent({
-                    card: event.card,
-                    player: event.player,
-                    location: 'dead pile'
-                })
-            );
-        });
-
-        const leavePlayEvent = LeavePlay.createEvent({ card, allowSave });
-
-        return this.atomic(event, leavePlayEvent);
+    createEvent({ card, allowSave, isBurn }) {
+        return MoveCardEventGenerator.createKillCharacterEvent({ card, allowSave, isBurn });
     }
 }
 

--- a/server/game/GameActions/MoveCardEventGenerator.js
+++ b/server/game/GameActions/MoveCardEventGenerator.js
@@ -68,10 +68,8 @@ class MoveCardEventGenerator {
             allowSave,
             orderable
         });
-        const discardEvent = this.compositeEvent('onCardDiscarded', params, {
-            name: 'placeCard',
-            event: placeCardEvent
-        });
+        const discardEvent = this.composite('onCardDiscarded', params);
+        discardEvent.setChildEvent('placeCard', placeCardEvent);
 
         return discardEvent;
     }
@@ -89,10 +87,8 @@ class MoveCardEventGenerator {
             location: 'dead pile',
             allowSave
         });
-        const killedEvent = this.compositeEvent('onCharacterKilled', params, {
-            name: 'placeCard',
-            event: placeCardEvent
-        });
+        const killedEvent = this.composite('onCharacterKilled', params);
+        killedEvent.setChildEvent('placeCard', placeCardEvent);
 
         return killedEvent;
     }
@@ -109,10 +105,8 @@ class MoveCardEventGenerator {
             player: card.controller,
             location: 'discard pile'
         });
-        const sacrificeEvent = this.compositeEvent('onSacrificed', params, {
-            name: 'placeCard',
-            event: placeCardEvent
-        });
+        const sacrificeEvent = this.composite('onSacrificed', params);
+        sacrificeEvent.setChildEvent('placeCard', placeCardEvent);
 
         return sacrificeEvent;
     }
@@ -130,10 +124,8 @@ class MoveCardEventGenerator {
             location: 'hand',
             allowSave
         });
-        const returnEvent = this.compositeEvent('onCardReturnedToHand', params, {
-            name: 'placeCard',
-            event: placeCardEvent
-        });
+        const returnEvent = this.composite('onCardReturnedToHand', params);
+        returnEvent.setChildEvent('placeCard', placeCardEvent);
 
         return returnEvent;
     }
@@ -154,10 +146,8 @@ class MoveCardEventGenerator {
             bottom,
             orderable
         });
-        const returnEvent = this.compositeEvent('onCardReturnedToDeck', params, {
-            name: 'placeCard',
-            event: placeCardEvent
-        });
+        const returnEvent = this.composite('onCardReturnedToDeck', params);
+        returnEvent.setChildEvent('placeCard', placeCardEvent);
 
         return returnEvent;
     }
@@ -176,10 +166,8 @@ class MoveCardEventGenerator {
             allowSave,
             location: 'shadows'
         });
-        const putEvent = this.compositeEvent('onCardPutIntoShadows', params, {
-            name: 'placeCard',
-            event: placeCardEvent
-        });
+        const putEvent = this.composite('onCardPutIntoShadows', params);
+        putEvent.setChildEvent('placeCard', placeCardEvent);
 
         return putEvent;
     }
@@ -259,14 +247,10 @@ class MoveCardEventGenerator {
         return new Event(name, params, handler);
     }
 
-    compositeEvent(name, params, ...events) {
+    composite(name, params, ...events) {
         const compositeEvent = new CompositeEvent(name, params);
         for (const event of events) {
-            if (event.name && event.event) {
-                compositeEvent.setChildEvent(event.name, event.event);
-            } else {
-                compositeEvent.addChildEvent(event);
-            }
+            compositeEvent.addChildEvent(event);
         }
         return compositeEvent;
     }

--- a/server/game/GameActions/PutIntoShadows.js
+++ b/server/game/GameActions/PutIntoShadows.js
@@ -1,6 +1,5 @@
 import GameAction from './GameAction.js';
 import Message from '../Message.js';
-import LeavePlay from './LeavePlay.js';
 import PlaceCard from './PlaceCard.js';
 
 class PutIntoShadows extends GameAction {
@@ -20,28 +19,26 @@ class PutIntoShadows extends GameAction {
         );
     }
 
-    createEvent({ player, card, allowSave = true, reason = 'ability' }) {
+    createEvent({
+        card,
+        allowSave = true,
+        reason = 'ability',
+        placeCardEvent = PlaceCard.createEvent({
+            card,
+            player: card.controller,
+            location: 'shadows'
+        })
+    }) {
         const params = {
             card,
-            player: player || card.controller,
             allowSave,
             snapshotName: 'cardStateWhenMoved',
-            reason
+            reason,
+            placeCardEvent
         };
 
-        const putIntoShadowsEvent = this.event('onCardPutIntoShadows', params, (event) => {
-            event.thenAttachEvent(
-                PlaceCard.createEvent({
-                    card: event.card,
-                    player: event.player,
-                    location: 'shadows'
-                })
-            );
-        });
-
-        if (card.location === 'play area') {
-            return this.atomic(putIntoShadowsEvent, LeavePlay.createEvent({ card, allowSave }));
-        }
+        const putIntoShadowsEvent = this.event('onCardPutIntoShadows', params);
+        putIntoShadowsEvent.addChildEvent(placeCardEvent);
 
         return putIntoShadowsEvent;
     }

--- a/server/game/GameActions/PutIntoShadows.js
+++ b/server/game/GameActions/PutIntoShadows.js
@@ -1,6 +1,6 @@
 import GameAction from './GameAction.js';
 import Message from '../Message.js';
-import PlaceCard from './PlaceCard.js';
+import MoveCardEventGenerator from './MoveCardEventGenerator.js';
 
 class PutIntoShadows extends GameAction {
     constructor() {
@@ -19,28 +19,8 @@ class PutIntoShadows extends GameAction {
         );
     }
 
-    createEvent({
-        card,
-        allowSave = true,
-        reason = 'ability',
-        placeCardEvent = PlaceCard.createEvent({
-            card,
-            player: card.controller,
-            location: 'shadows'
-        })
-    }) {
-        const params = {
-            card,
-            allowSave,
-            snapshotName: 'cardStateWhenMoved',
-            reason,
-            placeCardEvent
-        };
-
-        const putIntoShadowsEvent = this.event('onCardPutIntoShadows', params);
-        putIntoShadowsEvent.addChildEvent(placeCardEvent);
-
-        return putIntoShadowsEvent;
+    createEvent({ card, allowSave = true, reason = 'ability' }) {
+        return MoveCardEventGenerator.createPutIntoShadowsEvent({ card, allowSave, reason });
     }
 }
 

--- a/server/game/GameActions/ReturnCardToDeck.js
+++ b/server/game/GameActions/ReturnCardToDeck.js
@@ -1,7 +1,6 @@
 import Message from '../Message.js';
 import GameAction from './GameAction.js';
-import LeavePlay from './LeavePlay.js';
-import PlaceCard from './PlaceCard.js';
+import MoveCardEventGenerator from './MoveCardEventGenerator.js';
 
 class ReturnCardToDeck extends GameAction {
     constructor() {
@@ -16,36 +15,16 @@ class ReturnCardToDeck extends GameAction {
     }
 
     canChangeGameState({ card }) {
-        if (card.location === 'play area' && !LeavePlay.allow({ card })) {
-            return false;
-        }
-
         return card.location !== 'draw deck';
     }
 
     createEvent({ card, allowSave = true, bottom = false, orderable }) {
-        let params = {
-            card: card,
-            allowSave: allowSave,
-            bottom: bottom,
-            snapshotName: 'cardStateWhenMoved'
-        };
-        const returnEvent = this.event('onCardReturnedToDeck', params, (event) => {
-            event.thenAttachEvent(
-                PlaceCard.createEvent({
-                    card: event.card,
-                    location: 'draw deck',
-                    bottom,
-                    orderable
-                })
-            );
+        return MoveCardEventGenerator.createReturnCardToDeckEvent({
+            card,
+            allowSave,
+            bottom,
+            orderable
         });
-
-        if (card.location === 'play area') {
-            return this.atomic(returnEvent, LeavePlay.createEvent({ card, allowSave }));
-        }
-
-        return returnEvent;
     }
 }
 

--- a/server/game/GameActions/SacrificeCard.js
+++ b/server/game/GameActions/SacrificeCard.js
@@ -1,7 +1,7 @@
 import GameAction from './GameAction.js';
 import Message from '../Message.js';
+import MoveCardEventGenerator from './MoveCardEventGenerator.js';
 import LeavePlay from './LeavePlay.js';
-import PlaceCard from './PlaceCard.js';
 
 class SacrificeCard extends GameAction {
     constructor() {
@@ -17,17 +17,7 @@ class SacrificeCard extends GameAction {
     }
 
     createEvent({ card, player }) {
-        player = player || card.controller;
-        const params = {
-            card,
-            player,
-            snapshotName: 'cardStateWhenSacrificed'
-        };
-        const sacrificeEvent = this.event('onSacrificed', params, (event) => {
-            event.thenAttachEvent(PlaceCard.createEvent({ card: card, location: 'discard pile' }));
-        });
-        const leavePlayEvent = LeavePlay.createEvent({ card });
-        return this.atomic(sacrificeEvent, leavePlayEvent);
+        return MoveCardEventGenerator.createSacrificeCardEvent({ card, player });
     }
 }
 

--- a/server/game/NullEvent.js
+++ b/server/game/NullEvent.js
@@ -3,6 +3,7 @@ class NullEvent {
         this.attachedEvents = [];
         this.cancelled = false;
         this.invalid = false;
+        this.order = 0;
     }
 
     get resolved() {
@@ -30,6 +31,8 @@ class NullEvent {
     checkExecuteValidity() {
         this.invalid = true;
     }
+
+    createSnapshot() {}
 
     executeHandler() {}
 

--- a/server/game/NullEvent.js
+++ b/server/game/NullEvent.js
@@ -21,6 +21,10 @@ class NullEvent {
         this.cancelled = true;
     }
 
+    replace() {}
+
+    replaceChildEvent() {}
+
     replaceHandler() {}
 
     checkExecuteValidity() {

--- a/server/game/SimultaneousEvents.js
+++ b/server/game/SimultaneousEvents.js
@@ -3,6 +3,7 @@ class SimultaneousEvents {
     constructor() {
         this.childEvents = [];
         this.postHandlers = [];
+        this.order = 0;
     }
 
     get activeChildEvents() {
@@ -45,8 +46,13 @@ class SimultaneousEvents {
     }
 
     executeHandler() {
-        for (let event of this.activeChildEvents.sort((a, b) => a.order - b.order)) {
-            event.executeHandler();
+        this.queue = this.getConcurrentEvents().sort((a, b) => a.order - b.order);
+
+        for (let event of this.queue) {
+            event.createSnapshot();
+            if (!event.invalid) {
+                event.handler(event);
+            }
         }
     }
 

--- a/server/game/TriggeredAbilityContext.js
+++ b/server/game/TriggeredAbilityContext.js
@@ -14,6 +14,10 @@ class TriggeredAbilityContext extends AbilityContext {
     replaceHandler(handler) {
         this.event.replaceHandler(handler);
     }
+
+    replaceChildEvent(name, event) {
+        this.event.replaceChildEvent(name, event);
+    }
 }
 
 export default TriggeredAbilityContext;

--- a/server/game/TriggeredAbilityContext.js
+++ b/server/game/TriggeredAbilityContext.js
@@ -11,12 +11,12 @@ class TriggeredAbilityContext extends AbilityContext {
         this.event.cancel();
     }
 
-    replaceHandler(handler) {
-        this.event.replaceHandler(handler);
+    replaceEvent(newEvent) {
+        this.event.replace(newEvent);
     }
 
-    replaceChildEvent(name, event) {
-        this.event.replaceChildEvent(name, event);
+    replaceHandler(handler) {
+        this.event.replaceHandler(handler);
     }
 }
 

--- a/server/game/cards/01-Core/BenjenStark.js
+++ b/server/game/cards/01-Core/BenjenStark.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class BenjenStark extends DrawCard {
     setupCardAbilities(ability) {
@@ -11,20 +12,14 @@ class BenjenStark extends DrawCard {
                 onCharacterKilled: (event) =>
                     event.card === this && this.controller.canGainFactionPower()
             },
+            message:
+                '{player} uses {source} to gain 2 power for their faction and shuffles {source} back into their deck instead of placing him in their dead pile',
             handler: (context) => {
-                this.game.addMessage(
-                    '{0} uses {1} to gain 2 power for their faction and shuffles {1} back into their deck instead of placing it in their dead pile',
-                    this.controller,
-                    this
-                );
-
                 this.game.addPower(this.controller, 2);
-                context.replaceHandler(() => {
-                    context.event.cardStateWhenKilled = this.createSnapshot();
-                    this.controller.moveCard(this, 'draw deck', {}, () => {
-                        this.controller.shuffleDrawDeck();
-                    });
-                });
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.shuffleIntoDeck({ cards: [this], allowSave: false }).createEvent()
+                );
             }
         });
     }

--- a/server/game/cards/01-Core/BenjenStark.js
+++ b/server/game/cards/01-Core/BenjenStark.js
@@ -16,8 +16,7 @@ class BenjenStark extends DrawCard {
                 '{player} uses {source} to gain 2 power for their faction and shuffles {source} back into their deck instead of placing him in their dead pile',
             handler: (context) => {
                 this.game.addPower(this.controller, 2);
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.shuffleIntoDeck({ cards: [this], allowSave: false }).createEvent()
                 );
             }

--- a/server/game/cards/01-Core/HeadsOnSpikes.js
+++ b/server/game/cards/01-Core/HeadsOnSpikes.js
@@ -18,14 +18,13 @@ class HeadsOnSpikes extends PlotCard {
                             let powerMessage = '';
 
                             if (card.getType() === 'character') {
-                                event.replaceHandler(() => {
-                                    event.thenAttachEvent(
-                                        GameActions.placeCard({
-                                            card: event.card,
-                                            location: 'dead pile'
-                                        }).createEvent()
-                                    );
-                                });
+                                event.replaceChildEvent(
+                                    'placeCard',
+                                    GameActions.placeCard({
+                                        card: event.card,
+                                        location: 'dead pile'
+                                    }).createEvent()
+                                );
                                 const gainPower = GameActions.gainPower({
                                     amount: 2,
                                     card: context.player.faction

--- a/server/game/cards/01-Core/HeadsOnSpikes.js
+++ b/server/game/cards/01-Core/HeadsOnSpikes.js
@@ -18,8 +18,7 @@ class HeadsOnSpikes extends PlotCard {
                             let powerMessage = '';
 
                             if (card.getType() === 'character') {
-                                event.replaceChildEvent(
-                                    'placeCard',
+                                event.childEvent.placeCard.replace(
                                     GameActions.placeCard({
                                         card: event.card,
                                         location: 'dead pile'

--- a/server/game/cards/01-Core/SerDavosSeaworth.js
+++ b/server/game/cards/01-Core/SerDavosSeaworth.js
@@ -10,8 +10,7 @@ class SerDavosSeaworth extends DrawCard {
             message:
                 '{player} uses {source} to return {source} to their hand instead of placing him in their dead pile',
             handler: (context) => {
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.returnCardToHand({ card: this }).createEvent()
                 );
             }

--- a/server/game/cards/01-Core/SerDavosSeaworth.js
+++ b/server/game/cards/01-Core/SerDavosSeaworth.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class SerDavosSeaworth extends DrawCard {
     setupCardAbilities() {
@@ -6,17 +7,13 @@ class SerDavosSeaworth extends DrawCard {
             when: {
                 onCharacterKilled: (event) => event.card === this
             },
+            message:
+                '{player} uses {source} to return {source} to their hand instead of placing him in their dead pile',
             handler: (context) => {
-                this.game.addMessage(
-                    '{0} uses {1} to return {1} to their hand instead of their dead pile',
-                    this.controller,
-                    this,
-                    this
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.returnCardToHand({ card: this }).createEvent()
                 );
-                context.replaceHandler(() => {
-                    context.event.cardStateWhenKilled = this.createSnapshot();
-                    this.controller.moveCard(this, 'hand');
-                });
             }
         });
     }

--- a/server/game/cards/05-LoCR/TywinLannister.js
+++ b/server/game/cards/05-LoCR/TywinLannister.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class TywinLannister extends DrawCard {
     setupCardAbilities() {
@@ -11,10 +12,8 @@ class TywinLannister extends DrawCard {
                 args: { discardingPlayer: (context) => context.event.card.controller }
             },
             handler: (context) => {
-                this.eventObj = context.event;
-                this.discardingPlayer = this.eventObj.card.controller;
-
-                let top2Cards = this.discardingPlayer.drawDeck.slice(0, 2);
+                this.context = context;
+                let top2Cards = this.context.event.card.controller.drawDeck.slice(0, 2);
                 let buttons = top2Cards.map((card) => {
                     return { method: 'cardSelected', card: card, mapCard: true };
                 });
@@ -49,8 +48,18 @@ class TywinLannister extends DrawCard {
         );
     }
 
-    cardSelected(player, card) {
-        this.eventObj.card = card;
+    cardSelected(p, card) {
+        const currentEvent = this.context.event.childEvent.placeCard;
+        const { player, location, bottom, orderable } = currentEvent;
+        currentEvent.replace(
+            GameActions.placeCard({
+                card,
+                player,
+                location,
+                bottom,
+                orderable
+            }).createEvent()
+        );
         this.game.addMessage('{0} chooses to discard {1}', this.controller, card);
 
         return true;

--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class SpearsOfTheMerlingKing extends DrawCard {
     setupCardAbilities(ability) {
@@ -7,17 +8,15 @@ class SpearsOfTheMerlingKing extends DrawCard {
                 onCharacterKilled: (event) => event.card.controller === this.controller
             },
             cost: ability.costs.sacrificeSelf(),
+            message: {
+                format: '{player} sacrifices {source} to return {card} to their hand',
+                args: { card: (context) => context.event.card }
+            },
             handler: (context) => {
-                this.game.addMessage(
-                    '{0} sacrifices {1} to return {2} to their hand',
-                    context.player,
-                    this,
-                    context.event.card
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.returnCardToHand({ card: context.event.card }).createEvent()
                 );
-                context.replaceHandler(() => {
-                    context.event.cardStateWhenKilled = context.event.card.createSnapshot();
-                    this.controller.moveCard(context.event.card, 'hand');
-                });
             }
         });
     }

--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -13,8 +13,7 @@ class SpearsOfTheMerlingKing extends DrawCard {
                 args: { card: (context) => context.event.card }
             },
             handler: (context) => {
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.returnCardToHand({ card: context.event.card }).createEvent()
                 );
             }

--- a/server/game/cards/10-SoD/Missandei.js
+++ b/server/game/cards/10-SoD/Missandei.js
@@ -14,8 +14,7 @@ class Missandei extends DrawCard {
             message:
                 '{player} uses {source} to put {source} into play instead of placing her their discard pile',
             handler: (context) => {
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.putIntoPlay({ card: this }).createEvent()
                 );
             }

--- a/server/game/cards/10-SoD/Missandei.js
+++ b/server/game/cards/10-SoD/Missandei.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class Missandei extends DrawCard {
     setupCardAbilities() {
@@ -10,15 +11,13 @@ class Missandei extends DrawCard {
                     ['draw deck', 'hand'].includes(event.originalLocation)
             },
             location: ['hand', 'draw deck'],
+            message:
+                '{player} uses {source} to put {source} into play instead of placing her their discard pile',
             handler: (context) => {
-                this.game.addMessage(
-                    '{0} uses {1} to put {1} into play instead of placing in their discard pile',
-                    this.controller,
-                    this
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.putIntoPlay({ card: this }).createEvent()
                 );
-                context.event.replaceHandler(() => {
-                    this.controller.putIntoPlay(this);
-                });
             }
         });
     }

--- a/server/game/cards/13.6-LMHR/SerJorahMormont.js
+++ b/server/game/cards/13.6-LMHR/SerJorahMormont.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class SerJorahMormont extends DrawCard {
     setupCardAbilities() {
@@ -7,15 +8,13 @@ class SerJorahMormont extends DrawCard {
                 onCardDiscarded: (event) => event.card === this && event.originalLocation === 'hand'
             },
             location: ['hand'],
+            message:
+                '{player} uses {source} to put {source} into shadows instead of placing him in their discard pile',
             handler: (context) => {
-                this.game.addMessage(
-                    '{0} uses {1} to put {1} into shadows instead of placing it in their discard pile',
-                    this.controller,
-                    this
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.putIntoShadows({ card: this }).createEvent()
                 );
-                context.event.replaceHandler(() => {
-                    this.controller.putIntoShadows(this);
-                });
             }
         });
     }

--- a/server/game/cards/13.6-LMHR/SerJorahMormont.js
+++ b/server/game/cards/13.6-LMHR/SerJorahMormont.js
@@ -11,8 +11,7 @@ class SerJorahMormont extends DrawCard {
             message:
                 '{player} uses {source} to put {source} into shadows instead of placing him in their discard pile',
             handler: (context) => {
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.putIntoShadows({ card: this }).createEvent()
                 );
             }

--- a/server/game/cards/23-AHaH/WingedKnight.js
+++ b/server/game/cards/23-AHaH/WingedKnight.js
@@ -13,8 +13,7 @@ class WingedKnight extends DrawCard {
                 args: { character: (context) => context.event.card }
             },
             handler: (context) => {
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.removeFromGame({ card: context.event.card }).createEvent()
                 );
             }

--- a/server/game/cards/23-AHaH/WingedKnight.js
+++ b/server/game/cards/23-AHaH/WingedKnight.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class WingedKnight extends DrawCard {
     setupCardAbilities(ability) {
@@ -12,10 +13,10 @@ class WingedKnight extends DrawCard {
                 args: { character: (context) => context.event.card }
             },
             handler: (context) => {
-                context.replaceHandler(() => {
-                    context.event.cardStateWhenKilled = context.event.card.createSnapshot();
-                    this.controller.moveCard(context.event.card, 'out of game');
-                });
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.removeFromGame({ card: context.event.card }).createEvent()
+                );
             }
         });
     }

--- a/server/game/cards/24-TSoW/CaggoCorpsekiller.js
+++ b/server/game/cards/24-TSoW/CaggoCorpsekiller.js
@@ -20,15 +20,13 @@ class CaggoCorpsekiller extends DrawCard {
                 }
             },
             handler: (context) => {
-                context.event.replaceHandler(() => {
-                    this.game.resolveGameAction(
-                        GameActions.placeCard((context) => ({
-                            card: context.event.card,
-                            location: 'dead pile'
-                        })),
-                        context
-                    );
-                });
+                context.replaceChildEvent(
+                    'placeCard',
+                    GameActions.placeCard({
+                        card: context.event.card,
+                        location: 'dead pile'
+                    }).createEvent()
+                );
             }
         });
     }

--- a/server/game/cards/24-TSoW/CaggoCorpsekiller.js
+++ b/server/game/cards/24-TSoW/CaggoCorpsekiller.js
@@ -20,8 +20,7 @@ class CaggoCorpsekiller extends DrawCard {
                 }
             },
             handler: (context) => {
-                context.replaceChildEvent(
-                    'placeCard',
+                context.event.childEvent.placeCard.replace(
                     GameActions.placeCard({
                         card: context.event.card,
                         location: 'dead pile'

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -85,6 +85,24 @@ class Event {
         }
     }
 
+    replace(newEvent) {
+        if (this.parent) {
+            this.parent.replaceChildEvent(this, newEvent);
+        } else {
+            throw new Error('Cannot replace an event without a parent!');
+        }
+    }
+
+    replaceChildEvent(childEvent, newEvent) {
+        const index = this.childEvents.findIndex((e) => e == childEvent);
+
+        if (index >= 0) {
+            childEvent.parent = null;
+            this.childEvents.splice(index, 1);
+            this.addChildEvent(newEvent);
+        }
+    }
+
     replaceHandler(handler) {
         this.handler = handler;
     }

--- a/server/game/gamesteps/InterruptWindowOrder.js
+++ b/server/game/gamesteps/InterruptWindowOrder.js
@@ -75,6 +75,9 @@ const OrderableEventFunc = {
 
 const InterruptWindowOrder = {
     orderConcurrentEvents: function (game, event) {
+        if (game.disableOrderPrompt) {
+            return;
+        }
         // Prompt for any simultaneous events which can be ordered
         for (const eventName of Object.keys(OrderableEventFunc)) {
             const orderableEvents = event

--- a/server/game/gamesteps/InterruptWindowOrder.js
+++ b/server/game/gamesteps/InterruptWindowOrder.js
@@ -60,7 +60,7 @@ const OrderableEventFunc = {
                         const orderedCards = selectedCards.reverse();
                         for (let order in orderedCards) {
                             const event = cardsToEvents.get(orderedCards[order]);
-                            event.order = order;
+                            event.order = parseInt(order) + 1; // Start order index at 1
                         }
                         return true;
                     },

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -40,6 +40,7 @@ class GameFlowWrapper {
         this.game.started = true;
         this.game.disableWonPrompt = true;
         this.game.disableRevealAcknowledgement = true;
+        this.game.disableOrderPrompt = true;
 
         this.allPlayers = this.game
             .getPlayers()

--- a/test/server/AtomicEvent.spec.js
+++ b/test/server/AtomicEvent.spec.js
@@ -5,14 +5,16 @@ describe('AtomicEvent', function () {
         this.childEventSpy1 = jasmine.createSpyObj('childEvent1', [
             'cancel',
             'emitTo',
-            'executeHandler',
-            'getConcurrentEvents'
+            'handler',
+            'getConcurrentEvents',
+            'createSnapshot'
         ]);
         this.childEventSpy2 = jasmine.createSpyObj('childEvent2', [
             'cancel',
             'emitTo',
-            'executeHandler',
-            'getConcurrentEvents'
+            'handler',
+            'getConcurrentEvents',
+            'createSnapshot'
         ]);
         this.event = new AtomicEvent();
         this.event.addChildEvent(this.childEventSpy1);
@@ -33,12 +35,14 @@ describe('AtomicEvent', function () {
 
     describe('executeHandler', function () {
         beforeEach(function () {
+            this.childEventSpy1.getConcurrentEvents.and.returnValue([this.childEventSpy1]);
+            this.childEventSpy2.getConcurrentEvents.and.returnValue([this.childEventSpy2]);
             this.event.executeHandler();
         });
 
-        it('should call executeHandler on all children', function () {
-            expect(this.childEventSpy1.executeHandler).toHaveBeenCalled();
-            expect(this.childEventSpy2.executeHandler).toHaveBeenCalled();
+        it('should call handler on all children', function () {
+            expect(this.childEventSpy1.handler).toHaveBeenCalled();
+            expect(this.childEventSpy2.handler).toHaveBeenCalled();
         });
     });
 

--- a/test/server/GameActions/Kill.spec.js
+++ b/test/server/GameActions/Kill.spec.js
@@ -3,8 +3,7 @@ import Kill from '../../../server/game/GameActions/Kill.js';
 describe('Kill', function () {
     beforeEach(function () {
         this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction', 'getType']);
-        this.playerSpy = jasmine.createSpyObj('player', ['moveCard']);
-        this.props = { card: this.cardSpy, player: this.playerSpy };
+        this.props = { card: this.cardSpy };
     });
 
     describe('allow()', function () {
@@ -53,36 +52,36 @@ describe('Kill', function () {
 
     describe('createEvent()', function () {
         beforeEach(function () {
-            const events = Kill.createEvent(this.props).getConcurrentEvents();
-            this.killEvent = events.find((event) => event.name === 'onCharacterKilled');
-            this.leaveEvent = events.find((event) => event.name === 'onCardLeftPlay');
+            this.cardSpy.location = 'play area';
+            this.concurrentEvents = Kill.createEvent(this.props).getConcurrentEvents();
         });
 
-        it('creates a onCharacterKilled event', function () {
-            expect(this.killEvent.name).toBe('onCharacterKilled');
-            expect(this.killEvent.card).toBe(this.cardSpy);
-            expect(this.killEvent.player).toBe(this.playerSpy);
-            expect(this.killEvent.allowSave).toBe(true);
-            expect(this.killEvent.isBurn).toBe(false);
-            expect(this.killEvent.snapshotName).toBe('cardStateWhenKilled');
+        it('creates an onCharacterKilled event', function () {
+            const eventObj = {
+                name: 'onCharacterKilled',
+                card: this.cardSpy,
+                allowSave: true,
+                isBurn: false,
+                snapshotName: 'cardStateWhenKilled'
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
 
-        it('creates an onCardLeftPlay event', function () {
-            expect(this.leaveEvent.name).toBe('onCardLeftPlay');
-            expect(this.leaveEvent.card).toBe(this.cardSpy);
+        it('creates a concurrent onCardPlaced event', function () {
+            const eventObj = {
+                name: 'onCardPlaced',
+                card: this.cardSpy,
+                location: 'dead pile'
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
 
-        describe('the event handler', function () {
-            beforeEach(function () {
-                this.killEvent.executeHandler();
-            });
-
-            it('moves the card to the dead pile', function () {
-                const placeEvent = this.killEvent.attachedEvents[0];
-                expect(placeEvent.name).toBe('onCardPlaced');
-                expect(placeEvent.card).toBe(this.cardSpy);
-                expect(placeEvent.location).toBe('dead pile');
-            });
+        it('creates a concurrent onCardLeftPlay event', function () {
+            const eventObj = {
+                name: 'onCardLeftPlay',
+                card: this.cardSpy
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
     });
 });

--- a/test/server/GameActions/PlaceCard.spec.js
+++ b/test/server/GameActions/PlaceCard.spec.js
@@ -102,13 +102,17 @@ describe('PlaceCard', function () {
     xdescribe('createEvent()', function () {
         beforeEach(function () {
             this.event = PlaceCard.createEvent(this.props);
+            this.concurrentEvents = this.event.getConcurrentEvents();
         });
 
-        it('creates a onCardLeftPlay event', function () {
-            expect(this.event.name).toBe('onCardPlaced');
-            expect(this.event.card).toBe(this.cardSpy);
-            expect(this.event.location).toBe('discard pile');
-            expect(this.event.bottom).toBe(false);
+        it('creates an onCardPlaced event', function () {
+            const eventObj = {
+                name: 'onCardPlaced',
+                card: this.cardSpy,
+                location: 'discard pile',
+                bottom: false
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
 
         describe('the event handler', function () {

--- a/test/server/GameActions/SacrificeCard.spec.js
+++ b/test/server/GameActions/SacrificeCard.spec.js
@@ -2,7 +2,7 @@ import SacrificeCard from '../../../server/game/GameActions/SacrificeCard.js';
 
 describe('SacrificeCard', function () {
     beforeEach(function () {
-        this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction', 'createSnapshot']);
+        this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction']);
         this.props = { card: this.cardSpy };
     });
 
@@ -55,40 +55,35 @@ describe('SacrificeCard', function () {
 
     describe('createEvent()', function () {
         beforeEach(function () {
-            this.events = SacrificeCard.createEvent(this.props).getConcurrentEvents();
+            this.cardSpy.location = 'play area';
+            this.concurrentEvents = SacrificeCard.createEvent(this.props).getConcurrentEvents();
         });
 
-        it('creates a onSacrificed event', function () {
-            const event = this.events.find((e) => e.name === 'onSacrificed');
-            expect(event).toBeDefined();
-            expect(event.card).toBe(this.cardSpy);
-            expect(event.player).toBe(this.player1Object);
+        it('creates an onSacrificed event', function () {
+            const eventObj = {
+                name: 'onSacrificed',
+                card: this.cardSpy,
+                player: this.player1Object,
+                snapshotName: 'cardStateWhenSacrificed'
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
 
-        it('creates an onCardLeftPlay event', function () {
-            const event = this.events.find((e) => e.name === 'onCardLeftPlay');
-            expect(event).toBeDefined();
-            expect(event.card).toBe(this.cardSpy);
-            expect(event.allowSave).toBe(false);
+        it('creates a concurrent onCardPlaced event', function () {
+            const eventObj = {
+                name: 'onCardPlaced',
+                card: this.cardSpy,
+                location: 'discard pile'
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
 
-        describe('the event handler', function () {
-            beforeEach(function () {
-                this.event = this.events.find((e) => e.name === 'onSacrificed');
-                this.cardSpy.createSnapshot.and.returnValue('snapshot');
-                this.event.executeHandler();
-            });
-
-            it('sets the card snapshot on the event', function () {
-                expect(this.event.cardStateWhenSacrificed).toBe('snapshot');
-            });
-
-            it('places the card in the discard pile', function () {
-                const placeEvent = this.event.attachedEvents[0];
-                expect(placeEvent.name).toBe('onCardPlaced');
-                expect(placeEvent.card).toBe(this.cardSpy);
-                expect(placeEvent.location).toBe('discard pile');
-            });
+        it('creates a concurrent onCardLeftPlay event', function () {
+            const eventObj = {
+                name: 'onCardLeftPlay',
+                card: this.cardSpy
+            };
+            expect(this.concurrentEvents).toContain(jasmine.objectContaining(eventObj));
         });
     });
 });

--- a/test/server/SimultaneousEvents.spec.js
+++ b/test/server/SimultaneousEvents.spec.js
@@ -35,16 +35,16 @@ describe('SimultaneousEvents', function () {
 
     describe('executeHandler', function () {
         beforeEach(function () {
-            spyOn(this.childEvent1, 'executeHandler');
-            spyOn(this.childEvent2, 'executeHandler');
-            spyOn(this.childEvent3, 'executeHandler');
+            spyOn(this.childEvent1, 'handler');
+            spyOn(this.childEvent2, 'handler');
+            spyOn(this.childEvent3, 'handler');
             this.event.executeHandler();
         });
 
-        it('should call executeHandler on all children', function () {
-            expect(this.childEvent1.executeHandler).toHaveBeenCalled();
-            expect(this.childEvent2.executeHandler).not.toHaveBeenCalled();
-            expect(this.childEvent3.executeHandler).toHaveBeenCalled();
+        it('should call handler on all children', function () {
+            expect(this.childEvent1.handler).toHaveBeenCalled();
+            expect(this.childEvent2.handler).not.toHaveBeenCalled();
+            expect(this.childEvent3.handler).toHaveBeenCalled();
         });
     });
 

--- a/test/server/cards/01-Core/Varys.spec.js
+++ b/test/server/cards/01-Core/Varys.spec.js
@@ -33,8 +33,6 @@ describe('Varys (Core)', function () {
                 this.completeChallengesPhase();
 
                 this.player1.triggerAbility('Varys');
-                // Skip order prompt
-                this.player2.clickPrompt('Done');
             });
 
             it('should cause all cards to be discarded simultaneously', function () {

--- a/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
+++ b/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
@@ -65,6 +65,9 @@ describe('Valar Morghulis', function () {
 
         describe('when multiple characters die', function () {
             beforeEach(function () {
+                // Enable ordering prompt
+                this.game.disableOrderPrompt = false;
+
                 const deck = this.buildDeck('tyrell', [
                     'Valar Morghulis',
                     'A Noble Cause',

--- a/test/server/cards/05-LoCR/CerseiLannister.spec.js
+++ b/test/server/cards/05-LoCR/CerseiLannister.spec.js
@@ -59,8 +59,6 @@ describe('Cersei Lannister (LoCR)', function () {
                     this.unopposedChallenge(this.player1, 'Intrigue', this.cersei);
 
                     this.player1.clickPrompt('Apply Claim');
-                    // Skip order prompt
-                    this.player2.clickPrompt('Done');
                 });
 
                 it('should not prompt Cersei to gain power twice', function () {

--- a/test/server/cards/08.1-TAK/ValarDohaeris.spec.js
+++ b/test/server/cards/08.1-TAK/ValarDohaeris.spec.js
@@ -85,14 +85,6 @@ describe('Valar Dohaeris', function () {
                 // Select no cards for Dohaeris
                 this.player2.clickPrompt('Done');
                 this.player1.clickPrompt('Done');
-
-                // Don't choose order for bottom for Dohaeris
-                this.player2.clickPrompt('Done');
-                this.player1.clickPrompt('Done');
-
-                // Don't choose order for attachments to discard pile
-                this.player2.clickPrompt('Done');
-                this.player1.clickPrompt('Done');
             });
 
             it('puts all attachments in discard before triggering archivist', function () {

--- a/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
+++ b/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
@@ -75,9 +75,6 @@ describe('Emissary of the Hightower', function () {
                 this.player2.clickCard('Varys', 'hand');
                 this.player2.clickPrompt('Done');
 
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
-
                 this.player1.clickPrompt('Apply Claim');
                 this.completeChallengesPhase();
             });

--- a/test/server/cards/09-HoT/HiddenThorns.spec.js
+++ b/test/server/cards/09-HoT/HiddenThorns.spec.js
@@ -42,9 +42,6 @@ describe('Hidden Thorns', function () {
                 this.player2.clickCard(this.card1);
                 this.player2.clickCard(this.card2);
                 this.player2.clickPrompt('Done');
-
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
             });
 
             it('should discard the cards', function () {
@@ -67,9 +64,6 @@ describe('Hidden Thorns', function () {
 
                 this.player2.clickCard(this.card1);
                 this.player2.clickCard(this.card2);
-                this.player2.clickPrompt('Done');
-
-                // Skip order of discarded cards
                 this.player2.clickPrompt('Done');
             });
 

--- a/test/server/cards/10-SoD/FalsePlans.spec.js
+++ b/test/server/cards/10-SoD/FalsePlans.spec.js
@@ -52,9 +52,6 @@ describe('False Plans', function () {
                 this.player2.clickPrompt('Apply Claim');
 
                 this.player1.triggerAbility('False Plans');
-
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
             });
 
             it('should discard 2 cards from the opponent', function () {

--- a/test/server/cards/11.2-TMoW/Meereen.spec.js
+++ b/test/server/cards/11.2-TMoW/Meereen.spec.js
@@ -45,10 +45,6 @@ describe('Meereen', function () {
                 this.player1.clickMenu(this.meereen, 'Place hand facedown and draw 3');
 
                 this.completeMarshalPhase();
-
-                // Skip order of discarded cards (for both instances of the ability)
-                this.player1.clickPrompt('Done');
-                this.player1.clickPrompt('Done');
             });
 
             it('should discard all of the cards placed under Meereen', function () {
@@ -133,17 +129,11 @@ describe('Meereen', function () {
                 this.player2.triggerAbility(this.dagmer);
                 this.player2.clickCard(this.meereen);
 
-                // Skip order of discarded cards
-                this.player1.clickPrompt('Done');
-
                 // Stand Meereen and place player 2 cards under Meereen
                 this.player2.clickCard(this.meereen);
                 this.player2.clickMenu(this.meereen, 'Place hand facedown and draw 3');
 
                 this.completeChallengesPhase();
-
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
             });
 
             it('should return the owners cards to hand', function () {

--- a/test/server/cards/11.3-SoKL/ValyriansCrew.spec.js
+++ b/test/server/cards/11.3-SoKL/ValyriansCrew.spec.js
@@ -71,8 +71,6 @@ describe("Valyrian's Crew", function () {
                     this.completeChallengesPhase();
 
                     this.player2.discardToReserve();
-                    // Skip order of discarded cards
-                    this.player2.clickPrompt('Done');
 
                     this.player1.selectPlot('A Noble Cause');
                     this.player2.selectPlot('Blood of the Dragon');
@@ -103,8 +101,6 @@ describe("Valyrian's Crew", function () {
                     this.completeChallengesPhase();
 
                     this.player2.discardToReserve();
-                    // Skip order of discarded cards
-                    this.player2.clickPrompt('Done');
 
                     this.player1.selectPlot('A Noble Cause');
                     this.player2.selectPlot('A Noble Cause');
@@ -150,8 +146,6 @@ describe("Valyrian's Crew", function () {
 
                 this.completeChallengesPhase();
                 this.player2.discardToReserve();
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
 
                 this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('A Noble Cause');

--- a/test/server/cards/17.1-R/Meereen.spec.js
+++ b/test/server/cards/17.1-R/Meereen.spec.js
@@ -55,10 +55,6 @@ describe('Meereen', function () {
                 expect(this.viserion.location).toBe('discard pile');
 
                 this.completeMarshalPhase();
-
-                // Skip order of discarded cards (for both instances of the ability)
-                this.player1.clickPrompt('Done');
-                this.player1.clickPrompt('Done');
             });
 
             it('should discard all of the cards placed under Meereen', function () {
@@ -154,18 +150,12 @@ describe('Meereen', function () {
                 this.player2.triggerAbility(this.dagmer);
                 this.player2.clickCard(this.meereen);
 
-                // Skip order of discarded cards
-                this.player1.clickPrompt('Done');
-
                 // Stand Meereen and place player 2 cards under Meereen
                 this.player2.clickCard(this.meereen);
                 this.player2.clickMenu(this.meereen, 'Place hand facedown and draw 3');
                 this.player2.clickCard(this.viserion2);
 
                 this.completeChallengesPhase();
-
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
             });
 
             it('should return the owners cards to hand', function () {

--- a/test/server/cards/20-HMW/AMummersFarce.spec.js
+++ b/test/server/cards/20-HMW/AMummersFarce.spec.js
@@ -73,9 +73,6 @@ describe('A Mummer´s Farce', function () {
                 expect(this.jinglebell.getStrength()).toBe(4);
                 this.player1.clickCard(this.blessed);
                 this.player1.clickCard(this.jinglebell);
-
-                // Skip order of discarded cards
-                this.player1.clickPrompt('Done');
             });
 
             it('the weapon attachments should be discarded because they are invalidly attached', function () {

--- a/test/server/cards/22-BtB/TheMadKingsCommand.spec.js
+++ b/test/server/cards/22-BtB/TheMadKingsCommand.spec.js
@@ -43,10 +43,6 @@ describe("The Mad King's Command", function () {
                 this.player2.clickPrompt('Done');
                 // P2 Choosing cards in hand/shadow
                 this.player2.clickPrompt('Done');
-
-                // Skip placement order
-                this.player1.clickPrompt('Done');
-                this.player2.clickPrompt('Done');
             });
 
             it("should return that attachment to it's owners hand", function () {
@@ -73,10 +69,6 @@ describe("The Mad King's Command", function () {
                 // Trigger Lemore on Aegon
                 this.player1.clickCard(this.lemore);
                 this.player1.clickCard(this.aegon);
-
-                // Skip placement order
-                this.player1.clickPrompt('Done');
-                this.player2.clickPrompt('Done');
             });
 
             it('should not be moved to deck', function () {

--- a/test/server/integration/AbilityRequirements.spec.js
+++ b/test/server/integration/AbilityRequirements.spec.js
@@ -98,8 +98,6 @@ describe('ability requirements', function () {
 
                 this.player1.triggerAbility('Without His Beard');
                 this.player1.clickPrompt('3');
-                // Skip order of discarded cards
-                this.player2.clickPrompt('Done');
                 this.player1.triggerAbility('Maester at the Rock');
                 this.player1.triggerAbility('Lannisport');
 

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -379,8 +379,6 @@ describe('effects', function () {
                 expect(this.character.tokens[Tokens.poison]).toBeTruthy();
 
                 this.player2.clickPrompt('Apply Claim');
-                // Skip order of discarded cards
-                this.player1.clickPrompt('Done');
 
                 this.player2.clickPrompt('Done');
 


### PR DESCRIPTION
Extending from various bugs noticed with the card ordering update (https://github.com/throneteki/throneteki/issues/3443), and discussions with @ystros about improving how game events (not the cardtype) are handled - this rework aims to properly group simultaneous actions in the same windows, and provide a more "predefined" structure for ability events.

- Adds a new event type, `CompositeEvent`, which is a mix of Atomic & regular Event's:
  - Each inner child event is named, making replacement easier
  - Cancelling any child will cancel the whole event
  - Parameters of children are shared within composite event
  - Best example is `onCharacterKilled` consisting (and sharing properties with) `onCardPlaced` & `onLeavePlay`. It also allows cards like core Benjen Stark to simply replace the `cardPlaced` child event with something different for a simple (and trackable) replacement.

*TODO: Add more detailed description*