### PR TITLE
Fixing eslint for jasmine files which use global "integration" function

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,8 @@ export default [
             globals: {
                 ...globals.browser,
                 ...globals.node,
-                ...globals.jasmine
+                ...globals.jasmine,
+                integration: 'readable'
             },
             ecmaVersion: 'latest',
             sourceType: 'module',


### PR DESCRIPTION
Found a way to fix eslint on global "integration" function for jasmine tests; simply needed to add to globals list