### PR TITLE
Release TTS + Related QoL Updates

### DIFF
--- a/client/Components/GameBoard/AltCard.jsx
+++ b/client/Components/GameBoard/AltCard.jsx
@@ -12,6 +12,7 @@ class AltCard extends React.Component {
                 if (present) {
                     icons.push(
                         <div
+                            key={icon}
                             className={`challenge-icon thronesicon thronesicon-${icon} with-background`}
                         />
                     );

--- a/client/Components/GameBoard/AltCard.jsx
+++ b/client/Components/GameBoard/AltCard.jsx
@@ -17,7 +17,7 @@ class AltCard extends React.Component {
                         />
                     );
                 } else {
-                    icons.push(<div className='challenge-icon' />);
+                    icons.push(<div key={icon} className='challenge-icon' />);
                 }
             }
         }

--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -73,12 +73,6 @@ class InnerCard extends React.Component {
     }
 
     isAllowedMenuSource() {
-        // Explicitly disable menus on agendas when they're selectable during a
-        // card select prompt.
-        if (this.props.source === 'agenda' && this.props.card.selectable) {
-            return false;
-        }
-
         return (
             this.props.source === 'play area' ||
             this.props.source === 'agenda' ||
@@ -90,11 +84,7 @@ class InnerCard extends React.Component {
         event.preventDefault();
         event.stopPropagation();
 
-        if (
-            this.isAllowedMenuSource() &&
-            this.props.card.menu &&
-            this.props.card.menu.length !== 0
-        ) {
+        if (this.showMenu()) {
             this.setState({ showMenu: !this.state.showMenu });
 
             return;
@@ -279,15 +269,19 @@ class InnerCard extends React.Component {
     }
 
     showMenu() {
-        if (!this.isAllowedMenuSource()) {
-            return false;
+        return (
+            this.getMenu().some((item) => item.command !== 'click') && this.isAllowedMenuSource()
+        );
+    }
+
+    getMenu() {
+        let menu = this.props.menu || [];
+
+        if (this.props.card.menu) {
+            menu = menu.concat(this.props.card.menu);
         }
 
-        if (!this.props.card.menu || !this.state.showMenu) {
-            return false;
-        }
-
-        return true;
+        return menu;
     }
 
     isFacedown() {
@@ -372,8 +366,8 @@ class InnerCard extends React.Component {
                     ) : null}
                     {!this.isFacedown() ? this.getAlertStatus() : null}
                 </div>
-                {this.showMenu() ? (
-                    <CardMenu menu={this.props.card.menu} onMenuItemClick={this.onMenuItemClick} />
+                {this.state.showMenu ? (
+                    <CardMenu menu={this.getMenu()} onMenuItemClick={this.onMenuItemClick} />
                 ) : null}
             </div>
         );
@@ -489,6 +483,7 @@ InnerCard.propTypes = {
     dragOffset: PropTypes.object,
     hideTokens: PropTypes.bool,
     isDragging: PropTypes.bool,
+    menu: PropTypes.array,
     onClick: PropTypes.func,
     onMenuItemClick: PropTypes.func,
     onMouseOut: PropTypes.func,

--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -237,7 +237,7 @@ class InnerCard extends React.Component {
         // are being placed underneath the current card. In the future there may
         // be other types of cards in this array and it should be filtered.
         let underneathCards = this.props.card.childCards;
-        if (!underneathCards || underneathCards.length === 0) {
+        if (!underneathCards || underneathCards.length === 0 || this.props.card.type === 'agenda') {
             return;
         }
 
@@ -508,7 +508,6 @@ InnerCard.propTypes = {
         'agenda',
         'faction',
         'additional',
-        'conclave',
         'shadows',
         'full deck',
         'rookery',

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -236,7 +236,7 @@ class CardPile extends React.Component {
         let menu;
         // Note "Open/Close Popup" item will never be available for CardPiles in locations that use select in non-triggerable ways (eg. click to force stand or kneel)
         // For example, if CardPile is ever used in play area, it will need to know when "clicking" on it is a valid option to do something
-        if(!this.props.disablePopup && this.props.topCard && this.props.topCard.selectable) {
+        if (!this.props.disablePopup && this.props.topCard && this.props.topCard.selectable) {
             menu = [{ showPopup: true, text: `${this.state.showPopup ? 'Close' : 'Open'} Popup` }];
         }
 

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -300,7 +300,7 @@ CardPile.propTypes = {
         'agenda',
         'faction',
         'additional',
-        'conclave',
+        'agenda',
         'shadows'
     ]).isRequired,
     title: PropTypes.string,

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -19,6 +19,7 @@ class CardPile extends React.Component {
         this.onCollectionClick = this.onCollectionClick.bind(this);
         this.onTopCardClick = this.onTopCardClick.bind(this);
         this.onCloseClick = this.onCloseClick.bind(this);
+        this.onMenuItemClick = this.onMenuItemClick.bind(this);
     }
 
     componentWillReceiveProps(props) {
@@ -65,6 +66,11 @@ class CardPile extends React.Component {
 
         if (menuItem.handler) {
             menuItem.handler();
+        }
+
+        if (this.props.onMenuItemClick) {
+            this.props.onMenuItemClick(this.props.topCard, menuItem);
+            this.setState({ showMenu: !this.state.showMenu });
         }
     }
 
@@ -207,24 +213,6 @@ class CardPile extends React.Component {
         return popup;
     }
 
-    getMenu() {
-        let menuIndex = 0;
-
-        let menu = this.props.menu.map((item) => {
-            return (
-                <div
-                    key={(menuIndex++).toString()}
-                    className='menu-item'
-                    onClick={this.onMenuItemClick.bind(this, item)}
-                >
-                    {item.text}
-                </div>
-            );
-        });
-
-        return <div className='panel menu'>{menu}</div>;
-    }
-
     render() {
         let className = classNames('panel', 'card-pile', this.props.className, {
             [this.props.size]: this.props.size !== 'normal',
@@ -245,6 +233,13 @@ class CardPile extends React.Component {
             topCard = { facedown: true };
         }
 
+        let menu;
+        // Note "Open/Close Popup" item will never be available for CardPiles in locations that use select in non-triggerable ways (eg. click to force stand or kneel)
+        // For example, if CardPile is ever used in play area, it will need to know when "clicking" on it is a valid option to do something
+        if(!this.props.disablePopup && this.props.topCard && this.props.topCard.selectable) {
+            menu = [{ showPopup: true, text: `${this.state.showPopup ? 'Close' : 'Open'} Popup` }];
+        }
+
         return (
             <div className={className} onClick={this.onCollectionClick}>
                 <div className='panel-header'>{headerText}</div>
@@ -255,6 +250,7 @@ class CardPile extends React.Component {
                         onMouseOver={this.props.onMouseOver}
                         onMouseOut={this.props.onMouseOut}
                         disableMouseOver={this.props.hiddenTopCard}
+                        menu={menu}
                         onClick={this.onTopCardClick}
                         onMenuItemClick={this.props.onMenuItemClick}
                         orientation={cardOrientation}
@@ -263,7 +259,6 @@ class CardPile extends React.Component {
                 ) : (
                     <div className='card-placeholder' />
                 )}
-                {this.state.showMenu ? this.getMenu() : null}
                 {this.getPopup()}
             </div>
         );
@@ -279,7 +274,6 @@ CardPile.propTypes = {
     disableMouseOver: PropTypes.bool,
     disablePopup: PropTypes.bool,
     hiddenTopCard: PropTypes.bool,
-    menu: PropTypes.array,
     onCardClick: PropTypes.func,
     onDragDrop: PropTypes.func,
     onMenuItemClick: PropTypes.func,

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -137,7 +137,11 @@ class CardPile extends React.Component {
             size: this.props.size,
             source: this.props.source
         };
-
+        if (this.props.showCards) {
+            for (const card of this.props.cards) {
+                card.facedown = false;
+            }
+        }
         if (this.props.cards && this.props.cards.some((card) => card.group)) {
             const cardGroup = this.props.cards.reduce((grouping, card) => {
                 (grouping[card.group] = grouping[card.group] || []).push(card);
@@ -286,6 +290,7 @@ CardPile.propTypes = {
     orientation: PropTypes.string,
     popupLocation: PropTypes.string,
     popupMenu: PropTypes.array,
+    showCards: PropTypes.bool,
     size: PropTypes.string,
     source: PropTypes.oneOf([
         'hand',

--- a/client/Components/GameBoard/Droppable.jsx
+++ b/client/Components/GameBoard/Droppable.jsx
@@ -12,7 +12,7 @@ const validTargets = {
         'draw deck',
         'dead pile',
         'out of game',
-        'conclave',
+        'agenda',
         'shadows'
     ],
     'play area': [
@@ -21,7 +21,7 @@ const validTargets = {
         'draw deck',
         'dead pile',
         'out of game',
-        'conclave',
+        'agenda',
         'shadows'
     ],
     'discard pile': [
@@ -30,7 +30,7 @@ const validTargets = {
         'draw deck',
         'play area',
         'out of game',
-        'conclave',
+        'agenda',
         'shadows'
     ],
     'dead pile': [
@@ -39,7 +39,7 @@ const validTargets = {
         'play area',
         'discard pile',
         'out of game',
-        'conclave',
+        'agenda',
         'shadows'
     ],
     'draw deck': [
@@ -48,7 +48,7 @@ const validTargets = {
         'dead pile',
         'play area',
         'out of game',
-        'conclave',
+        'agenda',
         'rookery',
         'shadows'
     ],
@@ -64,7 +64,7 @@ const validTargets = {
         'dead pile',
         'shadows'
     ],
-    conclave: [
+    agenda: [
         'hand',
         'play area',
         'draw deck',

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -26,7 +26,6 @@ const placeholderPlayer = {
     cardPiles: {
         bannerCards: [],
         cardsInPlay: [],
-        conclavePile: [],
         deadPile: [],
         discardPile: [],
         hand: [],
@@ -394,7 +393,6 @@ export class GameBoard extends React.Component {
                     <PlayerRow
                         agenda={otherPlayer.agenda}
                         bannerCards={otherPlayer.cardPiles.bannerCards}
-                        conclavePile={otherPlayer.cardPiles.conclavePile}
                         faction={otherPlayer.faction}
                         hand={otherPlayer.cardPiles.hand}
                         isMe={false}
@@ -464,7 +462,6 @@ export class GameBoard extends React.Component {
                         isMe={!this.state.spectating}
                         agenda={thisPlayer.agenda}
                         bannerCards={thisPlayer.cardPiles.bannerCards}
-                        conclavePile={thisPlayer.cardPiles.conclavePile}
                         faction={thisPlayer.faction}
                         hand={thisPlayer.cardPiles.hand}
                         isMelee={this.props.currentGame.isMelee}

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -22,9 +22,8 @@ import ChessClock from './ChessClock';
 
 const placeholderPlayer = {
     activePlot: null,
-    agenda: null,
+    agendas: [],
     cardPiles: {
-        bannerCards: [],
         cardsInPlay: [],
         deadPile: [],
         discardPile: [],
@@ -290,7 +289,6 @@ export class GameBoard extends React.Component {
                 <PlayerPlots
                     {...commonProps}
                     activePlot={otherPlayer.activePlot}
-                    agenda={otherPlayer.agenda}
                     direction='reverse'
                     isMe={false}
                     plotDeck={otherPlayer.cardPiles.plotDeck}
@@ -302,7 +300,6 @@ export class GameBoard extends React.Component {
                 <PlayerPlots
                     {...commonProps}
                     activePlot={thisPlayer.activePlot}
-                    agenda={thisPlayer.agenda}
                     direction='default'
                     isMe
                     plotDeck={thisPlayer.cardPiles.plotDeck}
@@ -391,8 +388,7 @@ export class GameBoard extends React.Component {
             <div key='board-middle' className='board-middle'>
                 <div className='player-home-row'>
                     <PlayerRow
-                        agenda={otherPlayer.agenda}
-                        bannerCards={otherPlayer.cardPiles.bannerCards}
+                        agendas={otherPlayer.agendas}
                         faction={otherPlayer.faction}
                         hand={otherPlayer.cardPiles.hand}
                         isMe={false}
@@ -460,8 +456,7 @@ export class GameBoard extends React.Component {
                 <div className='player-home-row our-side'>
                     <PlayerRow
                         isMe={!this.state.spectating}
-                        agenda={thisPlayer.agenda}
-                        bannerCards={thisPlayer.cardPiles.bannerCards}
+                        agendas={thisPlayer.agendas}
                         faction={thisPlayer.faction}
                         hand={thisPlayer.cardPiles.hand}
                         isMelee={this.props.currentGame.isMelee}

--- a/client/Components/GameBoard/PlayerPlots.jsx
+++ b/client/Components/GameBoard/PlayerPlots.jsx
@@ -91,7 +91,6 @@ class PlayerPlots extends React.Component {
 PlayerPlots.displayName = 'PlayerPlots';
 PlayerPlots.propTypes = {
     activePlot: PropTypes.object,
-    agenda: PropTypes.object,
     cardSize: PropTypes.string,
     direction: PropTypes.oneOf(['default', 'reverse']),
     isMe: PropTypes.bool,

--- a/client/Components/GameBoard/PlayerRow.jsx
+++ b/client/Components/GameBoard/PlayerRow.jsx
@@ -89,30 +89,28 @@ class PlayerRow extends React.Component {
             )
         );
 
-        if (additionalAgendas) {
-            for (let index = 0; index < additionalAgendas.length; index++) {
-                let additionalAgenda = additionalAgendas[index];
-                let className = classNames('agenda', `agenda-${additionalAgenda.code} banner`);
-                let offset = spreadWidth * (index + 1);
-                let style = { left: `${offset}px` };
-                agendas.push(
-                    <Card
-                        key={additionalAgenda.uuid}
-                        className={className}
-                        card={additionalAgenda}
-                        source={source}
-                        onMouseOver={this.props.onMouseOver}
-                        onMouseOut={this.props.onMouseOut}
-                        disableMouseOver={false}
-                        onClick={this.props.onCardClick}
-                        onMenuItemClick={this.props.onMenuItemClick}
-                        orientation={'vertical'}
-                        size={this.props.cardSize}
-                        style={style}
-                    />
-                );
-            }
-        }
+        // Add all additional agendas separately (not as a CardPile)
+        agendas = agendas.concat(additionalAgendas.map((agenda, index) => {
+            let className = classNames('agenda', `agenda-${agenda.code} additional`);
+            let style = { left: `${spreadWidth * (index + 1)}px` };
+            return (
+                <Card
+                    key={agenda.uuid}
+                    className={className}
+                    card={agenda}
+                    source={source}
+                    onMouseOver={this.props.onMouseOver}
+                    onMouseOut={this.props.onMouseOut}
+                    disableMouseOver={false}
+                    onClick={this.props.onCardClick}
+                    onMenuItemClick={this.props.onMenuItemClick}
+                    orientation={'vertical'}
+                    size={this.props.cardSize}
+                    style={style}
+                />
+            );
+        }))
+        
         // 6 is the left + right padding of main agenda
         let totalWidth = 6 + cardWidth.width + spreadWidth * additionalAgendas.length;
         let totalStyle = { width: `${totalWidth}px` };

--- a/client/Components/GameBoard/PlayerRow.jsx
+++ b/client/Components/GameBoard/PlayerRow.jsx
@@ -90,27 +90,29 @@ class PlayerRow extends React.Component {
         );
 
         // Add all additional agendas separately (not as a CardPile)
-        agendas = agendas.concat(additionalAgendas.map((agenda, index) => {
-            let className = classNames('agenda', `agenda-${agenda.code} additional`);
-            let style = { left: `${spreadWidth * (index + 1)}px` };
-            return (
-                <Card
-                    key={agenda.uuid}
-                    className={className}
-                    card={agenda}
-                    source={source}
-                    onMouseOver={this.props.onMouseOver}
-                    onMouseOut={this.props.onMouseOut}
-                    disableMouseOver={false}
-                    onClick={this.props.onCardClick}
-                    onMenuItemClick={this.props.onMenuItemClick}
-                    orientation={'vertical'}
-                    size={this.props.cardSize}
-                    style={style}
-                />
-            );
-        }))
-        
+        agendas = agendas.concat(
+            additionalAgendas.map((agenda, index) => {
+                let className = classNames('agenda', `agenda-${agenda.code} additional`);
+                let style = { left: `${spreadWidth * (index + 1)}px` };
+                return (
+                    <Card
+                        key={agenda.uuid}
+                        className={className}
+                        card={agenda}
+                        source={source}
+                        onMouseOver={this.props.onMouseOver}
+                        onMouseOut={this.props.onMouseOut}
+                        disableMouseOver={false}
+                        onClick={this.props.onCardClick}
+                        onMenuItemClick={this.props.onMenuItemClick}
+                        orientation={'vertical'}
+                        size={this.props.cardSize}
+                        style={style}
+                    />
+                );
+            })
+        );
+
         // 6 is the left + right padding of main agenda
         let totalWidth = 6 + cardWidth.width + spreadWidth * additionalAgendas.length;
         let totalStyle = { width: `${totalWidth}px` };

--- a/client/Components/GameBoard/PlayerRow.jsx
+++ b/client/Components/GameBoard/PlayerRow.jsx
@@ -46,26 +46,31 @@ class PlayerRow extends React.Component {
     }
 
     getAgenda() {
-        if (!this.props.agenda || this.props.agenda.code === '') {
+        let agenda =
+            this.props.agendas && this.props.agendas.length > 0 ? this.props.agendas[0] : undefined;
+        if (!agenda || agenda.code === '') {
             let className = classNames('agenda', 'card-pile', 'vertical', {
                 [this.props.cardSize]: this.props.cardSize !== 'normal'
             });
             return <div className={className} />;
         }
-        let underneath = this.props.agenda.childCards || [];
+        let cardWidth = getCardDimensions(this.props.cardSize);
+
+        let underneath = agenda.childCards || [];
         let disablePopup = underneath.length === 0;
         let title = !disablePopup ? 'Agenda' : null;
         let source = 'agenda';
-        let pileClass = classNames('agenda', `agenda-${this.props.agenda.code}`);
-        let cardWidth = getCardDimensions(this.props.cardSize);
-        let additionalWidth = cardWidth.width / 2;
+        let pileClass = classNames('agenda', `agenda-${agenda.code}`);
+
+        let additionalAgendas = this.props.agendas.slice(1);
+        let spreadWidth = cardWidth.width / 2;
 
         let agendas = [];
         agendas.push(
             this.renderDroppablePile(
                 source,
                 <CardPile
-                    key={this.props.agenda.uuid}
+                    key={agenda.uuid}
                     className={pileClass}
                     cards={underneath}
                     disablePopup={disablePopup}
@@ -75,25 +80,26 @@ class PlayerRow extends React.Component {
                     onMouseOut={this.props.onMouseOut}
                     onMouseOver={this.props.onMouseOver}
                     popupLocation={this.props.side}
+                    showCards={true}
                     source={source}
                     title={title}
-                    topCard={this.props.agenda}
+                    topCard={agenda}
                     size={this.props.cardSize}
                 />
             )
         );
 
-        if (this.props.bannerCards) {
-            for (let index = 0; index < this.props.bannerCards.length; index++) {
-                let banner = this.props.bannerCards[index];
-                let bannerClass = classNames('agenda', `agenda-${banner.code} banner`);
-                let offset = additionalWidth * (index + 1);
+        if (additionalAgendas) {
+            for (let index = 0; index < additionalAgendas.length; index++) {
+                let additionalAgenda = additionalAgendas[index];
+                let className = classNames('agenda', `agenda-${additionalAgenda.code} banner`);
+                let offset = spreadWidth * (index + 1);
                 let style = { left: `${offset}px` };
                 agendas.push(
                     <Card
-                        key={banner.uuid}
-                        className={bannerClass}
-                        card={banner}
+                        key={additionalAgenda.uuid}
+                        className={className}
+                        card={additionalAgenda}
                         source={source}
                         onMouseOver={this.props.onMouseOver}
                         onMouseOut={this.props.onMouseOut}
@@ -107,7 +113,8 @@ class PlayerRow extends React.Component {
                 );
             }
         }
-        let totalWidth = 6 + cardWidth.width + additionalWidth * this.props.bannerCards.length;
+        // 6 is the left + right padding of main agenda
+        let totalWidth = 6 + cardWidth.width + spreadWidth * additionalAgendas.length;
         let totalStyle = { width: `${totalWidth}px` };
         return (
             <div className='agendas' style={totalStyle}>
@@ -247,8 +254,7 @@ class PlayerRow extends React.Component {
 
 PlayerRow.displayName = 'PlayerRow';
 PlayerRow.propTypes = {
-    agenda: PropTypes.object,
-    bannerCards: PropTypes.array,
+    agendas: PropTypes.array,
     cardSize: PropTypes.string,
     deadPile: PropTypes.array,
     discardPile: PropTypes.array,

--- a/client/Components/GameBoard/PopupDefaults.js
+++ b/client/Components/GameBoard/PopupDefaults.js
@@ -39,8 +39,5 @@ export default {
     },
     'agenda-top': {
         top: '185px'
-    },
-    'conclave-bottom': {
-        bottom: '155px'
     }
 };

--- a/client/Components/GameBoard/SquishableCardPanel.jsx
+++ b/client/Components/GameBoard/SquishableCardPanel.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { getCardDimensions } from '../../util';
 
 import Card from './Card';
 
 class SquishableCardPanel extends React.Component {
     getCards(needsSquish) {
         let overallDimensions = this.getOverallDimensions();
-        let dimensions = this.getCardDimensions();
+        let dimensions = getCardDimensions(this.props.cardSize);
 
         let cards = this.props.cards;
         let cardIndex = 0;
@@ -57,29 +58,8 @@ class SquishableCardPanel extends React.Component {
         );
     }
 
-    getCardDimensions() {
-        let multiplier = this.getCardSizeMultiplier();
-        return {
-            width: 65 * multiplier,
-            height: 91 * multiplier
-        };
-    }
-
-    getCardSizeMultiplier() {
-        switch (this.props.cardSize) {
-            case 'small':
-                return 0.8;
-            case 'large':
-                return 1.4;
-            case 'x-large':
-                return 2;
-        }
-
-        return 1;
-    }
-
     getOverallDimensions() {
-        let cardDimensions = this.getCardDimensions();
+        let cardDimensions = getCardDimensions(this.props.cardSize);
         return {
             width: (cardDimensions.width + 5) * this.props.maxCards,
             height: cardDimensions.height

--- a/client/Components/Games/GamePlayer.jsx
+++ b/client/Components/Games/GamePlayer.jsx
@@ -21,14 +21,16 @@ function GamePlayer(props) {
                     </span>
                     <span className='bold'>{props.player.name}</span>
                 </div>
-                <div className='agenda-mini'>
-                    {
-                        <img
-                            className='img-responsive'
-                            src={`/img/cards/${props.player.agenda || 'cardback'}.png`}
-                        />
-                    }
-                </div>
+                {props.player.agendas.reverse().map((agenda) => (
+                    <div key={agenda} className='agenda-mini'>
+                        {
+                            <img
+                                className='img-responsive'
+                                src={`/img/cards/${agenda || 'cardback'}.png`}
+                            />
+                        }
+                    </div>
+                ))}
                 <div className='faction-mini'>
                     {
                         <img
@@ -50,14 +52,16 @@ function GamePlayer(props) {
                         />
                     }
                 </div>
-                <div className='agenda-mini'>
-                    {
-                        <img
-                            className='img-responsive'
-                            src={`/img/cards/${props.player.agenda || 'cardback'}.png`}
-                        />
-                    }
-                </div>
+                {props.player.agendas.map((agenda) => (
+                    <div key={agenda} className='agenda-mini'>
+                        {
+                            <img
+                                className='img-responsive'
+                                src={`/img/cards/${agenda || 'cardback'}.png`}
+                            />
+                        }
+                    </div>
+                ))}
                 <div className='game-player-name'>
                     <span className='bold'>{props.player.name}</span>
                     <span className='gamelist-avatar'>

--- a/client/less/gameboard.less
+++ b/client/less/gameboard.less
@@ -407,17 +407,21 @@
     }
 }
 
-// Alliance agenda
-.agenda-06018 {
-    .inner {
-        .calculate-tiled-card-prop(width, 2, width);
-    }
-}
+.agendas {
+    position: relative;
+    display: flex;
 
-// Conclave agenda
-.agenda-09045 {
-    .inner {
-        .calculate-tiled-card-prop(width, 7, width);
+    > .card-wrapper {
+        position: absolute;
+        margin: 6px;
+    }
+
+    .agenda {
+        .popup {
+            .inner {
+                .calculate-tiled-card-prop(width, 5, width);
+            }
+        }
     }
 }
 

--- a/client/util.jsx
+++ b/client/util.jsx
@@ -40,3 +40,24 @@ export function getMessageWithLinks(message) {
 
     return parts;
 }
+
+export function getCardDimensions(cardSize) {
+    let multiplier = getCardSizeMultiplier(cardSize);
+    return {
+        width: 65 * multiplier,
+        height: 91 * multiplier
+    };
+}
+
+function getCardSizeMultiplier(cardSize) {
+    switch (cardSize) {
+        case 'small':
+            return 0.8;
+        case 'large':
+            return 1.4;
+        case 'x-large':
+            return 2;
+    }
+
+    return 1;
+}

--- a/deck-helper/AgendaRules.js
+++ b/deck-helper/AgendaRules.js
@@ -1,22 +1,25 @@
 function hasKeyword(card, keywordRegex) {
     let lines = card.text.split('\n');
     let keywordLine = lines[0] || '';
-    let keywords = keywordLine.split('.').map(keyword => keyword.trim()).filter(keyword => keyword.length !== 0);
+    let keywords = keywordLine
+        .split('.')
+        .map((keyword) => keyword.trim())
+        .filter((keyword) => keyword.length !== 0);
 
-    return keywords.some(keyword => keywordRegex.test(keyword));
+    return keywords.some((keyword) => keywordRegex.test(keyword));
 }
 
 function hasTrait(card, trait) {
-    return card.traits.some(t => t.toLowerCase() === trait.toLowerCase());
+    return card.traits.some((t) => t.toLowerCase() === trait.toLowerCase());
 }
 
 function rulesForBanner(faction, factionName) {
     return {
-        mayInclude: card => card.faction === faction && !card.loyal && card.type !== 'plot',
+        mayInclude: (card) => card.faction === faction && !card.loyal && card.type !== 'plot',
         rules: [
             {
                 message: 'Must contain 12 or more ' + factionName + ' cards',
-                condition: deck => deck.countDrawCards(card => card.faction === faction) >= 12
+                condition: (deck) => deck.countDrawCards((card) => card.faction === faction) >= 12
             }
         ]
     };
@@ -42,7 +45,7 @@ const agendaRules = {
     // Banner of the sun
     '01201': rulesForBanner('martell', 'Martell'),
     // Banner of the watch
-    '01202': rulesForBanner('thenightswatch', 'Night\'s Watch'),
+    '01202': rulesForBanner('thenightswatch', "Night's Watch"),
     // Banner of the wolf
     '01203': rulesForBanner('stark', 'Stark'),
     // Banner of the dragon
@@ -54,27 +57,29 @@ const agendaRules = {
         rules: [
             {
                 message: 'You cannot include more than 15 neutral cards in a deck with Fealty',
-                condition: deck => deck.countDrawCards(card => card.faction === 'neutral') <= 15
+                condition: (deck) => deck.countDrawCards((card) => card.faction === 'neutral') <= 15
             }
         ]
     },
     // Kings of Summer
     '04037': {
-        cannotInclude: card => card.type === 'plot' && hasTrait(card, 'Winter'),
+        cannotInclude: (card) => card.type === 'plot' && hasTrait(card, 'Winter'),
         rules: [
             {
                 message: 'Kings of Summer cannot include Winter plot cards',
-                condition: deck => !(deck.plotCards.some(cardQuantity => hasTrait(cardQuantity.card, 'Winter')))
+                condition: (deck) =>
+                    !deck.plotCards.some((cardQuantity) => hasTrait(cardQuantity.card, 'Winter'))
             }
         ]
     },
     // Kings of Winter
     '04038': {
-        cannotInclude: card => card.type === 'plot' && hasTrait(card, 'Summer'),
+        cannotInclude: (card) => card.type === 'plot' && hasTrait(card, 'Summer'),
         rules: [
             {
                 message: 'Kings of Winter cannot include Summer plot cards',
-                condition: deck => !(deck.plotCards.some(cardQuantity => hasTrait(cardQuantity.card, 'Summer')))
+                condition: (deck) =>
+                    !deck.plotCards.some((cardQuantity) => hasTrait(cardQuantity.card, 'Summer'))
             }
         ]
     },
@@ -84,9 +89,11 @@ const agendaRules = {
         rules: [
             {
                 message: 'Rains of Castamere must contain exactly 5 different Scheme plots',
-                condition: deck => {
-                    const isScheme = card => hasTrait(card, 'Scheme');
-                    let schemePlots = deck.plotCards.filter(cardQuantity => isScheme(cardQuantity.card));
+                condition: (deck) => {
+                    const isScheme = (card) => hasTrait(card, 'Scheme');
+                    let schemePlots = deck.plotCards.filter((cardQuantity) =>
+                        isScheme(cardQuantity.card)
+                    );
                     return schemePlots.length === 5 && deck.countPlotCards(isScheme) === 5;
                 }
             }
@@ -98,161 +105,204 @@ const agendaRules = {
         rules: [
             {
                 message: 'Alliance cannot have more than 2 Banner agendas',
-                condition: deck => !deck.bannerCards || deck.bannerCards.length <= 2
+                condition: (deck) => !deck.bannerCards || deck.bannerCards.length <= 2
             }
         ]
     },
     // The Brotherhood Without Banners
     '06119': {
-        cannotInclude: card => card.type === 'character' && card.loyal,
+        cannotInclude: (card) => card.type === 'character' && card.loyal,
         rules: [
             {
                 message: 'The Brotherhood Without Banners cannot include loyal characters',
-                condition: deck => !(deck.drawCards.some(cardQuantity => cardQuantity.card.type === 'character' && cardQuantity.card.loyal))
+                condition: (deck) =>
+                    !deck.drawCards.some(
+                        (cardQuantity) =>
+                            cardQuantity.card.type === 'character' && cardQuantity.card.loyal
+                    )
             }
         ]
     },
     // The Conclave
     '09045': {
-        mayInclude: card => card.type === 'character' && hasTrait(card, 'Maester') && !card.loyal,
+        mayInclude: (card) => card.type === 'character' && hasTrait(card, 'Maester') && !card.loyal,
         rules: [
             {
                 message: 'Must contain 12 or more Maester characters',
-                condition: deck => deck.countDrawCards(card => card.type === 'character' && hasTrait(card, 'Maester')) >= 12
+                condition: (deck) =>
+                    deck.countDrawCards(
+                        (card) => card.type === 'character' && hasTrait(card, 'Maester')
+                    ) >= 12
             }
         ]
     },
     // The Wars To Come
-    '10045': {
+    10045: {
         requiredPlots: 10,
         maxDoubledPlots: 2
     },
     // The Free Folk
-    '11079': {
-        cannotInclude: card => card.faction !== 'neutral'
+    11079: {
+        cannotInclude: (card) => card.faction !== 'neutral'
     },
     // Kingdom of Shadows
-    '13079': {
-        mayInclude: card => !card.loyal && hasKeyword(card, /Shadow \(\d+\)/)
+    13079: {
+        mayInclude: (card) => !card.loyal && hasKeyword(card, /Shadow \(\d+\)/)
     },
     // The White Book
-    '13099': {
-        mayInclude: card => card.type === 'character' && hasTrait(card, 'Kingsguard') && !card.loyal,
+    13099: {
+        mayInclude: (card) =>
+            card.type === 'character' && hasTrait(card, 'Kingsguard') && !card.loyal,
         rules: [
             {
                 message: 'Must contain 7 or more different Kingsguard characters',
-                condition: deck => {
-                    const kingsguardChars = deck.drawCards.filter(cardQuantity => cardQuantity.card.type === 'character' && hasTrait(cardQuantity.card, 'Kingsguard'));
+                condition: (deck) => {
+                    const kingsguardChars = deck.drawCards.filter(
+                        (cardQuantity) =>
+                            cardQuantity.card.type === 'character' &&
+                            hasTrait(cardQuantity.card, 'Kingsguard')
+                    );
                     return kingsguardChars.length >= 7;
                 }
             }
         ]
     },
     // Valyrian Steel
-    '13118': {
+    13118: {
         requiredDraw: 75,
         rules: [
             {
                 message: 'Cannot include more than 1 copy of each attachment (by title)',
-                condition: deck => {
+                condition: (deck) => {
                     const allCards = deck.drawCards.concat(deck.plotCards);
-                    const attachmentNames = allCards.filter(cardQuantity => cardQuantity.card.type === 'attachment').map(cardQuantity => cardQuantity.card.name);
-                    return attachmentNames.every(attachmentName => {
-                        return deck.countCards(card => card.name === attachmentName) <= 1;
+                    const attachmentNames = allCards
+                        .filter((cardQuantity) => cardQuantity.card.type === 'attachment')
+                        .map((cardQuantity) => cardQuantity.card.name);
+                    return attachmentNames.every((attachmentName) => {
+                        return deck.countCards((card) => card.name === attachmentName) <= 1;
                     });
                 }
             }
         ]
     },
     // Dark Wings, Dark Words
-    '16028': {
+    16028: {
         requiredDraw: 75,
         rules: [
             {
                 message: 'Cannot include more than 1 copy of each event (by title)',
-                condition: deck => {
+                condition: (deck) => {
                     const allCards = deck.drawCards.concat(deck.plotCards);
-                    const eventNames = allCards.filter(cardQuantity => cardQuantity.card.type === 'event').map(cardQuantity => cardQuantity.card.name);
-                    return eventNames.every(eventName => {
-                        return deck.countCards(card => card.name === eventName) <= 1;
+                    const eventNames = allCards
+                        .filter((cardQuantity) => cardQuantity.card.type === 'event')
+                        .map((cardQuantity) => cardQuantity.card.name);
+                    return eventNames.every((eventName) => {
+                        return deck.countCards((card) => card.name === eventName) <= 1;
                     });
                 }
             }
         ]
     },
     // The Long Voyage
-    '16030': {
+    16030: {
         requiredDraw: 100
     },
     // Kingdom of Shadows (Redesign)
-    '17148': {
-        mayInclude: card => !card.loyal && hasKeyword(card, /Shadow \(\d+\)/)
+    17148: {
+        mayInclude: (card) => !card.loyal && hasKeyword(card, /Shadow \(\d+\)/)
     },
     // Sea of Blood (Redesign)
-    '17149': {
-        cannotInclude: card => card.faction === 'neutral' && card.type === 'event'
+    17149: {
+        cannotInclude: (card) => card.faction === 'neutral' && card.type === 'event'
     },
     // The Free Folk (Redesign)
-    '17150': {
-        mayInclude: card => card.faction !== 'neutral' && card.type === 'character' && !card.loyal && hasTrait(card, 'Wildling'),
-        rules: [{
-            message: 'Must only contain neutral cards or Non-loyal Wildling characters',
-            condition: function condition(deck) {
-                let drawDeckValid = !deck.drawCards.some(function (cardQuantity) {
-                    return cardQuantity.card.faction !== 'neutral' && !(cardQuantity.card.type === 'character' && !cardQuantity.card.loyal && hasTrait(cardQuantity.card, 'Wildling'));
-                });
-                let plotDeckValid = !deck.plotCards.some(function (cardQuantity) {
-                    return cardQuantity.card.faction !== 'neutral';
-                });
-                return drawDeckValid && plotDeckValid;
+    17150: {
+        mayInclude: (card) =>
+            card.faction !== 'neutral' &&
+            card.type === 'character' &&
+            !card.loyal &&
+            hasTrait(card, 'Wildling'),
+        rules: [
+            {
+                message: 'Must only contain neutral cards or Non-loyal Wildling characters',
+                condition: function condition(deck) {
+                    let drawDeckValid = !deck.drawCards.some(function (cardQuantity) {
+                        return (
+                            cardQuantity.card.faction !== 'neutral' &&
+                            !(
+                                cardQuantity.card.type === 'character' &&
+                                !cardQuantity.card.loyal &&
+                                hasTrait(cardQuantity.card, 'Wildling')
+                            )
+                        );
+                    });
+                    let plotDeckValid = !deck.plotCards.some(function (cardQuantity) {
+                        return cardQuantity.card.faction !== 'neutral';
+                    });
+                    return drawDeckValid && plotDeckValid;
+                }
             }
-        }]
+        ]
     },
     // The Wars To Come (Redesign)
-    '17151': {
+    17151: {
         requiredPlots: 10,
         maxDoubledPlots: 2
     },
     // Valyrian Steel (Redesign)
-    '17152': {
+    17152: {
         requiredDraw: 75,
         rules: [
             {
                 message: 'Cannot include more than 1 copy of each attachment',
-                condition: deck => {
+                condition: (deck) => {
                     const allCards = deck.drawCards.concat(deck.plotCards);
-                    const attachments = allCards.filter(cardQuantity => cardQuantity.card.type === 'attachment');
-                    return attachments.every(attachment => attachment.count <= 1);
+                    const attachments = allCards.filter(
+                        (cardQuantity) => cardQuantity.card.type === 'attachment'
+                    );
+                    return attachments.every((attachment) => attachment.count <= 1);
                 }
             }
         ]
     },
     // A Mummer's Farce
-    '20051': {
-        mayInclude: card => card.type === 'character' && hasTrait(card, 'Fool') && !card.loyal
+    20051: {
+        mayInclude: (card) => card.type === 'character' && hasTrait(card, 'Fool') && !card.loyal
     },
     // The Many-Faced God
-    '20052': {
-        cannotInclude: card => card.type === 'plot' && hasTrait(card, 'Kingdom')
+    20052: {
+        cannotInclude: (card) => card.type === 'plot' && hasTrait(card, 'Kingdom')
     },
     // Battle of the Trident
-    '21030': {
+    21030: {
         requiredPlots: 10,
-        rules: [{
-            message: 'Battle of the Trident must contain exactly 10 Edict, Siege or War plots',
-            condition: deck => {
-                return deck.plotCards.every(cardQuantity => hasTrait(cardQuantity.card, 'Edict') || hasTrait(cardQuantity.card, 'Siege') || hasTrait(cardQuantity.card, 'War'));
+        rules: [
+            {
+                message: 'Battle of the Trident must contain exactly 10 Edict, Siege or War plots',
+                condition: (deck) => {
+                    return deck.plotCards.every(
+                        (cardQuantity) =>
+                            hasTrait(cardQuantity.card, 'Edict') ||
+                            hasTrait(cardQuantity.card, 'Siege') ||
+                            hasTrait(cardQuantity.card, 'War')
+                    );
+                }
             }
-        }]
+        ]
     },
     // Banner of the Falcon
-    '23040': {
+    23040: {
         rules: [
             {
                 message: 'Must contain 12 or more House Arryn cards',
-                condition: deck => deck.countDrawCards(card => hasTrait(card, 'House Arryn')) >= 12
+                condition: (deck) =>
+                    deck.countDrawCards((card) => hasTrait(card, 'House Arryn')) >= 12
             }
         ]
+    },
+    // The Gift of Mercy
+    25080: {
+        cannotInclude: (card) => card.type === 'plot' && hasTrait(card, 'Omen')
     },
     // Draft Agendas
     // The Power of Wealth
@@ -261,9 +311,17 @@ const agendaRules = {
         rules: [
             {
                 message: 'Cannot include cards from more than 1 outside faction',
-                condition: deck => {
-                    let outOfFactionCards = deck.drawCards.concat(deck.plotCards).filter(cardQuantity => cardQuantity.card.faction !== deck.faction.value && cardQuantity.card.faction !== 'neutral');
-                    let factions = new Set(outOfFactionCards.map(cardQuantity => cardQuantity.card.faction));
+                condition: (deck) => {
+                    let outOfFactionCards = deck.drawCards
+                        .concat(deck.plotCards)
+                        .filter(
+                            (cardQuantity) =>
+                                cardQuantity.card.faction !== deck.faction.value &&
+                                cardQuantity.card.faction !== 'neutral'
+                        );
+                    let factions = new Set(
+                        outOfFactionCards.map((cardQuantity) => cardQuantity.card.faction)
+                    );
                     return factions.size <= 1;
                 }
             }
@@ -271,7 +329,8 @@ const agendaRules = {
     },
     // Protectors of the Realm
     '00002': {
-        mayInclude: card => card.type === 'character' && (hasTrait(card, 'Knight') || hasTrait(card, 'Army'))
+        mayInclude: (card) =>
+            card.type === 'character' && (hasTrait(card, 'Knight') || hasTrait(card, 'Army'))
     },
     // Treaty
     '00003': {
@@ -279,9 +338,17 @@ const agendaRules = {
         rules: [
             {
                 message: 'Cannot include cards from more than 2 outside factions',
-                condition: deck => {
-                    let outOfFactionCards = deck.drawCards.concat(deck.plotCards).filter(cardQuantity => cardQuantity.card.faction !== deck.faction.value && cardQuantity.card.faction !== 'neutral');
-                    let factions = new Set(outOfFactionCards.map(cardQuantity => cardQuantity.card.faction));
+                condition: (deck) => {
+                    let outOfFactionCards = deck.drawCards
+                        .concat(deck.plotCards)
+                        .filter(
+                            (cardQuantity) =>
+                                cardQuantity.card.faction !== deck.faction.value &&
+                                cardQuantity.card.faction !== 'neutral'
+                        );
+                    let factions = new Set(
+                        outOfFactionCards.map((cardQuantity) => cardQuantity.card.faction)
+                    );
                     return factions.size <= 2;
                 }
             }
@@ -289,7 +356,7 @@ const agendaRules = {
     },
     // Uniting the Seven Kingdoms
     '00004': {
-        mayInclude: card => card.type !== 'plot'
+        mayInclude: (card) => card.type !== 'plot'
     }
 };
 

--- a/server/api/account.js
+++ b/server/api/account.js
@@ -5,12 +5,10 @@ import crypto from 'crypto';
 import moment from 'moment';
 import _ from 'underscore';
 import sendgrid from '@sendgrid/mail';
-import fs from 'fs';
 import logger from '../log.js';
 import { wrapAsync } from '../util.js';
+import { writeFile } from 'fs/promises';
 import ServiceFactory from '../services/ServiceFactory.js';
-import { finished } from 'stream/promises';
-import { Readable } from 'stream';
 const configService = ServiceFactory.configService();
 const appName = configService.getValue('appName');
 
@@ -83,11 +81,6 @@ function validatePassword(password) {
     }
 
     return undefined;
-}
-
-async function writeFile(path, data) {
-    const writer = fs.createWriteStream(path, { flags: 'wx' });
-    await finished(Readable.fromWeb(data).pipe(writer));
 }
 
 const DefaultEmailHash = crypto.createHash('md5').update('noreply@theironthrone.net').digest('hex');
@@ -954,7 +947,9 @@ async function downloadAvatar(user) {
         ? crypto.createHash('md5').update(user.email).digest('hex')
         : DefaultEmailHash;
     const avatar = await fetch(`https://www.gravatar.com/avatar/${emailHash}?d=identicon&s=24`);
-    await writeFile(`public/img/avatar/${user.username}.png`, avatar.body);
+    const arrayBuffer = await avatar.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    await writeFile(`public/img/avatar/${user.username}.png`, buffer);
 }
 
 async function checkAuth(req, res) {

--- a/server/game/AbilityContext.js
+++ b/server/game/AbilityContext.js
@@ -9,6 +9,7 @@ class AbilityContext {
         this.source = properties.source;
         this.player = properties.player;
         this.costs = {};
+        this.costStatesWhenInitiated = {};
         this.costValues = {};
         this.targets = new ResolvedTargets();
         this.resolutionStage = 'effect';
@@ -22,6 +23,9 @@ class AbilityContext {
         let valueAsArray = Array.isArray(value) ? value : [value];
         this.costValues[name] = this.costValues[name].concat(valueAsArray);
         this.costs[name] = value;
+        this.costStatesWhenInitiated[name] = Array.isArray(value)
+            ? value.map((v) => v.createSnapshot())
+            : value.createSnapshot();
     }
 
     getCostValuesFor(name) {

--- a/server/game/Deck.js
+++ b/server/game/Deck.js
@@ -24,12 +24,14 @@ class Deck {
         return new DrawCard(player, { type: 'faction' });
     }
 
-    createAgendaCard(player) {
-        if (this.data.agenda) {
-            return this.createCardForType(AgendaCard, player, this.data.agenda);
+    createAgendaCards(player) {
+        if (!this.data.agenda) {
+            return;
         }
 
-        return;
+        // Conditionally collect all possible additional agendas
+        const agendas = [this.data.agenda, ...(this.data.bannerCards ? this.data.bannerCards : [])];
+        return agendas.map((agenda) => this.createCardForType(AgendaCard, player, agenda));
     }
 
     isPlotCard(cardData) {
@@ -67,19 +69,12 @@ class Deck {
 
         result.allCards = [result.faction].concat(result.drawCards).concat(result.plotCards);
 
-        result.agenda = this.createAgendaCard(player);
-        if (result.agenda) {
-            result.agenda.moveTo('agenda');
-            result.allCards.push(result.agenda);
-        }
-
-        result.bannerCards = (this.data.bannerCards || []).map((card) =>
-            this.createCardForType(AgendaCard, player, card)
-        );
-
-        for (let card of result.bannerCards) {
-            card.moveTo('agenda');
-            result.allCards.push(card);
+        result.agendas = this.createAgendaCards(player);
+        if (result.agendas) {
+            for (const agenda of result.agendas) {
+                agenda.moveTo('agenda');
+                result.allCards.push(agenda);
+            }
         }
 
         return result;

--- a/server/game/GameActions/PlaceCardUnderneath.js
+++ b/server/game/GameActions/PlaceCardUnderneath.js
@@ -1,0 +1,38 @@
+import GameAction from './GameAction.js';
+import Message from '../Message.js';
+
+class PlaceCardUnderneath extends GameAction {
+    constructor() {
+        super('placeCardUnderneath');
+    }
+
+    message({ card, parentCard, facedown = false }) {
+        return Message.fragment('places {card} underneath {parentCard}', {
+            card: facedown ? 'a card facedown' : card,
+            parentCard
+        });
+    }
+
+    canChangeGameState({ card, parentCard }) {
+        return (
+            !parentCard.underneath.includes(card) &&
+            (parentCard.location === 'play area' || parentCard === parentCard.controller.agenda)
+        );
+    }
+
+    createEvent({ card, parentCard, player, facedown = false }) {
+        return this.event(
+            'onCardPlacedUnderneath',
+            { card, player, parentCard, facedown },
+            (event) => {
+                // TODO: Improve the logic for underneath cards to share location with their parentCard rather than using 'underneath'
+                const player = event.player || event.card.controller;
+                player.removeCardFromPile(event.card);
+                event.parentCard.addChildCard(event.card, 'underneath');
+                event.card.facedown = event.facedown;
+            }
+        );
+    }
+}
+
+export default new PlaceCardUnderneath();

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -24,6 +24,7 @@ import LoseIcon from './LoseIcon.js';
 import MayGameAction from './MayGameAction.js';
 import MovePower from './MovePower.js';
 import PlaceCard from './PlaceCard.js';
+import PlaceCardUnderneath from './PlaceCardUnderneath.js';
 import PlaceToken from './PlaceToken.js';
 import PutIntoShadows from './PutIntoShadows.js';
 import PutIntoPlay from './PutIntoPlay.js';
@@ -68,6 +69,7 @@ const GameActions = {
     may: (props) => new MayGameAction(props),
     movePower: (props) => new AbilityAdapter(MovePower, props),
     placeCard: (props) => new AbilityAdapter(PlaceCard, props),
+    placeCardUnderneath: (props) => new AbilityAdapter(PlaceCardUnderneath, props),
     placeToken: (props) => new AbilityAdapter(PlaceToken, props),
     putIntoPlay: (props) => new AbilityAdapter(PutIntoPlay, props),
     putIntoShadows: (props) => new AbilityAdapter(PutIntoShadows, props),

--- a/server/game/ServerCommands/DropCommand.js
+++ b/server/game/ServerCommands/DropCommand.js
@@ -33,7 +33,7 @@ class DropCommand {
             this.player.agenda.addChildCard(this.card, 'underneath');
             this.card.facedown = 'true';
         } else {
-            this.player.moveCard(this.card, this.targetLocation, { facedown: true });
+            this.player.moveCard(this.card, this.targetLocation);
         }
 
         this.addGameMessage();

--- a/server/game/ServerCommands/DropCommand.js
+++ b/server/game/ServerCommands/DropCommand.js
@@ -50,8 +50,7 @@ class DropCommand {
             'plot deck': PlotCardTypes,
             'revealed plots': PlotCardTypes,
             shadows: DrawDeckCardTypes,
-            // Agenda specific piles
-            conclave: DrawDeckCardTypes
+            agenda: DrawDeckCardTypes
         };
 
         let allowedTypes = AllowedTypesForPile[this.targetLocation];

--- a/server/game/ServerCommands/DropCommand.js
+++ b/server/game/ServerCommands/DropCommand.js
@@ -28,8 +28,12 @@ class DropCommand {
             DiscardCard.allow({ card: this.card, force: true })
         ) {
             this.player.discardCard(this.card, false, { force: true });
+        } else if (this.targetLocation === 'agenda') {
+            this.player.removeCardFromPile(this.card);
+            this.player.agenda.addChildCard(this.card, 'underneath');
+            this.card.facedown = 'true';
         } else {
-            this.player.moveCard(this.card, this.targetLocation);
+            this.player.moveCard(this.card, this.targetLocation, { facedown: true });
         }
 
         this.addGameMessage();

--- a/server/game/agendacard.js
+++ b/server/game/agendacard.js
@@ -1,5 +1,36 @@
 import BaseCard from './basecard.js';
 
-class AgendaCard extends BaseCard {}
+class AgendaCard extends BaseCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+        this.childCards = [];
+    }
+    addChildCard(card, location) {
+        this.childCards.push(card);
+        card.moveTo(location, this);
+    }
+
+    removeChildCard(card) {
+        if (!card) {
+            return;
+        }
+
+        this.childCards = this.childCards.filter((a) => a !== card);
+    }
+
+    get underneath() {
+        return this.childCards.filter((childCard) => childCard.location === 'underneath');
+    }
+
+    getSummary(activePlayer) {
+        let baseSummary = super.getSummary(activePlayer);
+
+        return Object.assign(baseSummary, {
+            childCards: this.childCards.map((card) => {
+                return card.getSummary(activePlayer);
+            })
+        });
+    }
+}
 
 export default AgendaCard;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -621,7 +621,6 @@ class BaseCard {
             return action.allowPlayer(player) && !action.isClickToActivate() && action.allowMenu();
         });
 
-        if(['play area', 'faction'])
         return [{ command: 'click', text: 'Select Card' }].concat(
             menuActionPairs.map(([action, index]) => action.getMenuItem(index, player))
         );

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -621,10 +621,7 @@ class BaseCard {
             return action.allowPlayer(player) && !action.isClickToActivate() && action.allowMenu();
         });
 
-        if (menuActionPairs.length === 0) {
-            return;
-        }
-
+        if(['play area', 'faction'])
         return [{ command: 'click', text: 'Select Card' }].concat(
             menuActionPairs.map(([action, index]) => action.getMenuItem(index, player))
         );

--- a/server/game/cards/01-Core/ObaraSand.js
+++ b/server/game/cards/01-Core/ObaraSand.js
@@ -10,9 +10,6 @@ class ObaraSand extends DrawCard {
                 }),
             match: this,
             effect: [
-                // Add the icon as a UI hint, but Obara can be declared even if
-                // the opponent removes that icon somehow.
-                ability.effects.addIcon('power'),
                 ability.effects.canBeDeclaredWithoutIcon(),
                 ability.effects.canBeDeclaredWhileKneeling()
             ]

--- a/server/game/cards/04.3-FFH/Spearmaiden.js
+++ b/server/game/cards/04.3-FFH/Spearmaiden.js
@@ -14,14 +14,8 @@ class Spearmaiden extends DrawCard {
                     card.controller === this.game.currentChallenge.defendingPlayer &&
                     card.getType() === 'character'
             },
+            message: '{player} chooses {target} for {source}',
             handler: (context) => {
-                this.game.addMessage(
-                    '{0} chooses {1} as the target for {2}',
-                    this.controller,
-                    context.target,
-                    this
-                );
-
                 this.game.once('afterChallenge', (event) =>
                     this.resolveIfWinBy5(event.challenge, context)
                 );
@@ -43,7 +37,8 @@ class Spearmaiden extends DrawCard {
 
         this.untilEndOfChallenge((ability) => ({
             targetController: 'opponent',
-            effect: ability.effects.mustChooseAsClaim((card) => card === context.target)
+            match: context.target,
+            effect: ability.effects.mustChooseAsClaim()
         }));
     }
 }

--- a/server/game/cards/22-BtB/TheGreatPyramid.js
+++ b/server/game/cards/22-BtB/TheGreatPyramid.js
@@ -3,6 +3,11 @@ import GenericTracker from '../../EventTrackers/GenericTracker.js';
 import GameActions from '../../GameActions/index.js';
 
 class TheGreatPyramid extends DrawCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+
+        this.registerEvents([{ 'onCardLeftPlay:forcedinterrupt': 'onCardLeftPlay' }]);
+    }
     setupCardAbilities(ability) {
         this.marshalledTracker = GenericTracker.forRound(this.game, 'onCardMarshalled');
         this.playedTracker = GenericTracker.forRound(this.game, 'onCardPlayed');
@@ -27,26 +32,19 @@ class TheGreatPyramid extends DrawCard {
                     )
             },
             limit: ability.limit.perRound(2),
-            handler: (context) => {
-                let discardedCards = context.event.events
-                    .map((discardEvent) => discardEvent.card)
-                    .filter((card) => card.location === 'discard pile');
-                this.game.addMessage(
-                    '{0} places {1} under {2}',
-                    context.player,
-                    discardedCards,
-                    this
-                );
-
-                this.lastingEffect((ability) => ({
-                    until: {
-                        onCardLeftPlay: (event) => event.card === this
-                    },
-                    targetLocation: 'any',
-                    match: discardedCards,
-                    effect: ability.effects.placeCardUnderneath(this.removeCardsUnderneathFromGame)
-                }));
-            }
+            message: {
+                format: '{player} uses {source} to place {cards} facedown under {source}',
+                args: { cards: (context) => context.events.map((event) => event.card) }
+            },
+            gameAction: GameActions.simultaneously((context) =>
+                context.events.map((event) =>
+                    GameActions.placeCardUnderneath({
+                        card: event.card,
+                        parentCard: this,
+                        facedown: true
+                    })
+                )
+            )
         });
     }
 
@@ -73,20 +71,23 @@ class TheGreatPyramid extends DrawCard {
         return marshalledCount + playedCount >= 2;
     }
 
-    removeCardsUnderneathFromGame(card, context) {
-        if (
-            card.location === 'underneath' &&
-            context.source.childCards.some((childCard) => childCard === card)
-        ) {
-            context.game.resolveGameAction(GameActions.removeFromGame({ card, player: this }));
-
-            context.game.addMessage(
-                '{0} removes {1} from the game from under {2}',
-                context.source.controller,
-                card,
-                context.source
-            );
+    onCardLeftPlay(event) {
+        if (event.card !== this || this.underneath.length === 0) {
+            return;
         }
+
+        this.game.resolveGameAction(
+            GameActions.simultaneously(
+                ...this.underneath.map((card) => GameActions.removeFromGame({ card }))
+            )
+        );
+
+        this.game.addMessage(
+            '{0} removes {1} from the game due to {2} leaving play',
+            this.controller,
+            this.underneath,
+            this
+        );
     }
 }
 

--- a/server/game/cards/25.4-TTS/AegonTheConqueror.js
+++ b/server/game/cards/25.4-TTS/AegonTheConqueror.js
@@ -1,0 +1,27 @@
+import DrawCard from '../../drawcard.js';
+
+class AegonTheConqueror extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({
+            type: 'location',
+            faction: 'targaryen',
+            controller: 'current',
+            unique: true
+        });
+        this.persistentEffect({
+            condition: () =>
+                this.controller.anyCardsInPlay({
+                    type: 'character',
+                    attacking: true,
+                    trait: 'Dragon',
+                    printedCostOrHigher: 7
+                }),
+            match: (card) => card === this.controller.activePlot,
+            effect: ability.effects.modifyClaim(1)
+        });
+    }
+}
+
+AegonTheConqueror.code = '25074';
+
+export default AegonTheConqueror;

--- a/server/game/cards/25.4-TTS/AllardSeaworth.js
+++ b/server/game/cards/25.4-TTS/AllardSeaworth.js
@@ -1,0 +1,34 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class AllardSeaworth extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Discard facedown card',
+            phase: 'dominance',
+            cost: ability.costs.discardFromPlay(
+                (card) =>
+                    card.facedown &&
+                    card.getType() === 'attachment' &&
+                    card.parent &&
+                    card.parent.controller === this.controller &&
+                    card.parent.isFaction('baratheon')
+            ),
+            limit: ability.limit.perPhase(1),
+            message: {
+                format: '{player} uses {source} and discards {costs.discardFromPlay} from underneath {parent} to gain 1 power for their faction',
+                args: {
+                    parent: (context) => context.costStatesWhenInitiated.discardFromPlay.parent
+                }
+            },
+            gameAction: GameActions.gainPower((context) => ({
+                card: context.player.faction,
+                amount: 1
+            }))
+        });
+    }
+}
+
+AllardSeaworth.code = '25061';
+
+export default AllardSeaworth;

--- a/server/game/cards/25.4-TTS/BattleOnTheGreenFork.js
+++ b/server/game/cards/25.4-TTS/BattleOnTheGreenFork.js
@@ -1,0 +1,27 @@
+import GameActions from '../../GameActions/index.js';
+import PlotCard from '../../plotcard.js';
+
+class BattleOnTheGreenFork extends PlotCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.attackingPlayer === this.controller
+            },
+            limit: ability.limit.perPhase(3),
+            message:
+                '{player} uses {source} to raise the claim on {source} by 1 until the end of the phase',
+            gameAction: GameActions.genericHandler(() => {
+                this.untilEndOfPhase((ability) => ({
+                    match: this,
+                    effect: ability.effects.modifyClaim(1)
+                }));
+            })
+        });
+    }
+}
+
+BattleOnTheGreenFork.code = '25079';
+
+export default BattleOnTheGreenFork;

--- a/server/game/cards/25.4-TTS/BlackBalaq.js
+++ b/server/game/cards/25.4-TTS/BlackBalaq.js
@@ -1,0 +1,17 @@
+import { Tokens } from '../../Constants/index.js';
+import DrawCard from '../../drawcard.js';
+
+class BlackBalaq extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.isAttacking(),
+            match: (card) => card.isDefending(),
+            targetController: 'opponent',
+            effect: ability.effects.dynamicStrength(() => -this.tokens[Tokens.gold])
+        });
+    }
+}
+
+BlackBalaq.code = '25073';
+
+export default BlackBalaq;

--- a/server/game/cards/25.4-TTS/BowenMarsh.js
+++ b/server/game/cards/25.4-TTS/BowenMarsh.js
@@ -1,0 +1,52 @@
+import DrawCard from '../../drawcard.js';
+import ChallengeTypes from '../../ChallengeTypes.js';
+
+class BowenMarsh extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card.controller === this.controller
+            },
+            limit: ability.limit.perPhase(3),
+            target: {
+                cardCondition: (card) =>
+                    card.location === 'play area' && card.getType() === 'character'
+            },
+            handler: (context) => {
+                this.selectedCharacter = context.target;
+
+                this.game.promptWithMenu(this.controller, this, {
+                    activePrompt: {
+                        menuTitle: 'Select a challenge type',
+                        buttons: ChallengeTypes.asButtons({ method: 'selectChallengeType' })
+                    },
+                    source: this
+                });
+            }
+        });
+    }
+
+    selectChallengeType(player, challengeType) {
+        this.untilEndOfPhase((ability) => ({
+            condition: () => this.game.isDuringChallenge({ challengeType }),
+            match: this.selectedCharacter,
+            effect: ability.effects.cannotBeDeclaredAsAttacker()
+        }));
+
+        this.game.addMessage(
+            '{0} uses {1} to make {2} unable to be declared as an attacker in {3} challenges this phase',
+            player,
+            this,
+            this.selectedCharacter,
+            challengeType
+        );
+
+        this.selectedCharacter = null;
+
+        return true;
+    }
+}
+
+BowenMarsh.code = '25069';
+
+export default BowenMarsh;

--- a/server/game/cards/25.4-TTS/DickonTarly.js
+++ b/server/game/cards/25.4-TTS/DickonTarly.js
@@ -1,0 +1,20 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class DickonTarly extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardStood: (event) =>
+                    event.card.controller === this.controller && event.card.isFaction('tyrell')
+            },
+            limit: ability.limit.perPhase(1),
+            message: '{player} uses {source} to stand {source}',
+            gameAction: GameActions.standCard({ card: this })
+        });
+    }
+}
+
+DickonTarly.code = '25075';
+
+export default DickonTarly;

--- a/server/game/cards/25.4-TTS/GrandMaesterPycelle.js
+++ b/server/game/cards/25.4-TTS/GrandMaesterPycelle.js
@@ -1,0 +1,26 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class GrandMaesterPycelle extends DrawCard {
+    setupCardAbilities(ability) {
+        this.interrupt({
+            when: {
+                onCardDiscarded: (event) => event.originalLocation === 'hand'
+            },
+            limit: ability.limit.perRound(2),
+            message: {
+                format: "{player} uses {source} to place a discarded card facedown under {controller}'s agenda instead of placing it in their discard pile",
+                args: { controller: (context) => context.event.card.controller }
+            },
+            gameAction: GameActions.placeCard((context) => ({
+                card: context.event.card,
+                player: context.event.card.controller,
+                location: 'conclave'
+            }))
+        });
+    }
+}
+
+GrandMaesterPycelle.code = '25065';
+
+export default GrandMaesterPycelle;

--- a/server/game/cards/25.4-TTS/GrandMaesterPycelle.js
+++ b/server/game/cards/25.4-TTS/GrandMaesterPycelle.js
@@ -12,10 +12,10 @@ class GrandMaesterPycelle extends DrawCard {
                 format: "{player} uses {source} to place a discarded card facedown under {controller}'s agenda instead of placing it in their discard pile",
                 args: { controller: (context) => context.event.card.controller }
             },
-            gameAction: GameActions.placeCard((context) => ({
+            gameAction: GameActions.placeCardUnderneath((context) => ({
                 card: context.event.card,
-                player: context.event.card.controller,
-                location: 'conclave'
+                parentCard: context.event.card.controller.agenda,
+                facedown: true
             }))
         });
     }

--- a/server/game/cards/25.4-TTS/GreatKrakensCrew.js
+++ b/server/game/cards/25.4-TTS/GreatKrakensCrew.js
@@ -1,0 +1,30 @@
+import DrawCard from '../../drawcard.js';
+
+class GreatKrakensCrew extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            target: {
+                cardCondition: (card) =>
+                    card.isDefending() &&
+                    card.getType() === 'character' &&
+                    card.hasPrintedCost() &&
+                    card.getPrintedCost() <= 3
+            },
+            message:
+                "{player} uses {source} to have {target} not contribute it's STR to this challenge",
+            handler: (context) => {
+                this.untilEndOfChallenge((ability) => ({
+                    match: context.target,
+                    effect: ability.effects.doesNotContributeStrength()
+                }));
+            }
+        });
+    }
+}
+
+GreatKrakensCrew.code = '25063';
+
+export default GreatKrakensCrew;

--- a/server/game/cards/25.4-TTS/JonSnow.js
+++ b/server/game/cards/25.4-TTS/JonSnow.js
@@ -1,0 +1,37 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class JonSnow extends DrawCard {
+    setupCardAbilities() {
+        this.interrupt({
+            when: {
+                onClaimApplied: (event) => event.challenge.isMatch({ challengeType: 'military' })
+            },
+            message:
+                '{player} uses {source} to have either standing or kneeling characters satisfied for claim',
+            choices: {
+                'Standing Characters': {
+                    message: '{player} chooses to have standing characters satisfied for claim',
+                    gameAction: this.mustChooseClaimGameAction((card) => !card.kneeled)
+                },
+                'Kneeling Characters': {
+                    message: '{player} chooses to have kneeling characters satisfied for claim',
+                    gameAction: this.mustChooseClaimGameAction((card) => card.kneeled)
+                }
+            }
+        });
+    }
+
+    mustChooseClaimGameAction(cardFunc) {
+        return GameActions.genericHandler(() => {
+            this.untilEndOfChallenge((ability) => ({
+                targetController: 'any',
+                effect: ability.effects.mustChooseAsClaim(cardFunc)
+            }));
+        });
+    }
+}
+
+JonSnow.code = '25071';
+
+export default JonSnow;

--- a/server/game/cards/25.4-TTS/JonSnow.js
+++ b/server/game/cards/25.4-TTS/JonSnow.js
@@ -8,25 +8,31 @@ class JonSnow extends DrawCard {
                 onClaimApplied: (event) => event.challenge.isMatch({ challengeType: 'military' })
             },
             message:
-                '{player} uses {source} to have either standing or kneeling characters satisfied for claim',
+                '{player} uses {source} to have either standing or kneeling characters satisfied for claim, if able',
             choices: {
                 'Standing Characters': {
-                    message: '{player} chooses to have standing characters satisfied for claim',
-                    gameAction: this.mustChooseClaimGameAction((card) => !card.kneeled)
+                    message:
+                        '{player} chooses standing characters to be satisfied for claim, if able',
+                    gameAction: this.mustChooseClaimGameAction(false)
                 },
                 'Kneeling Characters': {
-                    message: '{player} chooses to have kneeling characters satisfied for claim',
-                    gameAction: this.mustChooseClaimGameAction((card) => card.kneeled)
+                    message:
+                        '{player} chooses kneeling characters to be satisfied for claim, if able',
+                    gameAction: this.mustChooseClaimGameAction(true)
                 }
             }
         });
     }
 
-    mustChooseClaimGameAction(cardFunc) {
+    mustChooseClaimGameAction(kneeled) {
         return GameActions.genericHandler(() => {
+            const affectedChars = this.game.allCards.filter(
+                (card) => card.getType() === 'character' && card.kneeled === kneeled
+            );
             this.untilEndOfChallenge((ability) => ({
                 targetController: 'any',
-                effect: ability.effects.mustChooseAsClaim(cardFunc)
+                match: affectedChars,
+                effect: ability.effects.mustChooseAsClaim()
             }));
         });
     }

--- a/server/game/cards/25.4-TTS/Kingswood.js
+++ b/server/game/cards/25.4-TTS/Kingswood.js
@@ -1,0 +1,25 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class Kingswood extends DrawCard {
+    setupCardAbilities(ability) {
+        this.plotModifiers({
+            initiative: 1
+        });
+        this.reaction({
+            when: {
+                onCardEntersPlay: (event) =>
+                    event.playingType === 'ambush' &&
+                    event.card.isMatch({ type: 'character', controller: 'current' })
+            },
+            cost: [ability.costs.kneelSelf(), ability.costs.returnSelfToHand()],
+            message:
+                '{player} kneels and returns {costs.returnToHand} to their hand to draw 1 card',
+            gameAction: GameActions.drawCards((context) => ({ player: context.player, amount: 1 }))
+        });
+    }
+}
+
+Kingswood.code = '25066';
+
+export default Kingswood;

--- a/server/game/cards/25.4-TTS/MartialLaw.js
+++ b/server/game/cards/25.4-TTS/MartialLaw.js
@@ -1,0 +1,19 @@
+import { ChallengeTracker } from '../../EventTrackers/ChallengeTracker.js';
+import DrawCard from '../../drawcard.js';
+
+class MartialLaw extends DrawCard {
+    setupCardAbilities(ability) {
+        this.tracker = ChallengeTracker.forRound(this.game);
+
+        this.attachmentRestriction({ type: 'location', limited: false });
+        this.whileAttached({
+            condition: () =>
+                !this.tracker.some({ winner: this.parent.controller, challengeType: 'power' }),
+            effect: ability.effects.cannotBeStood()
+        });
+    }
+}
+
+MartialLaw.code = '25062';
+
+export default MartialLaw;

--- a/server/game/cards/25.4-TTS/Nightfall.js
+++ b/server/game/cards/25.4-TTS/Nightfall.js
@@ -1,0 +1,27 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class Nightfall extends DrawCard {
+    setupCardAbilities(ability) {
+        this.whileAttached({
+            match: (card) => card.hasTrait('House Harlaw'),
+            effect: ability.effects.addKeyword('Renown')
+        });
+
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.winner === this.controller &&
+                    this.parent &&
+                    this.parent.isParticipating()
+            },
+            cost: ability.costs.kneelSelf(),
+            message: '{player} kneels {costs.kneel} to have each player check for reserve',
+            gameAction: GameActions.checkReserve()
+        });
+    }
+}
+
+Nightfall.code = '25064';
+
+export default Nightfall;

--- a/server/game/cards/25.4-TTS/NymeriaOfNySar.js
+++ b/server/game/cards/25.4-TTS/NymeriaOfNySar.js
@@ -1,0 +1,64 @@
+import DrawCard from '../../drawcard.js';
+import RevealPlots from '../../gamesteps/revealplots.js';
+import SimpleStep from '../../gamesteps/simplestep.js';
+
+class NymeriaOfNySar extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({
+            type: 'location',
+            faction: 'martell',
+            controller: 'current',
+            unique: true
+        });
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5 &&
+                    !this.controller.hasFlag('cannotRevealPlot')
+            },
+            cost: ability.costs.kneelSelf(),
+            target: {
+                type: 'select',
+                activePromptTitle: 'Select a plot',
+                cardCondition: (card, context) =>
+                    card.controller === context.player &&
+                    card.location === 'plot deck' &&
+                    (card.hasTrait('Summer') || card.isFaction('martell')),
+                cardType: 'plot'
+            },
+            message: '{player} uses {source} and kneels their faction card to reveal {target}',
+            handler: (context) => this.trigger(context)
+        });
+
+        this.action({
+            title: 'Manually trigger',
+            cost: ability.costs.kneelSelf(),
+            condition: () => !this.controller.hasFlag('cannotRevealPlot'),
+            target: {
+                type: 'select',
+                activePromptTitle: 'Select a plot',
+                cardCondition: (card, context) =>
+                    card.controller === context.player &&
+                    card.location === 'plot deck' &&
+                    (card.hasTrait('Summer') || card.isFaction('martell')),
+                cardType: 'plot'
+            },
+            handler: (context) => this.trigger(context)
+        });
+    }
+
+    trigger(context) {
+        context.player.selectedPlot = context.target;
+        this.game.queueStep(new RevealPlots(this.game, [context.target]));
+        this.game.queueStep(
+            new SimpleStep(this.game, () => {
+                context.player.recyclePlots();
+            })
+        );
+    }
+}
+
+NymeriaOfNySar.code = '25068';
+
+export default NymeriaOfNySar;

--- a/server/game/cards/25.4-TTS/OlennasWheelhouse.js
+++ b/server/game/cards/25.4-TTS/OlennasWheelhouse.js
@@ -1,0 +1,30 @@
+import DrawCard from '../../drawcard.js';
+
+class OlennasWheelhouse extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Remove a character from game',
+            cost: [ability.costs.kneelSelf(), ability.costs.discardGold()],
+            phase: 'marshal',
+            target: {
+                cardCondition: { location: 'play area', faction: 'tyrell', controller: 'current' }
+            },
+            message:
+                '{player} kneels {costs.kneel} and discards 1 gold from it to remove {target} from the game until the beginning of the next phase',
+            handler: (context) => {
+                this.lastingEffect((ability) => ({
+                    until: {
+                        onPhaseStarted: () => true
+                    },
+                    match: context.target,
+                    targetLocation: ['play area', 'out of game'],
+                    effect: ability.effects.removeFromGame()
+                }));
+            }
+        });
+    }
+}
+
+OlennasWheelhouse.code = '25076';
+
+export default OlennasWheelhouse;

--- a/server/game/cards/25.4-TTS/TheGiftOfMercy.js
+++ b/server/game/cards/25.4-TTS/TheGiftOfMercy.js
@@ -1,0 +1,58 @@
+import AgendaCard from '../../agendacard.js';
+import GameActions from '../../GameActions/index.js';
+import { Tokens } from '../../Constants/index.js';
+
+class TheGiftOfMercy extends AgendaCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                afterChallenge: (event) => event.challenge.winner === this.controller
+            },
+            target: {
+                cardCondition: {
+                    type: 'character',
+                    location: 'play area',
+                    condition: (card, context) => card.controller === context.event.challenge.loser
+                }
+            },
+            message: '{player} uses {source} to place a Valar Morghulis token on {target}',
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.placeToken((context) => ({
+                        card: context.target,
+                        token: Tokens.valarmorghulis
+                    })),
+                    context
+                );
+            }
+        });
+
+        this.interrupt({
+            when: {
+                onCardLeftPlay: (event) =>
+                    event.card.getType() === 'character' &&
+                    event.card.tokens[Tokens.valarmorghulis] >= 3
+            },
+            message: {
+                format: '{player} uses {source} to have {players} gain 2 power for their faction from {card} leaving play',
+                args: {
+                    players: (context) => this.getPlayersNotControlling(context.event.card),
+                    card: (context) => context.event.card
+                }
+            },
+            gameAction: GameActions.simultaneously((context) =>
+                this.getPlayersNotControlling(context.event.card).map((player) =>
+                    GameActions.gainPower({ card: player.faction, amount: 2 })
+                )
+            )
+        });
+    }
+
+    getPlayersNotControlling(card) {
+        return this.game.getPlayers().filter((player) => player !== card.controller);
+    }
+}
+
+TheGiftOfMercy.code = '25080';
+
+export default TheGiftOfMercy;

--- a/server/game/cards/25.4-TTS/TheGreenFork.js
+++ b/server/game/cards/25.4-TTS/TheGreenFork.js
@@ -1,0 +1,27 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class TheGreenFork extends DrawCard {
+    setupCardAbilities() {
+        this.plotModifiers({
+            gold: 1
+        });
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.isMatch({
+                        winner: this.controller,
+                        by5: true,
+                        challengeType: 'intrigue'
+                    })
+            },
+            location: 'discard pile',
+            message: '{player} uses {source} to put {source} into play from their discard pile',
+            gameAction: GameActions.putIntoPlay({ card: this })
+        });
+    }
+}
+
+TheGreenFork.code = '25078';
+
+export default TheGreenFork;

--- a/server/game/cards/25.4-TTS/TheHourOfTheWolf.js
+++ b/server/game/cards/25.4-TTS/TheHourOfTheWolf.js
@@ -1,0 +1,37 @@
+import GameActions from '../../GameActions/index.js';
+import PlotCard from '../../plotcard.js';
+
+class TheHourOfTheWolf extends PlotCard {
+    setupCardAbilities() {
+        this.whenRevealed({
+            target: {
+                choosingPlayer: 'each',
+                ifAble: true,
+                cardCondition: {
+                    location: 'play area',
+                    type: 'character',
+                    loyal: false,
+                    controller: 'choosingPlayer'
+                }
+            },
+            message: {
+                format: '{player} uses {source} to have each player sacrifice {targets}',
+                args: { targets: (context) => context.targets.getTargets() }
+            },
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.simultaneously((context) =>
+                        context.targets
+                            .getTargets()
+                            .map((card) => GameActions.sacrificeCard({ card }))
+                    ),
+                    context
+                );
+            }
+        });
+    }
+}
+
+TheHourOfTheWolf.code = '25072';
+
+export default TheHourOfTheWolf;

--- a/server/game/cards/25.4-TTS/TheWatchNeedsGoodMen.js
+++ b/server/game/cards/25.4-TTS/TheWatchNeedsGoodMen.js
@@ -1,0 +1,25 @@
+import PlotCard from '../../plotcard.js';
+
+class TheWatchNeedsGoodMen extends PlotCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'current',
+            effect: [
+                ability.effects.canMarshal(this.characterCondition),
+                ability.effects.canAmbush(this.characterCondition)
+            ]
+        });
+    }
+
+    characterCondition(card) {
+        return (
+            card.controller !== this.controller &&
+            card.location === 'discard pile' &&
+            card.getType() === 'character'
+        );
+    }
+}
+
+TheWatchNeedsGoodMen.code = '25070';
+
+export default TheWatchNeedsGoodMen;

--- a/server/game/cards/25.4-TTS/Varys.js
+++ b/server/game/cards/25.4-TTS/Varys.js
@@ -1,0 +1,53 @@
+import DrawCard from '../../drawcard.js';
+import { Tokens } from '../../Constants/index.js';
+import GameActions from '../../GameActions/index.js';
+
+class Varys extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Name a card',
+            cost: ability.costs.discardGold(),
+            message: '{player} discards 1 gold from {source} to name a card',
+            handler: (context) => {
+                this.game.promptForCardName({
+                    player: context.player,
+                    onSelect: (player, cardName) => this.selectCardName(cardName),
+                    source: context.source
+                });
+            }
+        });
+    }
+
+    selectCardName(cardName) {
+        this.game.addMessage(
+            'Until the end of the phase, {0} cannot be marshaled, played or put into play',
+            cardName
+        );
+        this.untilEndOfPhase((ability) => ({
+            targetController: 'any',
+            effect: [
+                ability.effects.cannotMarshal(
+                    (card) => card.name.toLowerCase() === cardName.toLowerCase()
+                ),
+                ability.effects.cannotPlay(
+                    (card) => card.name.toLowerCase() === cardName.toLowerCase()
+                ),
+                ability.effects.cannotPutIntoPlay(
+                    (card) => card.name.toLowerCase() === cardName.toLowerCase()
+                )
+            ]
+        }));
+
+        this.reaction({
+            when: {
+                onPlotRevealed: (event) => event.plot.hasTrait('Scheme')
+            },
+            message: '{player} uses {source} to place 1 gold on {source}',
+            gameAction: GameActions.placeToken({ card: this, token: Tokens.gold })
+        });
+    }
+}
+
+Varys.code = '25077';
+
+export default Varys;

--- a/server/game/cards/25.4-TTS/WaterGardensSentry.js
+++ b/server/game/cards/25.4-TTS/WaterGardensSentry.js
@@ -1,0 +1,24 @@
+import DrawCard from '../../drawcard.js';
+
+class WaterGardensSentry extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () =>
+                this.controller.anyCardsInPlay({
+                    type: 'character',
+                    faction: 'martell',
+                    trait: ['Lord', 'Lady']
+                }) &&
+                this.game.isDuringChallenge({
+                    challengeType: 'intrigue',
+                    defendingPlayer: this.controller
+                }),
+            match: this,
+            effect: [ability.effects.canBeDeclaredWithoutIcon()]
+        });
+    }
+}
+
+WaterGardensSentry.code = '25067';
+
+export default WaterGardensSentry;

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -217,6 +217,11 @@ const Costs = {
      */
     discardFromShadows: (condition) => CostBuilders.discardFromShadows.select(condition),
     /**
+     * Cost that requires discarding a card from play matching the passed
+     * condition predicate function.
+     */
+    discardFromPlay: (condition) => CostBuilders.discardFromPlay.select(condition),
+    /**
      * Cost that requires discarding the top card from the draw deck.
      */
     discardFromDeck: () => new DiscardFromDeckCost(),

--- a/server/game/costs/CostBuilders.js
+++ b/server/game/costs/CostBuilders.js
@@ -2,6 +2,7 @@ import CostBuilder from './CostBuilder.js';
 import DiscardDuplicateCost from './DiscardDuplicateCost.js';
 import DiscardFromHandCost from './DiscardFromHandCost.js';
 import DiscardFromShadowsCost from './DiscardFromShadowsCost.js';
+import DiscardFromPlayCost from './DiscardFromPlayCost.js';
 import DiscardPowerCost from './DiscardPowerCost.js';
 import DiscardTokenCost from './DiscardTokenCost.js';
 import KillCost from './KillCost.js';
@@ -30,6 +31,10 @@ const CostBuilders = {
     discardFromShadows: new CostBuilder(new DiscardFromShadowsCost(), {
         select: 'Select card to discard from shadows',
         selectMultiple: (number) => `Select ${number} cards to discard from shadows`
+    }),
+    discardFromPlay: new CostBuilder(new DiscardFromPlayCost(), {
+        select: 'Select card to discard',
+        selectMultiple: (number) => `Select ${number} cards to discard`
     }),
     discardPower: function (amount = 1) {
         return new CostBuilder(new DiscardPowerCost(amount), {

--- a/server/game/costs/DiscardFromPlayCost.js
+++ b/server/game/costs/DiscardFromPlayCost.js
@@ -1,0 +1,30 @@
+import GameActions from '../GameActions/index.js';
+
+class DiscardFromPlayCost {
+    constructor() {
+        this.name = 'discardFromPlay';
+    }
+
+    isEligible(card) {
+        return (
+            card.location === 'play area' &&
+            GameActions.discardCard({ card, allowSave: false }).allow()
+        );
+    }
+
+    pay(cards, context) {
+        context.game.resolveGameAction(
+            GameActions.simultaneously(
+                cards.map((card) =>
+                    GameActions.discardCard({
+                        card,
+                        allowSave: false
+                    })
+                )
+            ),
+            context
+        );
+    }
+}
+
+export default DiscardFromPlayCost;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -401,6 +401,10 @@ class DrawCard extends BaseCard {
         this.childCards = this.childCards.filter((a) => a !== card);
     }
 
+    get underneath() {
+        return this.childCards.filter((childCard) => childCard.location === 'underneath');
+    }
+
     getPlayActions() {
         return StandardPlayActions.concat(this.abilities.playActions).concat(
             this.abilities.actions.filter((action) => !action.allowMenu())

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1516,14 +1516,15 @@ const Effects = {
             isStateDependent: true
         };
     },
-    mustChooseAsClaim: function (cardFunc) {
+    mustChooseAsClaim: function () {
         return {
-            targetType: 'player',
-            apply: function (player) {
-                player.mustChooseAsClaim.push(cardFunc);
+            apply: function (card) {
+                card.controller.mustChooseAsClaim.push(card);
             },
-            unapply: function (player) {
-                player.mustChooseAsClaim = player.mustChooseAsClaim.filter((c) => c !== cardFunc);
+            unapply: function (card) {
+                card.controller.mustChooseAsClaim = card.controller.mustChooseAsClaim.filter(
+                    (c) => c !== card
+                );
             }
         };
     },

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1772,17 +1772,22 @@ const Effects = {
         return {
             targetType: 'player',
             apply: function (player, context) {
-                for (let card of player.hand) {
-                    player.removeCardFromPile(card);
-                    context.source.addChildCard(card, 'underneath');
-                    card.facedown = true;
-                }
+                context.game.resolveGameAction(
+                    GameActions.simultaneously(
+                        player.hand.map((card) =>
+                            GameActions.placeCardUnderneath({
+                                card,
+                                player,
+                                parentCard: context.source,
+                                facedown: true
+                            })
+                        )
+                    )
+                );
             },
             unapply: function (player, context) {
                 player.discardCards(player.hand);
-                for (let card of context.source.childCards.filter(
-                    (card) => card.controller === player && card.location === 'underneath'
-                )) {
+                for (const card of context.source.underneath) {
                     player.moveCard(card, 'hand');
                 }
                 context.game.addMessage(

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1481,7 +1481,7 @@ class Game extends EventEmitter {
             return {
                 name: player.name,
                 faction: player.faction.name || player.faction.value,
-                agenda: player.agenda ? player.agenda.name : undefined,
+                agendas: player.agendas ? player.agendas.map((agenda) => agenda.name) : undefined,
                 power: player.getTotalPower(),
                 playtested: this.isPlaytesting()
                     ? player.preparedDeck.allCards
@@ -1562,7 +1562,7 @@ class Game extends EventEmitter {
             }
 
             playerSummaries[player.name] = {
-                agenda: player.agenda ? player.agenda.code : undefined,
+                agendas: player.agendas.map((agenda) => agenda.code),
                 deck: deck,
                 faction: player.faction.code,
                 id: player.id,

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1562,7 +1562,7 @@ class Game extends EventEmitter {
             }
 
             playerSummaries[player.name] = {
-                agendas: player.agendas.map((agenda) => agenda.code),
+                agendas: player.agendas?.map((agenda) => agenda.code),
                 deck: deck,
                 faction: player.faction.code,
                 id: player.id,

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -11,7 +11,7 @@ class FulfillMilitaryClaim extends BaseStep {
     continue() {
         // TODO: Add forced claim to fulfillmilitaryclaim.spec.js
         this.forcedClaim = this.player.filterCardsInPlay((card) =>
-            this.player.mustChooseAsClaim.some((cardFunc) => cardFunc(card))
+            this.player.mustChooseAsClaim.includes(card)
         );
 
         let claimToSelect = this.claim;

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -28,12 +28,12 @@ class SetupPhase extends Phase {
 
     announceFactionAndAgenda() {
         for (const player of this.game.getPlayers()) {
-            player.createFactionAndAgenda();
+            player.createFactionAndAgendas();
             this.game.addMessage(
                 '{0} announces they are playing as {1} with {2}',
                 player,
                 player.faction,
-                player.agenda || 'no agenda'
+                player.agendas || 'no agenda'
             );
         }
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -40,9 +40,6 @@ class Player extends Spectator {
         this.outOfGamePile = [];
         this.shadows = [];
 
-        // Agenda specific piles
-        this.bannerCards = [];
-
         this.faction = new DrawCard(this, {});
 
         this.owner = owner;
@@ -182,6 +179,13 @@ class Player extends Spectator {
 
     getFaction() {
         return this.faction.getPrintedFaction();
+    }
+
+    /**
+     * The primary agenda for this player
+     */
+    get agenda() {
+        return this.agendas && this.agendas.length > 0 ? this.agendas[0] : undefined;
     }
 
     getNumberOfUsedPlots() {
@@ -453,17 +457,16 @@ class Player extends Spectator {
         var deck = new Deck(this.deck);
         var preparedDeck = deck.prepare(this);
         this.plotDeck = preparedDeck.plotCards;
-        this.agenda = preparedDeck.agenda;
+        this.agendas = preparedDeck.agendas;
         this.faction = preparedDeck.faction;
         this.drawDeck = preparedDeck.drawCards;
-        this.bannerCards = preparedDeck.bannerCards;
         this.preparedDeck = preparedDeck;
 
         this.shuffleDrawDeck();
     }
 
     initialise() {
-        this.createFactionAndAgenda();
+        this.createFactionAndAgendas();
 
         this.gold = 0;
         this.readyToStart = false;
@@ -472,10 +475,10 @@ class Player extends Spectator {
         this.activePlot = undefined;
     }
 
-    createFactionAndAgenda() {
+    createFactionAndAgendas() {
         let deck = new Deck(this.deck);
         this.faction = deck.createFactionCard(this);
-        this.agenda = deck.createAgendaCard(this);
+        this.agendas = deck.createAgendaCards(this);
     }
 
     hasFlag(flagName) {
@@ -1434,9 +1437,10 @@ class Player extends Spectator {
 
         let state = {
             activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
-            agenda: this.agenda ? this.agenda.getSummary(activePlayer) : undefined,
+            agendas: this.agendas
+                ? this.agendas.map((agenda) => agenda.getSummary(activePlayer))
+                : undefined,
             cardPiles: {
-                bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
                 cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
                 deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
                 discardPile: this.getSummaryForCardList(fullDiscardPile, activePlayer).reverse(),

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -42,7 +42,6 @@ class Player extends Spectator {
 
         // Agenda specific piles
         this.bannerCards = [];
-        this.conclavePile = [];
 
         this.faction = new DrawCard(this, {});
 
@@ -929,9 +928,8 @@ class Player extends Spectator {
                 return this.outOfGamePile;
             case 'shadows':
                 return this.shadows;
-            // Agenda specific piles
-            case 'conclave':
-                return this.conclavePile;
+            case 'agenda':
+                return this.agenda.childCards;
         }
     }
 
@@ -967,9 +965,8 @@ class Player extends Spectator {
             case 'shadows':
                 this.shadows = targetList;
                 break;
-            // Agenda specific piles
-            case 'conclave':
-                this.conclavePile = targetList;
+            case 'agenda':
+                this.agenda.childCards = targetList;
         }
     }
 
@@ -1441,7 +1438,6 @@ class Player extends Spectator {
             cardPiles: {
                 bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
                 cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
-                conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer),
                 deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
                 discardPile: this.getSummaryForCardList(fullDiscardPile, activePlayer).reverse(),
                 drawDeck: this.getSummaryForCardList(this.drawDeck, activePlayer),

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -152,10 +152,9 @@ class TriggeredAbility extends BaseAbility {
         // inappropriate locations when requirements are checked for the ability.
         //
         // Also apparently the draw deck because of Maester Gormon.
-        // Also also apparently under conclave due to Archmaester Marwyn.
+        // Also also apparently under cards due to Archmaester Marwyn.
         if (this.isPlayableEventAbility()) {
             return [
-                'conclave',
                 'discard pile',
                 'draw deck',
                 'hand',

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -1012,7 +1012,7 @@ class Lobby {
                     name: player.name,
                     owner: game.owner === player.name,
                     faction: { cardData: { code: player.faction } },
-                    agenda: { cardData: { code: player.agenda } },
+                    agendas: player.agendas.map((code) => ({ cardData: { code } })),
                     user: new User(player.user)
                 };
             }

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -56,7 +56,9 @@ class PendingGame {
     getSaveState() {
         var players = _.map(this.getPlayers(), (player) => {
             return {
-                agenda: player.agenda ? player.agenda.cardData.name : undefined,
+                agendas: player.agendas
+                    ? player.agendas.map((agenda) => agenda.cardData.name)
+                    : undefined,
                 faction: player.faction.cardData.name,
                 name: player.name
             };
@@ -79,13 +81,12 @@ class PendingGame {
         player.faction.cardData.strength = 0;
     }
 
-    setupAgenda(player, agenda) {
+    setupAgendas(player, agenda, ...additional) {
         if (!agenda) {
             return;
         }
 
-        player.agenda = {};
-        player.agenda.cardData = agenda;
+        player.agendas = [agenda, ...additional].map((agenda) => ({ cardData: agenda }));
     }
 
     // Actions
@@ -263,7 +264,7 @@ class PendingGame {
         player.deck.selected = true;
 
         this.setupFaction(player, deck.faction);
-        this.setupAgenda(player, deck.agenda);
+        this.setupAgendas(player, deck.agenda, ...deck.bannerCards);
     }
 
     // interrogators
@@ -344,9 +345,9 @@ class PendingGame {
             //1. the game is NOT private
             //2. the game hasn´t started yet
             //3. agenda and faction are actually not undefined
-            let agenda;
-            if (!this.gamePrivate && this.started && player.agenda) {
-                agenda = player.agenda.cardData.code;
+            let agendas = [undefined];
+            if (!this.gamePrivate && this.started && player.agendas) {
+                agendas = player.agendas.map((card) => card.cardData.code);
             }
             let faction;
             if (!this.gamePrivate && this.started && player.faction) {
@@ -354,7 +355,7 @@ class PendingGame {
             }
 
             playerSummaries[player.name] = {
-                agenda: agenda,
+                agendas: agendas,
                 deck: activePlayer ? deck : {},
                 faction: faction,
                 id: player.id,

--- a/test/server/GameActions/PlaceCardUnderneath.spec.js
+++ b/test/server/GameActions/PlaceCardUnderneath.spec.js
@@ -1,0 +1,110 @@
+import PlaceCardUnderneath from '../../../server/game/GameActions/PlaceCardUnderneath.js';
+
+describe('PlaceCardUnderneath', function () {
+    beforeEach(function () {
+        this.controllerSpy = jasmine.createSpyObj('player', ['removeCardFromPile']);
+        this.controllerSpy.drawDeck = [];
+
+        this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction']);
+        this.cardSpy.location = 'hand';
+        this.cardSpy.controller = this.controllerSpy;
+
+        this.parentSpy = jasmine.createSpyObj('parent', ['addChildCard']);
+        this.parentSpy.controller = this.controllerSpy;
+        this.parentSpy.underneath = [];
+
+        this.props = { card: this.cardSpy, parentCard: this.parentSpy };
+    });
+
+    describe('allow()', function () {
+        beforeEach(function () {
+            this.cardSpy.allowGameAction.and.returnValue(true);
+        });
+
+        describe('when the card is being placed under a card in a different location', function () {
+            beforeEach(function () {
+                this.parentSpy.location = 'play area';
+            });
+
+            it('returns true', function () {
+                expect(PlaceCardUnderneath.allow(this.props)).toBe(true);
+            });
+        });
+
+        describe('when the card is being placed under a card it is currently under', function () {
+            beforeEach(function () {
+                this.parentSpy.location = 'play area';
+                this.parentSpy.underneath = [this.cardSpy];
+            });
+
+            it('returns false', function () {
+                expect(PlaceCardUnderneath.allow(this.props)).toBe(false);
+            });
+        });
+
+        describe('when the card is being placed under a card in an invalid location', function () {
+            beforeEach(function () {
+                this.parentSpy.location = 'draw deck';
+            });
+
+            it('returns false', function () {
+                expect(PlaceCardUnderneath.allow(this.props)).toBe(false);
+            });
+        });
+    });
+
+    xdescribe('createEvent()', function () {
+        beforeEach(function () {
+            this.event = PlaceCardUnderneath.createEvent(this.props);
+        });
+
+        it('creates a onCardPlacedUnderneath event', function () {
+            expect(this.event.name).toBe('onCardPlacedUnderneath');
+            expect(this.event.card).toBe(this.cardSpy);
+            expect(this.event.parentCard).toBe(this.parentSpy);
+            expect(this.event.facedown).toBe(false);
+        });
+
+        describe('the event handler', function () {
+            describe('when the target location is in-play', function () {
+                beforeEach(function () {
+                    this.parentSpy.location = 'play area';
+                    this.event.executeHandler();
+                });
+
+                it('removes it from current pile', function () {
+                    expect(this.controllerSpy.removeCardFromPile).toHaveBeenCalledWith(
+                        this.cardSpy
+                    );
+                });
+
+                it('adds it as a child to the parent', function () {
+                    expect(this.parentSpy.addChildCard).toHaveBeenCalledWith(
+                        this.cardSpy,
+                        'underneath'
+                    );
+                });
+            });
+
+            describe('when the target location is under an agenda', function () {
+                beforeEach(function () {
+                    this.controllerSpy.agenda = this.parentSpy;
+                    this.event.executeHandler();
+                });
+
+                it('removes it from current pile', function () {
+                    expect(this.controllerSpy.removeCardFromPile).toHaveBeenCalledWith(
+                        this.cardSpy
+                    );
+                });
+
+                it('adds it as a child to the agenda', function () {
+                    expect(this.parentSpy.addChildCard).toHaveBeenCalledWith(
+                        this.cardSpy,
+                        'underneath'
+                    );
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/04.2-CtA/DolorousEdd.spec.js
+++ b/test/server/cards/04.2-CtA/DolorousEdd.spec.js
@@ -4,7 +4,7 @@ describe('Dolorous Edd', function () {
             const deck1 = this.buildDeck('thenightswatch', ['Sneak Attack', 'Dolorous Edd']);
             const deck2 = this.buildDeck('lannister', [
                 'Sneak Attack',
-                'Grand Maester Pycelle',
+                'Grand Maester Pycelle (Core)',
                 'Ser Jaime Lannister (LoCR)'
             ]);
             this.player1.selectDeck(deck1);
@@ -12,7 +12,7 @@ describe('Dolorous Edd', function () {
             this.startGame();
             this.keepStartingHands();
 
-            this.player2.clickCard('Grand Maester Pycelle', 'hand');
+            this.player2.clickCard('Grand Maester Pycelle (Core)', 'hand');
             this.player2.clickCard('Ser Jaime Lannister', 'hand');
             this.completeSetup();
             this.selectFirstPlayer(this.player2);
@@ -25,7 +25,7 @@ describe('Dolorous Edd', function () {
         });
 
         it('should allow Dolorous Edd to jump in to the challenge', function () {
-            this.player2.clickCard('Grand Maester Pycelle', 'play area');
+            this.player2.clickCard('Grand Maester Pycelle (Core)', 'play area');
             this.player2.clickPrompt('Done');
 
             // Skip player 2's action window
@@ -40,7 +40,7 @@ describe('Dolorous Edd', function () {
 
         describe('when the player wins the challenge Edd enters', function () {
             beforeEach(function () {
-                this.player2.clickCard('Grand Maester Pycelle', 'play area');
+                this.player2.clickCard('Grand Maester Pycelle (Core)', 'play area');
                 this.player2.clickPrompt('Done');
 
                 // Skip player 2's action window

--- a/test/server/cards/15-DotE/ArchmaesterMarwyn.spec.js
+++ b/test/server/cards/15-DotE/ArchmaesterMarwyn.spec.js
@@ -1,3 +1,5 @@
+import PlaceCardUnderneath from '../../../../server/game/GameActions/PlaceCardUnderneath.js';
+
 describe('Archmaester Marwyn', function () {
     integration(function () {
         describe('ability', function () {
@@ -22,11 +24,14 @@ describe('Archmaester Marwyn', function () {
                 this.event = this.player1.findCardByName('Tithe');
 
                 this.player1.clickCard(this.marwyn);
-                // Move the rest of cards under the agenda
-                this.player1Object.moveCard(this.dupe, 'conclave');
-                this.player1Object.moveCard(this.card, 'conclave');
-                this.player1Object.moveCard(this.shadowCard, 'conclave');
-                this.player1Object.moveCard(this.event, 'conclave');
+                // Properly place all cards facedown under agenda
+                for (const card of [this.dupe, this.card, this.shadowCard, this.event]) {
+                    PlaceCardUnderneath.createEvent({
+                        card,
+                        parentCard: this.player1Object.agenda,
+                        facedown: true
+                    }).executeHandler();
+                }
 
                 this.completeSetup();
 
@@ -45,7 +50,7 @@ describe('Archmaester Marwyn', function () {
                 it('counts toward the limit', function () {
                     this.player1.clickCard(this.dupe);
 
-                    expect(this.dupe.location).toEqual('conclave');
+                    expect(this.player1Object.agenda.underneath).toContain(this.dupe);
                 });
             });
 
@@ -62,7 +67,7 @@ describe('Archmaester Marwyn', function () {
                 it('counts toward the limit', function () {
                     this.player1.clickCard(this.card);
 
-                    expect(this.card.location).toEqual('conclave');
+                    expect(this.player1Object.agenda.underneath).toContain(this.card);
                 });
             });
 
@@ -78,7 +83,7 @@ describe('Archmaester Marwyn', function () {
                 it('counts toward the limit', function () {
                     this.player1.clickCard(this.card);
 
-                    expect(this.card.location).toEqual('conclave');
+                    expect(this.player1Object.agenda.underneath).toContain(this.card);
                 });
             });
 
@@ -95,7 +100,7 @@ describe('Archmaester Marwyn', function () {
                 it('counts toward the limit', function () {
                     this.player1.clickCard(this.card);
 
-                    expect(this.card.location).toEqual('conclave');
+                    expect(this.player1Object.agenda.underneath).toContain(this.card);
                 });
             });
         });

--- a/test/server/cards/25.4-TTS/JonSnow.spec.js
+++ b/test/server/cards/25.4-TTS/JonSnow.spec.js
@@ -1,0 +1,212 @@
+describe('Jon Snow (TTS)', function () {
+    integration(function () {
+        beforeEach(function () {
+            const deck1 = this.buildDeck('stark', [
+                'Trading with the Pentoshi',
+                'Jon Snow (TTS)',
+                'Spearmaiden',
+                'Grey Wind (FtR)',
+                'Winter Is Coming'
+            ]);
+            const deck2 = this.buildDeck('baratheon', [
+                'Trading with the Pentoshi',
+                'Robert Baratheon (Core)',
+                'Stannis Baratheon (Core)',
+                'Selyse Baratheon (Core)',
+                'Mya Stone'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.jon = this.player1.findCardByName('Jon Snow');
+            this.spearmaiden = this.player1.findCardByName('Spearmaiden');
+            this.greywind = this.player1.findCardByName('Grey Wind (FtR)');
+            this.winteriscoming = this.player1.findCardByName('Winter Is Coming');
+            this.robert = this.player2.findCardByName('Robert Baratheon');
+            this.stannis = this.player2.findCardByName('Stannis Baratheon');
+            this.selyse = this.player2.findCardByName('Selyse Baratheon');
+            this.mya = this.player2.findCardByName('Mya Stone');
+
+            this.player1.clickCard(this.jon);
+            this.player2.clickCard(this.robert);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.player1.clickCard(this.spearmaiden);
+            this.player1.clickPrompt('Done');
+            this.player2.clickCard(this.stannis);
+            this.player2.clickCard(this.selyse);
+            this.player2.clickPrompt('Done');
+        });
+
+        describe('when military claim is applied as the attacker', function () {
+            beforeEach(function () {
+                this.unopposedChallenge(this.player1, 'military', this.jon);
+                this.player1.clickPrompt('Apply Claim');
+            });
+
+            it('should allow Jon Snow to trigger', function () {
+                expect(this.player1).toAllowAbilityTrigger(this.jon);
+            });
+        });
+
+        describe('when military claim is applied as the defender', function () {
+            beforeEach(function () {
+                // Pass challenges
+                this.player1.clickPrompt('Done');
+                this.unopposedChallenge(this.player2, 'military', this.robert);
+                this.player2.clickPrompt('Apply Claim');
+            });
+
+            it('should allow Jon Snow to trigger', function () {
+                expect(this.player1).toAllowAbilityTrigger(this.jon);
+            });
+        });
+
+        describe('when there is 1 character kneeling', function () {
+            beforeEach(function () {
+                // Kneel robert
+                this.player2.clickCard(this.robert);
+            });
+
+            describe('and a military claim of 1 is applied', function () {
+                beforeEach(function () {
+                    // Player 1's claim is already 1
+                    this.unopposedChallenge(this.player1, 'military', this.jon);
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                describe('and Jon triggers on kneeling characters', function () {
+                    beforeEach(function () {
+                        this.player1.clickCard(this.jon);
+                        this.player1.clickPrompt('Kneeling Characters');
+                    });
+
+                    it('should force that kneeling character to be chosen for claim', function () {
+                        expect(this.player2).toAllowSelect(this.robert);
+                        expect(this.player2).not.toAllowSelect(this.stannis);
+                        expect(this.player2).not.toAllowSelect(this.selyse);
+                    });
+                });
+
+                describe('and Jon triggers on standing characters', function () {
+                    beforeEach(function () {
+                        this.player1.clickCard(this.jon);
+                        this.player1.clickPrompt('Standing Characters');
+                    });
+
+                    it('should prevent that kneeling character from being chosen for claim', function () {
+                        expect(this.player2).not.toAllowSelect(this.robert);
+                        expect(this.player2).toAllowSelect(this.stannis);
+                        expect(this.player2).toAllowSelect(this.selyse);
+                    });
+                });
+            });
+
+            describe('and Spearmaiden chooses a standing character', function () {
+                beforeEach(function () {
+                    this.player1.clickPrompt('military');
+                    this.player1.clickCard(this.jon);
+                    this.player1.clickCard(this.spearmaiden);
+                    this.player1.clickPrompt('Done');
+                    // Choose Stannis for Spearmaiden ability
+                    this.player1.clickCard(this.spearmaiden);
+                    this.player1.clickCard(this.stannis);
+
+                    this.skipActionWindow();
+
+                    this.player2.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                describe('and Jon triggers on kneeling characters', function () {
+                    beforeEach(function () {
+                        this.player1.clickCard(this.jon);
+                        this.player1.clickPrompt('Kneeling Characters');
+                    });
+
+                    it('should allow the defender to choose between the kneeling character, and the character chosen by Spearmaiden', function () {
+                        expect(this.player2).toAllowSelect(this.robert);
+                        expect(this.player2).toAllowSelect(this.stannis);
+                        expect(this.player2).not.toAllowSelect(this.selyse);
+                    });
+                });
+            });
+
+            describe('and a military claim of 2 is applied', function () {
+                beforeEach(function () {
+                    this.player1.clickPrompt('military');
+                    this.player1.clickCard(this.jon);
+                    this.player1.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    this.player2.clickPrompt('Done');
+
+                    // Raise claim to 2
+                    this.player1.clickCard(this.winteriscoming);
+                    this.player2.clickPrompt('Pass');
+                    this.player1.clickPrompt('Pass');
+
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                describe('and Jon triggers on kneeling characters', function () {
+                    beforeEach(function () {
+                        this.player1.clickCard(this.jon);
+                        this.player1.clickPrompt('Kneeling Characters');
+                    });
+
+                    it('should force that kneeling character to be chosen for claim, and allow 1 standing character be chosen for claim', function () {
+                        expect(this.player2).not.toAllowSelect(this.robert);
+                        expect(this.player2).toAllowSelect(this.stannis);
+                        expect(this.player2).toAllowSelect(this.selyse);
+                    });
+                });
+            });
+        });
+
+        describe('when Jon chooses to satisfy claim on standing characters, and one of those characters kneels before claim is chosen', function () {
+            beforeEach(function () {
+                // Attach grey wind to Jon (to cancel Mya)
+                this.player1.dragCard(this.greywind, 'play area');
+                this.player1.clickCard(this.jon);
+                // Put Mya Stone into play
+                this.player2.dragCard(this.mya, 'play area');
+                this.player1.clickPrompt('military');
+                this.player1.clickCard(this.jon);
+                this.player1.clickPrompt('Done');
+                // Skip stealth for Jon
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player1.clickPrompt('Apply Claim');
+
+                this.player1.clickCard(this.jon);
+                this.player1.clickPrompt('Standing Characters');
+
+                // Player 2 attempts to trigger Mya Stone
+                this.player2.clickCard(this.mya);
+                // Player 1 returns Grey Wind to hand to cancel Mya, leaving claim as military, but she is now kneeling
+                this.player1.clickCard(this.greywind);
+                this.player1.clickCard(this.greywind);
+            });
+
+            it('should allow you to select all standing characters, and that knelt character, for claim', function () {
+                expect(this.player2).toAllowSelect(this.robert);
+                expect(this.player2).toAllowSelect(this.stannis);
+                expect(this.player2).toAllowSelect(this.selyse);
+                expect(this.player2).toAllowSelect(this.mya);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Releases all 20 cards from [Ten Thousand Ships](https://thronesdb.com/set/TTS/scan).

Additional changes:
- [x] Removing references to underneath agenda being "conclave", and switching to a more standardised "underneath" format. Cards are now actually treated as being underneath your main agenda, with any agenda being able to take cards underneath it.
  - [ ] *Optional:* Revamp the "underneath" system to no longer be a separate "underneath" location, but rather share it's location with the parent. Will require special consideration with in-play effects to not target facedown cards underneath others in this scenario.
- [x] Create unit tests to match Jon Snow rulings outlined below
  - _A forced claim test for `fulfillmilitaryclaim.spec.js` would be useful, but is not required just yet._
- [x] Revamping the look of "additional agendas" (currently only Alliance) to no longer show within a pop-up window:
  - [x] Update the in-game look to spread all agendas under each-other, similar to ones hand. Will make player-row wider, but this isn't anything new with shadows doing the same.
  - [x] Update the lobby-view to show alliance agendas.
- [x] Finally fix https://github.com/throneteki/throneteki/issues/3179, especially as this update involves some edits in the same area.
  - _Honestly, the entire "menu" system could use a rework in itself; it's working though!_
- [ ] General solution for specific **Interrupt** effects for characters being discarded (or, similarly, revealed); Pycelle currently triggers whilst the card is in hand but does not reveal it. Might be worth adding a "showTarget" to ensure that, when the interrupt fires on a card being discarded, it shows all players (reveals in client) that target during that interrupt window.
  - _NOT COMPLETE: Going to leave this to be part of the events update, as it involves a few interactions that are already being worked on there. See https://github.com/throneteki/throneteki/pull/3493 for more details._

Special rulings to consider for **[Jon Snow (TTS)](https://thronesdb.com/card/25071)**:
1. When Jon is triggered, his ability is applying the effect of "must be chosen for claim" to each character of that chosen group (even though the ability itself doesnt say "each").
   - For example, I have Robert Baratheon & Stannis Baratheon standing, and Edric Storm kneeling. Triggering "standing" on Jon essentially translates to:
     - Robert Baratheon must be chosen for claim
     - Stannis Baratheon must be chosen for claim
   - If claim was 1 for the above scenario, I must fulfill as much of claim as possible among the must be chosen characters (ie choose Robert or Stannis for claim)
   - Any other "must be chosen for claim" effects during this time, such as [Spearmaiden](https://thronesdb.com/card/04055), will also be available to be chosen for claim, regardless of whether they were standing or kneeling
2. If a character were to stand/kneel after Jon is triggered but before claim is chosen, that character does not change the "group" it was chosen in.
   - For example, Jon triggers "standing" which targets my standing Mya Stone. I then trigger Mya Stone (kneeling her as an interrupt to :military: claim) but she gets canceled. Mya Stone will still be targetable for claim, alongside all other standing characters I control, as she was standing when Jon's ability was triggered.
3. When a chosen "group" has less characters than the claim value, all characters in that group would be chosen, and the "spill-over" hits remaining characters.
   - For example, I have Cersei Lannsiter & Jaime Lannister standing, and Myrcella Baratheon & Tommen Baratheon kneeling, and I am being hit with 3 claim. Cersei & Jaime must be chosen for claim and, as there are no more standing characters for the third claim, I choose the "spill-over" of 1 between Myrcella or Tommen.