### PR TITLE
Releasing The Iron Chronicle

### DIFF
--- a/server/game/AllowedChallenges.js
+++ b/server/game/AllowedChallenges.js
@@ -8,6 +8,7 @@ class AllowedChallenges {
             new AllowedChallenge('intrigue'),
             new AllowedChallenge('power')
         ];
+        this.forcedChallenges = [];
         this.restrictions = [];
 
         this.reset();
@@ -25,35 +26,69 @@ class AllowedChallenges {
 
     track(challenge) {
         if (challenge.attackingPlayer === this.player) {
-            this.useAllowedChallenge(challenge);
+            this.useChallenge(challenge);
         }
     }
 
-    useAllowedChallenge(challenge) {
-        let allowedChallenge = this.allowedChallenges.find((allowedChallenge) =>
+    useChallenge(challenge) {
+        const allowedChallenge = this.allowedChallenges.find((allowedChallenge) =>
             allowedChallenge.isMatch(challenge.initiatedChallengeType, challenge.defendingPlayer)
         );
         if (allowedChallenge) {
             allowedChallenge.markUsed(challenge);
         }
+
+        const forcedChallenge = this.forcedChallenges.find((forcedChallenge) =>
+            forcedChallenge.isMatch(
+                this.player,
+                challenge.initiatedChallengeType,
+                challenge.defendingPlayer
+            )
+        );
+        if (forcedChallenge) {
+            forcedChallenge.markSatisfied(challenge);
+        }
     }
 
     untrack(challenge) {
-        let allowedChallenge = this.allowedChallenges.find(
+        const allowedChallenge = this.allowedChallenges.find(
             (allowedChallenge) => allowedChallenge.challenge === challenge && allowedChallenge.used
         );
         if (allowedChallenge) {
             allowedChallenge.resetUsage();
         }
-    }
 
-    reset() {
-        for (let allowedChallenge of this.allowedChallenges) {
-            allowedChallenge.resetUsage();
+        const forcedChallenge = this.forcedChallenges.find(
+            (forcedChallenge) =>
+                forcedChallenge.challenge === challenge && forcedChallenge.satisfied
+        );
+        if (forcedChallenge) {
+            forcedChallenge.resetUsage();
         }
     }
 
+    reset() {
+        for (const allowedChallenge of this.allowedChallenges) {
+            allowedChallenge.resetUsage();
+        }
+        for (const forcedChallenge of this.forcedChallenges) {
+            forcedChallenge.resetUsage();
+        }
+    }
+
+    mustInitiate(challengeType, opponent) {
+        return this.forcedChallenges.some(
+            (forcedChallenge) =>
+                forcedChallenge.isMatch(challengeType, opponent) &&
+                this.hasCardsToInitiate(forcedChallenge.challengeType)
+        );
+    }
+
     canInitiate(challengeType, opponent) {
+        if (this.player.isSupporter(opponent)) {
+            return false;
+        }
+
         if (!!this.maxTotal && this.numInitiated >= this.maxTotal) {
             return false;
         }
@@ -62,8 +97,30 @@ class AllowedChallenges {
             return false;
         }
 
-        return this.allowedChallenges.some((allowedChallenge) =>
-            allowedChallenge.isMatch(challengeType, opponent)
+        const forcableChallenges = this.forcedChallenges.filter(
+            (forcedChallenge) =>
+                !forcedChallenge.satisfied && this.hasCardsToInitiate(forcedChallenge.challengeType)
+        );
+
+        if (forcableChallenges.length > 0) {
+            return forcableChallenges.some((forcedChallenge) =>
+                forcedChallenge.isMatch(challengeType, opponent)
+            );
+        }
+
+        return this.allowedChallenges.some(
+            (allowedChallenge) =>
+                allowedChallenge.isMatch(challengeType, opponent) &&
+                this.hasCardsToInitiate(allowedChallenge.challengeType)
+        );
+    }
+
+    hasCardsToInitiate(challengeType) {
+        return this.player.anyCardsInPlay((card) =>
+            card.canParticipate({
+                attacking: true,
+                challengeType
+            })
         );
     }
 
@@ -88,9 +145,20 @@ class AllowedChallenges {
     }
 
     removeAllowedChallenge(allowedChallenge) {
-        let index = this.allowedChallenges.findIndex((a) => a === allowedChallenge);
+        const index = this.allowedChallenges.findIndex((a) => a === allowedChallenge);
         if (index !== -1) {
             this.allowedChallenges.splice(index, 1);
+        }
+    }
+
+    addForcedChallenge(forcedChallenge) {
+        this.forcedChallenges.push(forcedChallenge);
+    }
+
+    removeForcedChallenge(forcedChallenge) {
+        const index = this.forcedChallenges.findIndex((a) => a === forcedChallenge);
+        if (index !== -1) {
+            this.forcedChallenges.splice(index, 1);
         }
     }
 }

--- a/server/game/ForcedChallenge.js
+++ b/server/game/ForcedChallenge.js
@@ -1,0 +1,25 @@
+class ForcedChallenge {
+    constructor(challengeType, opponentFunc = () => true) {
+        this.challengeType = challengeType;
+        this.opponentFunc = opponentFunc;
+        this.satisfied = false;
+    }
+
+    markSatisfied(challenge) {
+        this.challenge = challenge;
+        this.satisfied = true;
+    }
+
+    resetUsage() {
+        this.challenge = null;
+        this.satisfied = false;
+    }
+
+    isMatch(challengeType, opponent) {
+        return (
+            !this.satisfied && this.challengeType === challengeType && this.opponentFunc(opponent)
+        );
+    }
+}
+
+export default ForcedChallenge;

--- a/server/game/GameActions/ApplyClaim.js
+++ b/server/game/GameActions/ApplyClaim.js
@@ -1,0 +1,17 @@
+import SatisfyClaim from '../gamesteps/challenge/SatisfyClaim.js';
+import GameAction from './GameAction.js';
+
+class ApplyClaim extends GameAction {
+    constructor() {
+        super('applyClaim');
+    }
+
+    createEvent({ player, challenge, claim, game }) {
+        return this.event('onClaimApplied', { player, challenge, claim }, (event) => {
+            // TODO: Move "SatisfyClaim" logic into here, properly.
+            game.queueStep(new SatisfyClaim(game, event.claim));
+        });
+    }
+}
+
+export default new ApplyClaim();

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -1,6 +1,7 @@
 import AbilityAdapter from './AbilityAdapter.js';
 import AddToChallenge from './AddToChallenge.js';
 import AddToHand from './AddToHand.js';
+import ApplyClaim from './ApplyClaim.js';
 import CancelEffects from './CancelEffects.js';
 import CheckReserve from './CheckReserve.js';
 import ChooseGameAction from './ChooseGameAction.js';
@@ -46,6 +47,7 @@ import TakeControl from './TakeControl.js';
 const GameActions = {
     addToChallenge: (props) => new AbilityAdapter(AddToChallenge, props),
     addToHand: (props) => new AbilityAdapter(AddToHand, props),
+    applyClaim: (props) => new AbilityAdapter(ApplyClaim, props),
     cancelEffects: (props) => new AbilityAdapter(CancelEffects, props),
     checkReserve: (props) => new AbilityAdapter(CheckReserve, props),
     choose: (props) => new ChooseGameAction(props),

--- a/server/game/cards/01-Core/NavalSuperiority.js
+++ b/server/game/cards/01-Core/NavalSuperiority.js
@@ -7,7 +7,7 @@ class NavalSuperiority extends PlotCard {
                 card.controller.activePlot === card &&
                 (card.hasTrait('Kingdom') || card.hasTrait('Edict')),
             targetController: 'any',
-            effect: ability.effects.preventPlotModifier('gold')
+            effect: ability.effects.setBaseGold(0)
         });
     }
 }

--- a/server/game/cards/02.1-TtB/TheSeastoneChair.js
+++ b/server/game/cards/02.1-TtB/TheSeastoneChair.js
@@ -5,6 +5,7 @@ class TheSeastoneChair extends DrawCard {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isUnopposed() &&
                     event.challenge.challengeType === 'military' &&
                     event.challenge.attackingPlayer === this.controller

--- a/server/game/cards/02.5-COW/MirriMazDuur.js
+++ b/server/game/cards/02.5-COW/MirriMazDuur.js
@@ -5,6 +5,7 @@ class MirriMazDuur extends DrawCard {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isMatch({ winner: this.controller, attackingAlone: this })
             },
             target: {

--- a/server/game/cards/02.5-COW/TrialByCombat.js
+++ b/server/game/cards/02.5-COW/TrialByCombat.js
@@ -1,11 +1,12 @@
 import DrawCard from '../../drawcard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
+import SatisfyClaim from '../../gamesteps/challenge/SatisfyClaim.js';
 
 class TrialByCombat extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.winner === this.controller &&
                     // While valid for anyone to play, typically only the attacking player
                     // or other Melee players will want to trigger it.
@@ -24,11 +25,10 @@ class TrialByCombat extends DrawCard {
                     'intrigue'
                 );
 
-                context.replaceHandler(() => {
-                    let replacementClaim = context.event.claim.clone();
-                    replacementClaim.challengeType = 'military';
+                context.replaceHandler((event) => {
+                    event.claim.challengeType = 'military';
 
-                    this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+                    this.game.queueStep(new SatisfyClaim(this.game, event.claim));
                 });
             }
         });

--- a/server/game/cards/02.5-COW/VengeanceForElia.js
+++ b/server/game/cards/02.5-COW/VengeanceForElia.js
@@ -1,11 +1,12 @@
 import DrawCard from '../../drawcard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
+import SatisfyClaim from '../../gamesteps/challenge/SatisfyClaim.js';
 
 class VengeanceForElia extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onClaimApplied: (event) => event.challenge.defendingPlayer === this.controller
+                onClaimApplied: (event) =>
+                    event.challenge && event.challenge.defendingPlayer === this.controller
             },
             chooseOpponent: true,
             handler: (context) => {
@@ -18,11 +19,10 @@ class VengeanceForElia extends DrawCard {
                     opponent
                 );
 
-                context.replaceHandler(() => {
-                    let replacementClaim = context.event.claim.clone();
-                    replacementClaim.replaceRecipient(this.controller, opponent);
+                context.replaceHandler((event) => {
+                    event.claim.replaceRecipient(this.controller, opponent);
 
-                    this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+                    this.game.queueStep(new SatisfyClaim(this.game, event.claim));
                 });
             }
         });

--- a/server/game/cards/02.6-TS/DagmerCleftjaw.js
+++ b/server/game/cards/02.6-TS/DagmerCleftjaw.js
@@ -5,6 +5,7 @@ class DagmerCleftjaw extends DrawCard {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isMatch({ winner: this.controller, attackingAlone: this })
             },
             target: {

--- a/server/game/cards/03-WotN/SnowedUnder.js
+++ b/server/game/cards/03-WotN/SnowedUnder.js
@@ -5,7 +5,7 @@ class SnowedUnder extends PlotCard {
         this.persistentEffect({
             match: (card) => card.controller.activePlot === card,
             targetController: 'any',
-            effect: ability.effects.preventPlotModifier('initiative')
+            effect: ability.effects.setBaseInitiative(0)
         });
     }
 }

--- a/server/game/cards/04.1-AtSK/RainsOfAutumn.js
+++ b/server/game/cards/04.1-AtSK/RainsOfAutumn.js
@@ -4,7 +4,7 @@ class RainsOfAutumn extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: (card) =>
-                card.plotModifierValues.gold > 0 &&
+                card.printedPlotModifiers.gold &&
                 (card.getType() === 'character' || card.getType() === 'location'),
             targetController: 'any',
             effect: ability.effects.preventPlotModifier('gold')

--- a/server/game/cards/04.2-CtA/BeggarKing.js
+++ b/server/game/cards/04.2-CtA/BeggarKing.js
@@ -31,7 +31,7 @@ class BeggarKing extends DrawCard {
 
         return opponentPlots.some(
             (opponentPlot) =>
-                this.controller.activePlot.getPrintedIncome() < opponentPlot.getPrintedIncome()
+                this.controller.activePlot.income.printedValue < opponentPlot.income.printedValue
         );
     }
 

--- a/server/game/cards/04.2-CtA/SummerHarvest.js
+++ b/server/game/cards/04.2-CtA/SummerHarvest.js
@@ -5,7 +5,20 @@ class SummerHarvest extends PlotCard {
         this.whenRevealed({
             chooseOpponent: true,
             handler: (context) => {
-                this.baseIncome = context.opponent.activePlot.getPrintedIncome() + 2;
+                // Referencing "this" ensures that whichever card is triggering this ability
+                // (eg. Summer Harvest OR Varys's Riddle), it refers to Summer Harvest's X
+                // TODO: Eventually when conflicting effects is properly implemented, this should 100% reflect
+                //       how it works in the physical game (where first player decides the order of conflicting effects)
+                this.lastingEffect((ability) => ({
+                    until: {
+                        onCardLeftPlay: (event) => event.card === this
+                    },
+                    match: this,
+                    targetController: 'any',
+                    effect: ability.effects.setBaseGold(
+                        context.opponent.activePlot.income.printedValue + 2
+                    )
+                }));
             }
         });
     }

--- a/server/game/cards/05-LoCR/InsidiousScheme.js
+++ b/server/game/cards/05-LoCR/InsidiousScheme.js
@@ -6,6 +6,7 @@ class InsidiousScheme extends DrawCard {
         this.reaction({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.challengeType === 'intrigue' &&
                     event.challenge.winner === this.controller &&
                     event.challenge.strengthDifference >= 5

--- a/server/game/cards/07-WotW/MaesterAemon.js
+++ b/server/game/cards/07-WotW/MaesterAemon.js
@@ -1,7 +1,7 @@
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
 import DrawCard from '../../drawcard.js';
 import Claim from '../../Claim.js';
 import { ChallengeTracker } from '../../EventTrackers/index.js';
+import GameActions from '../../GameActions/index.js';
 
 class MaesterAemon extends DrawCard {
     setupCardAbilities() {
@@ -56,7 +56,13 @@ class MaesterAemon extends DrawCard {
             claimType
         );
 
-        this.game.queueStep(new ApplyClaim(this.game, claim));
+        this.game.resolveGameAction(
+            GameActions.applyClaim({
+                player,
+                claim,
+                game: this.game
+            })
+        );
 
         return true;
     }

--- a/server/game/cards/08.6-SAT/MyaStone.js
+++ b/server/game/cards/08.6-SAT/MyaStone.js
@@ -1,11 +1,12 @@
 import DrawCard from '../../drawcard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
+import SatisfyClaim from '../../gamesteps/challenge/SatisfyClaim.js';
 
 class MyaStone extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     ['military', 'intrigue'].includes(event.challenge.challengeType) &&
                     event.challenge.defendingPlayer === this.controller
             },
@@ -19,11 +20,10 @@ class MyaStone extends DrawCard {
                     context.event.challenge.challengeType
                 );
 
-                context.replaceHandler(() => {
-                    let replacementClaim = context.event.claim.clone();
-                    replacementClaim.challengeType = 'power';
+                context.replaceHandler((event) => {
+                    event.claim.challengeType = 'power';
 
-                    this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+                    this.game.queueStep(new SatisfyClaim(this.game, event.claim));
                 });
             }
         });

--- a/server/game/cards/09-HoT/NowItComesToWar.js
+++ b/server/game/cards/09-HoT/NowItComesToWar.js
@@ -1,12 +1,12 @@
+import SatisfyClaim from '../../gamesteps/challenge/SatisfyClaim.js';
 import PlotCard from '../../plotcard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
 
 class NowItComesToWar extends PlotCard {
     setupCardAbilities() {
         this.forcedInterrupt({
             when: {
                 onClaimApplied: (event) =>
-                    ['intrigue', 'power'].includes(event.challenge.challengeType)
+                    event.challenge && ['intrigue', 'power'].includes(event.challenge.challengeType)
             },
             handler: (context) => {
                 this.currentContext = context;
@@ -31,11 +31,11 @@ class NowItComesToWar extends PlotCard {
             this,
             'military'
         );
-        this.currentContext.replaceHandler(() => {
-            let replacementClaim = this.currentContext.event.claim.clone();
-            replacementClaim.challengeType = 'military';
 
-            this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+        this.currentContext.replaceHandler((event) => {
+            event.claim.challengeType = 'military';
+
+            this.game.queueStep(new SatisfyClaim(this.game, event.claim));
         });
         return true;
     }

--- a/server/game/cards/09-HoT/TheSpidersWeb.js
+++ b/server/game/cards/09-HoT/TheSpidersWeb.js
@@ -6,7 +6,9 @@ class TheSpidersWeb extends PlotCard {
             limit: ability.limit.perPhase(1),
             when: {
                 onClaimApplied: (event) =>
-                    event.player === this.controller && event.challenge.challengeType === 'intrigue'
+                    event.challenge &&
+                    event.player === this.controller &&
+                    event.challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.game.addMessage(

--- a/server/game/cards/11.2-TMoW/TradingWithQohor.js
+++ b/server/game/cards/11.2-TMoW/TradingWithQohor.js
@@ -13,7 +13,7 @@ class TradingWithQohor extends AgendaCard {
 
         this.reaction({
             when: {
-                onClaimApplied: (event) => event.player === this.controller
+                onClaimApplied: (event) => event.challenge && event.player === this.controller
             },
             cost: ability.costs.sacrifice(
                 (card) => card.getType() === 'attachment' && card.hasPrintedCost()

--- a/server/game/cards/11.4-MoD/TheFreeFolk.js
+++ b/server/game/cards/11.4-MoD/TheFreeFolk.js
@@ -1,12 +1,13 @@
 import AgendaCard from '../../agendacard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
 import ChallengeTypes from '../../ChallengeTypes.js';
+import GameActions from '../../GameActions/index.js';
 
 class TheFreeFolk extends AgendaCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.attackers.some(
                         (attacker) =>
                             attacker.controller === this.controller &&
@@ -41,7 +42,7 @@ class TheFreeFolk extends AgendaCard {
 
         let claim = this.initialClaim.clone();
         claim.challengeType = claimType;
-        this.game.queueStep(new ApplyClaim(this.game, claim));
+        this.game.resolveGameAction(GameActions.applyClaim({ player, claim, game: this.game }));
 
         return true;
     }

--- a/server/game/cards/14-FotS/TheHandsTourney.js
+++ b/server/game/cards/14-FotS/TheHandsTourney.js
@@ -1,11 +1,12 @@
+import SatisfyClaim from '../../gamesteps/challenge/SatisfyClaim.js';
 import PlotCard from '../../plotcard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
 
 class TheHandsTourney extends PlotCard {
     setupCardAbilities() {
         this.forcedInterrupt({
             when: {
-                onClaimApplied: (event) => event.challenge.challengeType === 'military'
+                onClaimApplied: (event) =>
+                    event.challenge && event.challenge.challengeType === 'military'
             },
             handler: (context) => {
                 this.game.addMessage(
@@ -16,11 +17,10 @@ class TheHandsTourney extends PlotCard {
                     'military'
                 );
 
-                context.replaceHandler(() => {
-                    let replacementClaim = context.event.claim.clone();
-                    replacementClaim.challengeType = 'power';
+                context.replaceHandler((event) => {
+                    event.claim.challengeType = 'power';
 
-                    this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+                    this.game.queueStep(new SatisfyClaim(this.game, event.claim));
                 });
             }
         });

--- a/server/game/cards/20-HMW/CornCornCorn.js
+++ b/server/game/cards/20-HMW/CornCornCorn.js
@@ -1,7 +1,7 @@
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
 import DrawCard from '../../drawcard.js';
 import Claim from '../../Claim.js';
 import { ChallengeTracker } from '../../EventTrackers/index.js';
+import GameActions from '../../GameActions/index.js';
 
 class CornCornCorn extends DrawCard {
     setupCardAbilities(ability) {
@@ -58,7 +58,13 @@ class CornCornCorn extends DrawCard {
             claimType
         );
 
-        this.game.queueStep(new ApplyClaim(this.game, claim));
+        this.game.resolveGameAction(
+            GameActions.applyClaim({
+                player,
+                claim,
+                game: this.game
+            })
+        );
 
         return true;
     }

--- a/server/game/cards/21-FtR/BattleoftheTrident.js
+++ b/server/game/cards/21-FtR/BattleoftheTrident.js
@@ -7,6 +7,7 @@ class BattleoftheTrident extends AgendaCard {
         this.reaction({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.winner === this.owner &&
                     event.challenge.attackingPlayer === this.owner &&
                     event.challenge.attackers.some(

--- a/server/game/cards/22-BtB/BranStark.js
+++ b/server/game/cards/22-BtB/BranStark.js
@@ -15,6 +15,7 @@ class BranStark extends DrawCard {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isMatch({ challengeType: 'intrigue' }) &&
                     event.challenge.defendingPlayer.hand.length !== 0 &&
                     event.challenge

--- a/server/game/cards/23-AHaH/Crannogmen.js
+++ b/server/game/cards/23-AHaH/Crannogmen.js
@@ -5,10 +5,12 @@ class Crannogmen extends DrawCard {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isMatch({
                         winner: this.controller,
                         challengeType: 'intrigue'
-                    }) && this.isAttacking()
+                    }) &&
+                    this.isAttacking()
             },
             target: {
                 cardCondition: {

--- a/server/game/cards/25.1-ATT/Castamere.js
+++ b/server/game/cards/25.1-ATT/Castamere.js
@@ -1,5 +1,4 @@
 import GameActions from '../../GameActions/index.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
 import DrawCard from '../../drawcard.js';
 
 class Castamere extends DrawCard {
@@ -7,6 +6,7 @@ class Castamere extends DrawCard {
         this.reaction({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isMatch({
                         winner: this.controller,
                         challengeType: 'intrigue',
@@ -16,10 +16,10 @@ class Castamere extends DrawCard {
             cost: [ability.costs.kneelSelf(), ability.costs.sacrificeSelf()],
             message:
                 '{player} kneels and sacrifices {costs.sacrifice} to also apply military claim',
-            gameAction: GameActions.genericHandler((context) => {
-                let claim = context.event.claim.clone();
+            gameAction: GameActions.applyClaim((context) => {
+                const claim = context.event.claim.clone();
                 claim.challengeType = 'military';
-                this.game.queueStep(new ApplyClaim(this.game, claim));
+                return { player: context.player, claim, game: this.game };
             })
         });
     }

--- a/server/game/cards/25.1-ATT/DanceOfTheDragons.js
+++ b/server/game/cards/25.1-ATT/DanceOfTheDragons.js
@@ -6,10 +6,12 @@ class DanceOfTheDragons extends PlotCard {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.isMatch({
                         attackingPlayer: this.controller,
                         challengeType: ['military', 'intrigue']
-                    }) && event.challenge.loser.faction.power > 0
+                    }) &&
+                    event.challenge.loser.faction.power > 0
             },
             cost: ability.costs.kneel(
                 (card) => card.getType() === 'character' && card.hasTrait('Dragon')

--- a/server/game/cards/25.4-TTS/JonSnow.js
+++ b/server/game/cards/25.4-TTS/JonSnow.js
@@ -5,7 +5,8 @@ class JonSnow extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onClaimApplied: (event) => event.challenge.isMatch({ challengeType: 'military' })
+                onClaimApplied: (event) =>
+                    event.challenge && event.challenge.isMatch({ challengeType: 'military' })
             },
             message:
                 '{player} uses {source} to have either standing or kneeling characters satisfied for claim, if able',

--- a/server/game/cards/25.5-TIC/BlackhavenRider.js
+++ b/server/game/cards/25.5-TIC/BlackhavenRider.js
@@ -1,0 +1,40 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class BlackhavenRider extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardEntersPlay: (event) => event.card === this
+            },
+            target: {
+                choosingPlayer: 'each',
+                ifAble: true,
+                cardCondition: (card, context) =>
+                    card.location === 'play area' &&
+                    card.controller === context.choosingPlayer &&
+                    card.getType() === 'character' &&
+                    card.isLoyal()
+            },
+            handler: (context) => {
+                let selections = context.targets.selections.filter(
+                    (selection) => !!selection.value
+                );
+                this.game.resolveGameAction(
+                    GameActions.simultaneously(
+                        selections.map((selection) =>
+                            GameActions.kneelCard({
+                                player: selection.choosingPlayer,
+                                card: selection.value
+                            })
+                        )
+                    )
+                );
+            }
+        });
+    }
+}
+
+BlackhavenRider.code = '25081';
+
+export default BlackhavenRider;

--- a/server/game/cards/25.5-TIC/BoltonLoyalist.js
+++ b/server/game/cards/25.5-TIC/BoltonLoyalist.js
@@ -1,0 +1,72 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class BoltonLoyalist extends DrawCard {
+    setupCardAbilities() {
+        this.forcedReaction({
+            cannotBeCanceled: true,
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.isMatch({ loser: this.controller, challengeType: 'intrigue' })
+            },
+            message: {
+                format: '{player} is forced to give control of {source} to {winner}, or sacrifice another character they control',
+                args: { winner: (context) => context.event.challenge.winner }
+            },
+            gameAction: GameActions.choose({
+                choices: {
+                    'Give Control': {
+                        message: {
+                            format: '{player} gives control of {source} to {winner}',
+                            args: { winner: (context) => context.event.challenge.winner }
+                        },
+                        gameAction: GameActions.takeControl((context) => ({
+                            card: context.source,
+                            player: context.event.challenge.winner,
+                            context
+                        }))
+                    },
+                    'Sacrifice Character': {
+                        gameAction: GameActions.genericHandler((context) => {
+                            this.game.promptForSelect(context.player, {
+                                activePromptTitle: 'Select a character',
+                                cardCondition: (card) =>
+                                    card.getType() === 'character' &&
+                                    card.location === 'play area' &&
+                                    card !== context.source &&
+                                    card.controller === context.player,
+                                gameAction: 'sacrifice',
+                                onSelect: (player, card) => {
+                                    this.game.addMessage(
+                                        '{0} chooses to sacrifice {1}',
+                                        player,
+                                        card
+                                    );
+                                    this.game.resolveGameAction(
+                                        GameActions.sacrificeCard(() => ({ card })),
+                                        context
+                                    );
+                                    return true;
+                                },
+                                onCancel: (player) => {
+                                    this.game.addAlert(
+                                        'danger',
+                                        '{0} cancels resolution of {1}',
+                                        player,
+                                        context.source
+                                    );
+                                    return true;
+                                },
+                                source: context.source
+                            });
+                        })
+                    }
+                }
+            })
+        });
+    }
+}
+
+BoltonLoyalist.code = '25091';
+
+export default BoltonLoyalist;

--- a/server/game/cards/25.5-TIC/EnemiesInEveryShadow.js
+++ b/server/game/cards/25.5-TIC/EnemiesInEveryShadow.js
@@ -1,0 +1,51 @@
+import GameActions from '../../GameActions/index.js';
+import PlotCard from '../../plotcard.js';
+
+class EnemiesInEveryShadow extends PlotCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.game.allCards.every((card) => card.location !== 'shadows'),
+            match: (card) => card.getType() === 'character',
+            targetController: 'current',
+            effect: ability.effects.modifyStrength(1)
+        });
+
+        this.reaction({
+            when: {
+                afterChallenge: (event) => event.challenge.winner === this.controller
+            },
+            target: {
+                cardCondition: {
+                    location: 'shadows',
+                    condition: (card, context) =>
+                        card.controller === context.event.challenge.loser &&
+                        GameActions.discardCard({ card }).allow()
+                }
+            },
+            message: '{player} uses {source} to choose and discard {target}',
+            handler: (context) => {
+                const event = GameActions.discardCard({ card: context.target }).createEvent();
+                if (context.target.getType() === 'character') {
+                    event.replaceHandler(() => {
+                        this.game.addMessage(
+                            '{0} is placed in the dead pile for {1}',
+                            context.target,
+                            context.source
+                        );
+                        event.thenAttachEvent(
+                            GameActions.placeCard({
+                                card: event.card,
+                                location: 'dead pile'
+                            }).createEvent()
+                        );
+                    });
+                }
+                this.game.resolveEvent(event);
+            }
+        });
+    }
+}
+
+EnemiesInEveryShadow.code = '25099';
+
+export default EnemiesInEveryShadow;

--- a/server/game/cards/25.5-TIC/GilbertOfTheVines.js
+++ b/server/game/cards/25.5-TIC/GilbertOfTheVines.js
@@ -1,0 +1,59 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class GilbertOfTheVines extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Reveal top X cards of your deck',
+            cost: ability.costs.payXGold(
+                () => 1,
+                (context) => context.player.drawDeck.length
+            ),
+            message: {
+                format: '{player} plays {source} to reveal the top {amount} cards of their deck',
+                args: { amount: (context) => context.xValue }
+            },
+            gameAction: GameActions.revealTopCards((context) => ({
+                player: context.player,
+                amount: context.xValue,
+                whileRevealed: GameActions.genericHandler((context) => {
+                    const numRevealed = context.revealed.length;
+                    if (numRevealed > 0) {
+                        const numCards = Math.min(2, numRevealed);
+                        this.game.promptForSelect(context.player, {
+                            activePromptTitle: `Select up to ${numCards} cards`,
+                            numCards,
+                            cardCondition: (card) => context.revealed.includes(card),
+                            onSelect: (player, cards) => {
+                                cards = Array.isArray(cards) ? cards : [cards];
+                                this.game.addMessage('{0} adds {1} to their hand', player, cards);
+                                this.game.resolveGameAction(
+                                    GameActions.simultaneously(() =>
+                                        cards.map((card) => GameActions.addToHand({ card }))
+                                    ),
+                                    context
+                                );
+                                return true;
+                            },
+                            onCancel: (player) => {
+                                this.game.addMessage(
+                                    '{0} does not choose to add any cards to their hand',
+                                    player
+                                );
+                                return true;
+                            },
+                            source: this
+                        });
+                    }
+                })
+            })).then({
+                message: '{player} {gameAction}',
+                gameAction: GameActions.shuffle((context) => ({ player: context.player }))
+            })
+        });
+    }
+}
+
+GilbertOfTheVines.code = '25096';
+
+export default GilbertOfTheVines;

--- a/server/game/cards/25.5-TIC/HarrenTheBlack.js
+++ b/server/game/cards/25.5-TIC/HarrenTheBlack.js
@@ -1,0 +1,44 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class HarrenTheBlack extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({
+            type: 'location',
+            faction: 'greyjoy',
+            controller: 'current',
+            unique: true
+        });
+        this.persistentEffect({
+            targetController: 'opponent',
+            effect: ability.effects.cannotMarshal(
+                (card) => card.getType() === 'location' && this.hasCopyInDiscard(card)
+            )
+        });
+        this.forcedReaction({
+            when: {
+                onCardDiscarded: (event) =>
+                    event.isPillage && event.source.controller === this.controller
+            },
+            message: '{player} is forced by {source} to discard the top card of each players deck',
+            gameAction: GameActions.simultaneously((context) =>
+                context.game
+                    .getPlayersInFirstPlayerOrder()
+                    .map((player) =>
+                        GameActions.discardTopCards({ player, amount: 1, source: this })
+                    )
+            )
+        });
+    }
+
+    hasCopyInDiscard(card) {
+        let discardPile = card.controller.discardPile;
+        return discardPile.some(
+            (discardedCard) => card !== discardedCard && card.isCopyOf(discardedCard)
+        );
+    }
+}
+
+HarrenTheBlack.code = '25084';
+
+export default HarrenTheBlack;

--- a/server/game/cards/25.5-TIC/LannTheClever.js
+++ b/server/game/cards/25.5-TIC/LannTheClever.js
@@ -1,0 +1,48 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class LannTheClever extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({
+            type: 'location',
+            faction: 'lannister',
+            controller: 'current',
+            unique: true
+        });
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.winner === this.controller
+            },
+            cost: [
+                ability.costs.kneelSelf(),
+                ability.costs.returnToHand((card) =>
+                    card.isMatch({ type: 'character', faction: 'lannister', participating: true })
+                )
+            ],
+            message:
+                '{player} kneels {costs.kneel} and returns {costs.returnToHand} to their hand to either gain 3 gold or 1 power for their faction',
+            choices: {
+                'Gain 3 gold': {
+                    message: '{player} chooses to gain 3 gold',
+                    gameAction: GameActions.gainGold((context) => ({
+                        player: context.player,
+                        amount: 3
+                    }))
+                },
+                'Gain 1 power': {
+                    message: '{player} chooses to gain 1 power for their faction',
+                    gameAction: GameActions.gainPower((context) => ({
+                        card: context.player.faction,
+                        amount: 1
+                    }))
+                }
+            }
+        });
+    }
+}
+
+LannTheClever.code = '25086';
+
+export default LannTheClever;

--- a/server/game/cards/25.5-TIC/LittleBird.js
+++ b/server/game/cards/25.5-TIC/LittleBird.js
@@ -1,0 +1,47 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class LittleBird extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            chooseOpponent: (opponent) => opponent.drawDeck.length > 0,
+            message: {
+                format: "{player} uses {source} to look at the top card of {opponent}'s deck",
+                args: { opponent: (context) => context.opponent }
+            },
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.lookAtDeck((context) => ({
+                        player: context.player,
+                        lookingAt: context.opponent,
+                        amount: 1
+                    })).then({
+                        gameAction: GameActions.simultaneously((context) =>
+                            // TODO: Add a 'decline message' to GameActions.may
+                            context.game.getPlayersInFirstPlayerOrder().map((player) =>
+                                GameActions.may({
+                                    player,
+                                    title: (context) =>
+                                        'Draw 1 card from ' + context.source.name + '?',
+                                    message: '{choosingPlayer} chooses to draw 1 card',
+                                    gameAction: GameActions.drawCards((context) => ({
+                                        player: context.choosingPlayer,
+                                        amount: 1
+                                    }))
+                                })
+                            )
+                        )
+                    }),
+                    context
+                );
+            }
+        });
+    }
+}
+
+LittleBird.code = '25097';
+
+export default LittleBird;

--- a/server/game/cards/25.5-TIC/MaesterHarmune.js
+++ b/server/game/cards/25.5-TIC/MaesterHarmune.js
@@ -1,0 +1,42 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class MaesterHarmune extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onGoldTransferred: (event) =>
+                    event.source.getGameElementType() === 'player' &&
+                    event.source !== this.controller &&
+                    event.target === this.controller
+            },
+            limit: ability.limit.perRound(2),
+            message: {
+                format: "{player} uses {source} to reveal the top card of {opponent}'s deck",
+                args: { opponent: (context) => context.event.source }
+            },
+            gameAction: GameActions.revealTopCards((context) => ({
+                player: context.event.source
+            })).then({
+                message: '{player} {gameAction}',
+                gameAction: GameActions.ifCondition({
+                    condition: (context) => context.event.cards[0].getType() === 'character',
+                    thenAction: GameActions.simultaneously([
+                        GameActions.discardCard((context) => ({
+                            card: context.event.revealed[0]
+                        })),
+                        GameActions.drawCards((context) => ({
+                            player: context.player,
+                            amount: 1,
+                            source: this
+                        }))
+                    ])
+                })
+            })
+        });
+    }
+}
+
+MaesterHarmune.code = '25089';
+
+export default MaesterHarmune;

--- a/server/game/cards/25.5-TIC/MargaeryTyrell.js
+++ b/server/game/cards/25.5-TIC/MargaeryTyrell.js
@@ -1,0 +1,42 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class MargaeryTyrell extends DrawCard {
+    setupCardAbilities(ability) {
+        this.interrupt({
+            when: {
+                onCardRevealed: {
+                    aggregateBy: (event) => ({
+                        controller: event.card.controller,
+                        isTyrell: event.card.isFaction('tyrell'),
+                        isInHandOrDeck: ['hand', 'draw deck'].includes(event.card.location)
+                    }),
+                    condition: (aggregate) =>
+                        aggregate.controller === this.controller &&
+                        aggregate.isTyrell &&
+                        aggregate.isInHandOrDeck
+                }
+            },
+            limit: ability.limit.perRound(2),
+            target: {
+                activePromptTitle: 'Select a card',
+                cardCondition: (card, context) =>
+                    context.events.some((event) => event.card === card)
+            },
+            message: {
+                format: '{player} uses {source} to place {card} in shadows',
+                args: { card: (context) => context.target }
+            },
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.putIntoShadows((context) => ({ card: context.target })),
+                    context
+                );
+            }
+        });
+    }
+}
+
+MargaeryTyrell.code = '25095';
+
+export default MargaeryTyrell;

--- a/server/game/cards/25.5-TIC/PinkGraces.js
+++ b/server/game/cards/25.5-TIC/PinkGraces.js
@@ -1,0 +1,43 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+import GenericTracker from '../../EventTrackers/GenericTracker.js';
+
+class PinkGraces extends DrawCard {
+    setupCardAbilities() {
+        this.tracker = GenericTracker.forPhase(this.game, 'onClaimApplied');
+
+        this.interrupt({
+            when: {
+                onPhaseEnded: (event) => event.phase === 'challenge'
+            },
+            message:
+                '{player} uses {source} to allow each player who did not apply military claim this phase to draw 1 card',
+            gameAction: GameActions.simultaneously((context) =>
+                context.game
+                    .getPlayersInFirstPlayerOrder()
+                    .filter((player) => !this.hasAppliedMilitaryClaim(player))
+                    .map((player) =>
+                        GameActions.may({
+                            player,
+                            title: 'Draw 1 card from ' + this.name + '?',
+                            message: {
+                                format: '{choosingPlayer} {gameAction}',
+                                args: { choosingPlayer: () => player }
+                            },
+                            gameAction: GameActions.drawCards({ player, amount: 1, source: this })
+                        })
+                    )
+            )
+        });
+    }
+
+    hasAppliedMilitaryClaim(player) {
+        return this.tracker.some(
+            (event) => event.player === player && event.claim.challengeType === 'military'
+        );
+    }
+}
+
+PinkGraces.code = '25093';
+
+export default PinkGraces;

--- a/server/game/cards/25.5-TIC/Qyburn.js
+++ b/server/game/cards/25.5-TIC/Qyburn.js
@@ -1,0 +1,43 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class Qyburn extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            target: {
+                cardCondition: {
+                    type: 'character',
+                    location: 'dead pile',
+                    not: { trait: 'Army' },
+                    controller: 'opponent',
+                    condition: (card, context) =>
+                        GameActions.putIntoPlay({ card, player: context.player }).allow()
+                }
+            },
+            message: '{player} uses {source} to put {target} into play under their control',
+            handler: (context) => {
+                context.game.resolveGameAction(
+                    GameActions.putIntoPlay((context) => ({
+                        card: context.target,
+                        player: context.player
+                    })),
+                    context
+                );
+
+                this.atEndOfPhase((ability) => ({
+                    match: context.target,
+                    condition: () => ['play area', 'duplicate'].includes(context.target.location),
+                    targetLocation: 'any',
+                    effect: ability.effects.removeFromGameIfStillInPlay(false)
+                }));
+            }
+        });
+    }
+}
+
+Qyburn.code = '25085';
+
+export default Qyburn;

--- a/server/game/cards/25.5-TIC/RaventreeHall.js
+++ b/server/game/cards/25.5-TIC/RaventreeHall.js
@@ -1,0 +1,24 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class RaventreeHall extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardPowerGained: (event) => this.isCharacter(event.card),
+                onCardPowerMoved: (event) => this.isCharacter(event.target)
+            },
+            limit: ability.limit.perPhase(1),
+            message: '{player} uses {source} to gain 1 gold',
+            gameAction: GameActions.gainGold((context) => ({ player: context.player, amount: 1 }))
+        });
+    }
+
+    isCharacter(card) {
+        return card.getType() === 'character' && card.controller === this.controller;
+    }
+}
+
+RaventreeHall.code = '25092';
+
+export default RaventreeHall;

--- a/server/game/cards/25.5-TIC/RedMountains.js
+++ b/server/game/cards/25.5-TIC/RedMountains.js
@@ -1,0 +1,38 @@
+import DrawCard from '../../drawcard.js';
+
+class RedMountains extends DrawCard {
+    setupCardAbilities(ability) {
+        this.plotModifiers({
+            initiative: 1
+        });
+
+        this.action({
+            title: 'Force military challenge',
+            phase: 'challenge',
+            cost: [ability.costs.kneelSelf(), ability.costs.sacrificeSelf()],
+            chooseOpponent: true,
+            message: {
+                format: '{player} kneels and sacrifices {source} to force {opponent} to initiate their next challenge as a {challengeType} challenge against {player}, if able',
+                args: { challengeType: () => 'military' }
+            },
+            handler: (context) => {
+                this.lastingEffect((ability) => ({
+                    until: {
+                        onChallengeInitiated: (event) =>
+                            event.challenge.isMatch({ initiatingPlayer: context.opponent }),
+                        onPhaseEnded: () => true
+                    },
+                    match: context.opponent,
+                    effect: ability.effects.mustInitiateNextChallenge(
+                        'military',
+                        (player) => player === context.player
+                    )
+                }));
+            }
+        });
+    }
+}
+
+RedMountains.code = '25088';
+
+export default RedMountains;

--- a/server/game/cards/25.5-TIC/RobertsRebellion.js
+++ b/server/game/cards/25.5-TIC/RobertsRebellion.js
@@ -1,0 +1,33 @@
+import GameActions from '../../GameActions/index.js';
+import PlotCard from '../../plotcard.js';
+import { ChallengeTracker } from '../../EventTrackers/ChallengeTracker.js';
+
+class RobertsRebellion extends PlotCard {
+    setupCardAbilities() {
+        this.tracker = ChallengeTracker.forRound(this.game);
+
+        this.forcedInterrupt({
+            when: {
+                onPhaseEnded: (event) =>
+                    event.phase === 'challenge' &&
+                    this.tracker.some({ loser: this.controller, challengeType: 'power' })
+            },
+            message: {
+                format: '{player} is forced to discard {amount} power from their faction card for {source}',
+                args: { amount: (context) => this.getPowerAmount(context) }
+            },
+            gameAction: GameActions.discardPower((context) => ({
+                card: context.player.faction,
+                amount: this.getPowerAmount(context)
+            }))
+        });
+    }
+
+    getPowerAmount(context) {
+        return Math.min(context.player.faction.power, 3);
+    }
+}
+
+RobertsRebellion.code = '25082';
+
+export default RobertsRebellion;

--- a/server/game/cards/25.5-TIC/SavedByTheWatch.js
+++ b/server/game/cards/25.5-TIC/SavedByTheWatch.js
@@ -1,0 +1,71 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class SavedByTheWatch extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardDiscarded: (event) =>
+                    this.isCharacterControlledByOpponent(event.cardStateWhenDiscarded),
+                onSacrificed: (event) =>
+                    this.isCharacterControlledByOpponent(event.cardStateWhenSacrificed)
+            },
+            cost: ability.costs.kneelFactionCard(),
+            message: {
+                format: '{player} kneels their faction card and plays {source} to put {character} into play',
+                args: { character: (context) => context.event.card }
+            },
+            gameAction: GameActions.putIntoPlay((context) => ({ card: context.event.card })).then({
+                condition: (context) =>
+                    context.player.canAttach(this, context.parentContext.event.card),
+                message: {
+                    format: 'Then, {player} attaches {source} to {character}',
+                    args: { character: (context) => context.parentContext.event.card }
+                },
+                gameAction: GameActions.genericHandler((context) => {
+                    context.player.attach(
+                        context.player,
+                        this,
+                        context.parentContext.event.card,
+                        'play'
+                    );
+                    this.lastingEffect((ability) => ({
+                        condition: () => !!this.parent,
+                        targetLocation: 'any',
+                        match: this,
+                        effect: [
+                            ability.effects.setCardType('attachment'),
+                            ability.effects.addKeyword('Terminal'),
+                            ability.effects.addTrait('Condition')
+                        ]
+                    }));
+
+                    this.lastingEffect((ability) => ({
+                        condition: () => this.location === 'play area',
+                        targetLocation: 'any',
+                        targetController: 'any',
+                        match: (card) => card === this.parent,
+                        effect: ability.effects.takeControl(context.player)
+                    }));
+                })
+            })
+        });
+    }
+
+    isCharacterControlledByOpponent(card) {
+        return (
+            card.controller !== this.controller &&
+            card.getType() === 'character' &&
+            card.location === 'play area'
+        );
+    }
+
+    // Explicitly override since it has printed type 'event'.
+    canAttach(player, card) {
+        return card.getType() === 'character';
+    }
+}
+
+SavedByTheWatch.code = '25090';
+
+export default SavedByTheWatch;

--- a/server/game/cards/25.5-TIC/SerWillamWells.js
+++ b/server/game/cards/25.5-TIC/SerWillamWells.js
@@ -1,0 +1,30 @@
+import DrawCard from '../../drawcard.js';
+
+class SerWillamWells extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Remove icons from character',
+            phase: 'challenge',
+            cost: ability.costs.killSelf(),
+            target: {
+                cardCondition: { location: 'play area', type: 'character' }
+            },
+            message:
+                '{player} kills {costs.kill} to remove a military, an intrigue, and a power icon from {target} until the end of the phase',
+            handler: (context) => {
+                this.untilEndOfPhase((ability) => ({
+                    match: context.target,
+                    effect: [
+                        ability.effects.removeIcon('military'),
+                        ability.effects.removeIcon('intrigue'),
+                        ability.effects.removeIcon('power')
+                    ]
+                }));
+            }
+        });
+    }
+}
+
+SerWillamWells.code = '25087';
+
+export default SerWillamWells;

--- a/server/game/cards/25.5-TIC/TempleOfTheGraces.js
+++ b/server/game/cards/25.5-TIC/TempleOfTheGraces.js
@@ -1,0 +1,29 @@
+import DrawCard from '../../drawcard.js';
+import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
+
+class TempleOfTheGraces extends DrawCard {
+    setupCardAbilities(ability) {
+        this.interrupt({
+            when: {
+                onClaimApplied: (event) =>
+                    event.challenge.challengeType === 'military' &&
+                    event.challenge.attackingPlayer === this.controller
+            },
+            cost: ability.costs.kneel((card) => card.hasTrait('Grace')),
+            message:
+                '{player} uses {source} and kneels {costs.kneel} to apply intrigue claim instead of military claim',
+            handler: (context) => {
+                context.replaceHandler(() => {
+                    let replacementClaim = context.event.claim.clone();
+                    replacementClaim.challengeType = 'intrigue';
+
+                    this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+                });
+            }
+        });
+    }
+}
+
+TempleOfTheGraces.code = '25094';
+
+export default TempleOfTheGraces;

--- a/server/game/cards/25.5-TIC/TempleOfTheGraces.js
+++ b/server/game/cards/25.5-TIC/TempleOfTheGraces.js
@@ -1,11 +1,12 @@
 import DrawCard from '../../drawcard.js';
-import ApplyClaim from '../../gamesteps/challenge/applyclaim.js';
+import SatisfyClaim from '../../gamesteps/challenge/SatisfyClaim.js';
 
 class TempleOfTheGraces extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
                 onClaimApplied: (event) =>
+                    event.challenge &&
                     event.challenge.challengeType === 'military' &&
                     event.challenge.attackingPlayer === this.controller
             },
@@ -13,11 +14,10 @@ class TempleOfTheGraces extends DrawCard {
             message:
                 '{player} uses {source} and kneels {costs.kneel} to apply intrigue claim instead of military claim',
             handler: (context) => {
-                context.replaceHandler(() => {
-                    let replacementClaim = context.event.claim.clone();
-                    replacementClaim.challengeType = 'intrigue';
+                context.replaceHandler((event) => {
+                    event.claim.challengeType = 'intrigue';
 
-                    this.game.queueStep(new ApplyClaim(this.game, replacementClaim));
+                    this.game.queueStep(new SatisfyClaim(this.game, event.claim));
                 });
             }
         });

--- a/server/game/cards/25.5-TIC/TheBlueFork.js
+++ b/server/game/cards/25.5-TIC/TheBlueFork.js
@@ -1,0 +1,27 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class TheBlueFork extends DrawCard {
+    setupCardAbilities() {
+        this.plotModifiers({
+            reserve: 2
+        });
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.isMatch({
+                        winner: this.controller,
+                        by5: true,
+                        challengeType: 'power'
+                    })
+            },
+            location: 'discard pile',
+            message: '{player} uses {source} to put {source} into play from their discard pile',
+            gameAction: GameActions.putIntoPlay({ card: this })
+        });
+    }
+}
+
+TheBlueFork.code = '25098';
+
+export default TheBlueFork;

--- a/server/game/cards/25.5-TIC/TheKnight.js
+++ b/server/game/cards/25.5-TIC/TheKnight.js
@@ -1,0 +1,51 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class TheKnight extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Raise claim',
+            limit: ability.limit.perChallenge(1),
+            condition: () => this.game.isDuringChallenge({ attackingPlayer: this.controller }),
+            target: {
+                activePromptTitle: 'Select 2 characters',
+                type: 'select',
+                mode: 'exactly',
+                numCards: 2,
+                cardCondition: {
+                    type: 'character',
+                    location: 'discard pile',
+                    condition: (card) =>
+                        card.controller === this.game.currentChallenge.defendingPlayer
+                }
+            },
+            message: {
+                format: "{player} uses {source} to return {target} to {defendingPlayer}'s hand",
+                args: { defendingPlayer: () => this.game.currentChallenge.defendingPlayer }
+            },
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.simultaneously((context) =>
+                        context.target.map((card) =>
+                            GameActions.placeCard({ card, location: 'hand' })
+                        )
+                    ).then({
+                        message:
+                            'Then, {player} raises the claim on their revealed plot card by 1 until the end of the challenge',
+                        handler: () => {
+                            this.untilEndOfChallenge((ability) => ({
+                                match: (card) => card === this.controller.activePlot,
+                                effect: ability.effects.modifyClaim(1)
+                            }));
+                        }
+                    }),
+                    context
+                );
+            }
+        });
+    }
+}
+
+TheKnight.code = '25083';
+
+export default TheKnight;

--- a/server/game/cards/25.5-TIC/TheLastGreenseer.js
+++ b/server/game/cards/25.5-TIC/TheLastGreenseer.js
@@ -1,0 +1,62 @@
+import PlotCard from '../../plotcard.js';
+
+class TheLastGreenseer extends PlotCard {
+    setupCardAbilities() {
+        const getBaseStats = (card) => {
+            return {
+                income: card.income.baseValue,
+                claim: card.claim.baseValue,
+                reserve: card.reserve.baseValue
+            };
+        };
+
+        this.whenRevealed({
+            target: {
+                type: 'select',
+                cardType: ['plot'],
+                cardCondition: {
+                    location: 'active plot',
+                    type: 'plot',
+                    condition: (card, context) => card !== context.source
+                }
+            },
+            message:
+                '{player} uses {source} to switch the base gold, claim, and reserve values with {target}',
+            handler: (context) => {
+                const targetStats = getBaseStats(context.target);
+                const sourceStats = getBaseStats(context.source);
+
+                this.lastingEffect((ability) => ({
+                    until: {
+                        onCardLeftPlay: (event) =>
+                            [context.target, context.source].includes(event.card)
+                    },
+                    match: context.target,
+                    targetController: 'any',
+                    effect: [
+                        ability.effects.setBaseIncome(sourceStats.income),
+                        ability.effects.setBaseInitiative(sourceStats.initiative),
+                        ability.effects.setBaseClaim(sourceStats.claim)
+                    ]
+                }));
+                this.lastingEffect((ability) => ({
+                    until: {
+                        onCardLeftPlay: (event) =>
+                            [context.target, context.source].includes(event.card)
+                    },
+                    match: context.source,
+                    targetController: 'any',
+                    effect: [
+                        ability.effects.setBaseIncome(targetStats.income),
+                        ability.effects.setBaseInitiative(targetStats.initiative),
+                        ability.effects.setBaseClaim(targetStats.claim)
+                    ]
+                }));
+            }
+        });
+    }
+}
+
+TheLastGreenseer.code = '25100';
+
+export default TheLastGreenseer;

--- a/server/game/cards/25.5-TIC/TheLastGreenseer.js
+++ b/server/game/cards/25.5-TIC/TheLastGreenseer.js
@@ -27,9 +27,11 @@ class TheLastGreenseer extends PlotCard {
                 const targetStats = getBaseStats(context.target);
                 const sourceStats = getBaseStats(context.source);
 
+                // TODO: These should not be listening on the reaction variant, however there is a problem
+                // with base events being raised under `thenAttachEvent` scenarios.
                 this.lastingEffect((ability) => ({
                     until: {
-                        onCardLeftPlay: (event) =>
+                        'onCardLeftPlay:reaction': (event) =>
                             [context.target, context.source].includes(event.card)
                     },
                     match: context.target,
@@ -42,7 +44,7 @@ class TheLastGreenseer extends PlotCard {
                 }));
                 this.lastingEffect((ability) => ({
                     until: {
-                        onCardLeftPlay: (event) =>
+                        'onCardLeftPlay:reaction': (event) =>
                             [context.target, context.source].includes(event.card)
                     },
                     match: context.source,

--- a/server/game/cards/25.5-TIC/TheLastGreenseer.js
+++ b/server/game/cards/25.5-TIC/TheLastGreenseer.js
@@ -12,6 +12,7 @@ class TheLastGreenseer extends PlotCard {
 
         this.whenRevealed({
             target: {
+                activePromptTitle: 'Select a plot',
                 type: 'select',
                 cardType: ['plot'],
                 cardCondition: {
@@ -34,9 +35,9 @@ class TheLastGreenseer extends PlotCard {
                     match: context.target,
                     targetController: 'any',
                     effect: [
-                        ability.effects.setBaseIncome(sourceStats.income),
-                        ability.effects.setBaseInitiative(sourceStats.initiative),
-                        ability.effects.setBaseClaim(sourceStats.claim)
+                        ability.effects.setBaseGold(sourceStats.income),
+                        ability.effects.setBaseClaim(sourceStats.claim),
+                        ability.effects.setBaseReserve(sourceStats.reserve)
                     ]
                 }));
                 this.lastingEffect((ability) => ({
@@ -47,9 +48,9 @@ class TheLastGreenseer extends PlotCard {
                     match: context.source,
                     targetController: 'any',
                     effect: [
-                        ability.effects.setBaseIncome(targetStats.income),
-                        ability.effects.setBaseInitiative(targetStats.initiative),
-                        ability.effects.setBaseClaim(targetStats.claim)
+                        ability.effects.setBaseGold(targetStats.income),
+                        ability.effects.setBaseClaim(targetStats.claim),
+                        ability.effects.setBaseReserve(targetStats.reserve)
                     ]
                 }));
             }

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -439,6 +439,15 @@ class DrawCard extends BaseCard {
         return keys.every((key) => !this.challengeOptions.contains(key));
     }
 
+    canParticipate({ attacking, challengeType }) {
+        return (
+            this.getType() === 'character' &&
+            this.canDeclareAsParticipant({ attacking, challengeType }) &&
+            this.allowGameAction(attacking ? 'declareAsAttacker' : 'declareAsDefender') &&
+            !this.isParticipating()
+        );
+    }
+
     canDeclareAsParticipant({ attacking, challengeType }) {
         let canKneelForChallenge =
             (attacking && !this.kneeled && !this.kneelsAsAttacker(challengeType)) ||

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -196,8 +196,8 @@ class EffectEngine {
         }
 
         let eventNames = Object.keys(effect.until);
-        let handler = this.createCustomDurationHandler(effect);
         for (let eventName of eventNames) {
+            let handler = this.createCustomDurationHandler(eventName, effect);
             this.customDurationEvents.push({
                 name: eventName,
                 handler: handler,
@@ -220,10 +220,9 @@ class EffectEngine {
         this.customDurationEvents = remainingEvents;
     }
 
-    createCustomDurationHandler(customDurationEffect) {
+    createCustomDurationHandler(eventName, customDurationEffect) {
         return (...args) => {
-            let event = args[0];
-            let listener = customDurationEffect.until[event.name];
+            let listener = customDurationEffect.until[eventName];
             if (listener && listener(...args)) {
                 customDurationEffect.cancel();
                 this.unregisterCustomDurationEvents(customDurationEffect);

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -144,12 +144,11 @@ function setBaseCardModifier(propName) {
         return {
             apply: function (card, context) {
                 context[propName] = context[propName] || {};
-                context[propName][card.uuid] = calculate(card, context) || 0;
-                card[propName].baseValue = context[propName][card.uuid];
+                context[propName][card.uuid] = card[propName].baseValue;
+                card[propName].baseValue = calculate(card, context) || 0;
             },
             reapply: function (card, context) {
                 const newValue = calculate(card, context) || 0;
-                context[propName][card.uuid] = newValue;
                 card[propName].baseValue = newValue;
             },
             unapply: function (card, context) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -702,20 +702,28 @@ class Game extends EventEmitter {
             let valueGetter;
             switch (stat) {
                 case 'claim':
-                    if (typeof player.activePlot.claimSet === 'number') {
-                        effect = Effects.setClaim(Math.max(player.getClaim() + value, 0));
-                    } else {
+                    if (!player.activePlot.claim.setValue) {
                         effect = Effects.modifyClaim(value);
+                    } else {
+                        effect = Effects.setClaim(Math.max(player.getClaim() + value, 0));
                     }
                     valueGetter = () => player.getClaim();
                     break;
                 case 'initiative':
-                    effect = Effects.modifyInitiative(value);
-                    valueGetter = () => player.getTotalInitiative();
+                    if (!player.activePlot.initiative.setValue) {
+                        effect = Effects.modifyInitiative(value);
+                    } else {
+                        effect = Effects.setInitiative(Math.max(player.getInitiative() + value, 0));
+                    }
+                    valueGetter = () => player.getInitiative();
                     break;
                 case 'reserve':
-                    effect = Effects.modifyReserve(value);
-                    valueGetter = () => player.getTotalReserve();
+                    if (!player.activePlot.reserve.setValue) {
+                        effect = Effects.modifyReserve(value);
+                    } else {
+                        effect = Effects.setReserve(Math.max(player.getReserve() + value, 0));
+                    }
+                    valueGetter = () => player.getReserve();
                     break;
             }
 

--- a/server/game/gamesteps/challenge/ChooseParticipantsPrompt.js
+++ b/server/game/gamesteps/challenge/ChooseParticipantsPrompt.js
@@ -44,13 +44,10 @@ class ChooseParticipantsPrompt extends BaseStep {
     canParticipate(card) {
         return (
             card.controller === this.choosingPlayer &&
-            card.getType() === 'character' &&
-            card.canDeclareAsParticipant({
+            card.canParticipate({
                 attacking: this.attacking,
                 challengeType: this.challenge.challengeType
-            }) &&
-            card.allowGameAction(this.properties.gameAction) &&
-            !card.isParticipating()
+            })
         );
     }
 

--- a/server/game/gamesteps/challenge/ClaimPrompt.js
+++ b/server/game/gamesteps/challenge/ClaimPrompt.js
@@ -1,6 +1,6 @@
 import BaseStep from '../basestep.js';
-import ApplyClaim from './applyclaim.js';
 import Claim from '../../Claim.js';
+import GameActions from '../../GameActions/index.js';
 
 class ClaimPrompt extends BaseStep {
     constructor(game, challenge) {
@@ -10,6 +10,7 @@ class ClaimPrompt extends BaseStep {
     }
 
     continue() {
+        // TODO: Remove this prompt completely
         this.game.promptWithMenu(this.challenge.winner, this, {
             activePrompt: {
                 menuTitle: 'Perform before claim actions',
@@ -76,12 +77,13 @@ class ClaimPrompt extends BaseStep {
     }
 
     processClaim() {
-        this.game.raiseEvent(
-            'onClaimApplied',
-            { player: this.challenge.winner, challenge: this.challenge, claim: this.claim },
-            () => {
-                this.game.queueStep(new ApplyClaim(this.game, this.claim));
-            }
+        this.game.resolveGameAction(
+            GameActions.applyClaim({
+                player: this.challenge.winner,
+                challenge: this.challenge,
+                claim: this.claim,
+                game: this.game
+            })
         );
 
         return true;

--- a/server/game/gamesteps/challenge/SatisfyClaim.js
+++ b/server/game/gamesteps/challenge/SatisfyClaim.js
@@ -2,7 +2,7 @@ import BaseStep from '../basestep.js';
 import FulfillMilitaryClaim from './fulfillmilitaryclaim.js';
 import TextHelper from '../../TextHelper.js';
 
-class ApplyClaim extends BaseStep {
+class SatisfyClaim extends BaseStep {
     constructor(game, claim) {
         super(game);
         this.claim = claim;
@@ -76,4 +76,4 @@ class ApplyClaim extends BaseStep {
     }
 }
 
-export default ApplyClaim;
+export default SatisfyClaim;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -43,7 +43,6 @@ class ChallengeFlow extends BaseStep {
                 attacking: true,
                 challenge: this.challenge,
                 cannotCancel: this.challenge.declareDefendersFirst,
-                gameAction: 'declareAsAttacker',
                 mustBeDeclaredOption: 'mustBeDeclaredAsAttacker',
                 limitsProperty: 'attackerLimits',
                 activePromptTitle: 'Select challenge attackers',
@@ -66,7 +65,6 @@ class ChallengeFlow extends BaseStep {
             {
                 attacking: false,
                 challenge: this.challenge,
-                gameAction: 'declareAsDefender',
                 mustBeDeclaredOption: 'mustBeDeclaredAsDefender',
                 limitsProperty: 'defenderLimits',
                 activePromptTitle: 'Select defenders',
@@ -132,35 +130,7 @@ class ChallengeFlow extends BaseStep {
             return;
         }
 
-        if (
-            !this.challenge.attackingPlayer.anyCardsInPlay((card) =>
-                this.attackerPrompt.canParticipate(card)
-            )
-        ) {
-            this.game.promptWithMenu(this.challenge.attackingPlayer, this, {
-                activePrompt: {
-                    menuTitle:
-                        'You do not control enough elibile characters to legally initiate this challenge. Do you want to continue with defenders being declared anyway?',
-                    buttons: [
-                        { text: 'Yes', method: 'illegallyPromptForDefenders' },
-                        { text: 'No', method: 'cancelChallenge' }
-                    ]
-                },
-                source: this
-            });
-        } else {
-            this.game.queueStep(this.defenderPrompt);
-        }
-    }
-
-    illegallyPromptForDefenders() {
-        this.game.addAlert(
-            'danger',
-            '{0} does not control enough eligible characters to legally initiate this challenge, but has chosen to continue with declaring defenders anyway',
-            this.challenge.attackingPlayer
-        );
         this.game.queueStep(this.defenderPrompt);
-        return true;
     }
 
     promptForDefenders() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -373,11 +373,11 @@ class Player extends Spectator {
     }
 
     canInitiateChallenge(challengeType, opponent) {
-        if (this.isSupporter(opponent)) {
-            return false;
-        }
-
         return this.challenges.canInitiate(challengeType, opponent);
+    }
+
+    mustInitiateChallenge(challengeType, opponent) {
+        return this.challenges.mustInitiate(challengeType, opponent);
     }
 
     canGainGold() {
@@ -410,6 +410,14 @@ class Player extends Spectator {
 
     removeAllowedChallenge(allowedChallenge) {
         this.challenges.removeAllowedChallenge(allowedChallenge);
+    }
+
+    addForcedChallenge(forcedChallenge) {
+        this.challenges.addForcedChallenge(forcedChallenge);
+    }
+
+    removeForcedChallenge(forcedChallenge) {
+        this.challenges.removeForcedChallenge(forcedChallenge);
     }
 
     setMaxChallenge(number) {

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -5,11 +5,14 @@ class PlotCard extends BaseCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.reserveModifier = 0;
-        this.goldModifier = 0;
-        this.initiativeModifier = 0;
-        this.claimModifier = 0;
-        this.claimSet = undefined;
+        const printedIncome = this.getPrintedNumberFor(this.cardData.plotStats?.income);
+        this.income = new PlotStat(printedIncome);
+        const printedInitiative = this.getPrintedNumberFor(this.cardData.plotStats?.initiative);
+        this.initiative = new PlotStat(printedInitiative);
+        const printedClaim = this.getPrintedNumberFor(this.cardData.plotStats?.claim);
+        this.claim = new PlotStat(printedClaim);
+        const printedReserve = this.getPrintedNumberFor(this.cardData.plotStats?.reserve);
+        this.reserve = new PlotStat(printedReserve);
     }
 
     whenRevealed(properties) {
@@ -27,50 +30,20 @@ class PlotCard extends BaseCard {
         return this.abilities.reactions.find((ability) => ability instanceof CardWhenRevealed);
     }
 
-    getInitiative() {
-        const baseValue = this.canProvidePlotModifier['initiative']
-            ? this.getPrintedInitiative()
-            : 0;
-        return Math.max(baseValue + this.initiativeModifier, 0);
-    }
-
-    getPrintedInitiative() {
-        return this.getPrintedNumberFor(this.cardData.plotStats.initiative);
-    }
-
     getIncome() {
-        let baseValue = this.canProvidePlotModifier['gold']
-            ? this.baseIncome || this.getPrintedIncome()
-            : 0;
-
-        return baseValue + this.goldModifier;
+        return this.income.calculate();
     }
 
-    getPrintedIncome() {
-        return this.getPrintedNumberFor(this.cardData.plotStats.income);
-    }
-
-    getReserve() {
-        var baseValue = this.canProvidePlotModifier['reserve'] ? this.getPrintedReserve() : 0;
-        return baseValue + this.reserveModifier;
-    }
-
-    getPrintedReserve() {
-        return this.getPrintedNumberFor(this.cardData.plotStats.reserve);
-    }
-
-    getPrintedClaim() {
-        return this.getPrintedNumberFor(this.cardData.plotStats.claim);
+    getInitiative() {
+        return this.initiative.calculate();
     }
 
     getClaim() {
-        let baseClaim = this.getPrintedClaim();
+        return this.claim.calculate();
+    }
 
-        if (typeof this.claimSet === 'number') {
-            return this.claimSet;
-        }
-
-        return Math.max(baseClaim + this.claimModifier, 0);
+    getReserve() {
+        return this.reserve.calculate();
     }
 
     flipFaceup() {
@@ -79,6 +52,24 @@ class PlotCard extends BaseCard {
 
         // But this is
         this.selected = false;
+    }
+}
+
+export class PlotStat {
+    constructor(printedValue) {
+        this.printedValue = printedValue;
+        this.baseValue = this.printedValue;
+        // TODO: Improve modifiers so that other cards apply a "PlotStatModifier" which is collected here & used in calculate
+        //       Would make affecting that modified stat (eg. Rains of Autumn) much simpler
+        this.modifier = 0;
+        this.setValue = null;
+    }
+
+    calculate() {
+        if (!this.setValue) {
+            return this.baseValue + this.modifier;
+        }
+        return this.setValue;
     }
 }
 

--- a/test/server/cards/01-Core/HandOfTheKing.spec.js
+++ b/test/server/cards/01-Core/HandOfTheKing.spec.js
@@ -51,6 +51,7 @@ describe('Hand of the King', function () {
                 const deck = this.buildDeck('stark', [
                     'Sailing the Summer Sea',
                     'Bastard in Hiding',
+                    'Bastard in Hiding',
                     'Shireen Baratheon (Core)'
                 ]);
                 this.player1.selectDeck(deck);
@@ -59,6 +60,7 @@ describe('Hand of the King', function () {
                 this.startGame();
                 this.keepStartingHands();
 
+                this.player1.clickCard('Bastard in Hiding', 'hand');
                 this.player1.clickCard('Bastard in Hiding', 'hand');
                 this.player1.clickCard('Shireen Baratheon (Core)', 'hand');
 

--- a/test/server/cards/01-Core/KhalDrogo.spec.js
+++ b/test/server/cards/01-Core/KhalDrogo.spec.js
@@ -4,13 +4,15 @@ describe('Khal Drogo (Core)', function () {
             const deck = this.buildDeck('targaryen', [
                 'A Noble Cause',
                 'A Noble Cause',
-                'Khal Drogo (Core)'
+                'Khal Drogo (Core)',
+                'Braided Warrior'
             ]);
             this.player1.selectDeck(deck);
             this.player2.selectDeck(deck);
             this.startGame();
             this.keepStartingHands();
             this.player1.clickCard('Khal Drogo', 'hand');
+            this.player1.clickCard('Braided Warrior', 'hand');
             this.completeSetup();
             this.player1.selectPlot('A Noble Cause');
             this.player2.selectPlot('A Noble Cause');

--- a/test/server/cards/04.2-CtA/KingsOfSummer.spec.js
+++ b/test/server/cards/04.2-CtA/KingsOfSummer.spec.js
@@ -1,18 +1,20 @@
 import KingsOfSummer from '../../../../server/game/cards/04.2-CtA/KingsOfSummer.js';
+import { PlotStat } from '../../../../server/game/plotcard.js';
 
 describe('Kings Of Summer', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'getPlayers', 'on']);
 
         this.plot1 = jasmine.createSpyObj('plot1', ['hasTrait']);
-        this.plot1.goldModifier = 0;
-        this.plot1.reserveModifier = 0;
+        // TODO: Add these as PlotStats (so KingsOfSummer effect works properly)
+        this.plot1.income = new PlotStat(0);
+        this.plot1.reserve = new PlotStat(0);
         this.plot2 = jasmine.createSpyObj('plot2', ['hasTrait']);
-        this.plot2.goldModifier = 0;
-        this.plot2.reserveModifier = 0;
+        this.plot2.income = new PlotStat(0);
+        this.plot2.reserve = new PlotStat(0);
         this.plot3 = jasmine.createSpyObj('plot3', ['hasTrait']);
-        this.plot3.goldModifier = 0;
-        this.plot3.reserveModifier = 0;
+        this.plot3.income = new PlotStat(0);
+        this.plot3.reserve = new PlotStat(0);
 
         this.plot1.hasTrait.and.callFake((trait) => {
             return trait === 'Summer';
@@ -22,16 +24,12 @@ describe('Kings Of Summer', function () {
         this.player1Fake = {};
         this.player1Fake.game = this.gameSpy;
         this.player1Fake.activePlot = this.plot1;
-        this.player1Fake.activePlot.reserveModifier = 0;
-        this.player1Fake.activePlot.goldModifier = 0;
         this.plot1.controller = this.player1Fake;
         this.plot3.controller = this.player1Fake;
 
         this.player2Fake = {};
         this.player2Fake.game = this.gameSpy;
         this.player2Fake.activePlot = this.plot2;
-        this.player2Fake.activePlot.reserveModifier = 0;
-        this.player2Fake.activePlot.goldModifier = 0;
         this.plot2.controller = this.player2Fake;
 
         this.gameSpy.getPlayers.and.returnValue([this.player1Fake, this.player2Fake]);
@@ -57,7 +55,7 @@ describe('Kings Of Summer', function () {
 
         it('should increase the plots reserve', function () {
             this.reserveEffect.effect.apply(this.plot1, this.context);
-            expect(this.plot1.reserveModifier).toBe(1);
+            expect(this.plot1.reserve.modifier).toBe(1);
         });
     });
 
@@ -68,7 +66,7 @@ describe('Kings Of Summer', function () {
 
         it('should increase the gold on the plot', function () {
             this.goldEffect.effect.apply(this.plot1, this.context);
-            expect(this.plot1.goldModifier).toBe(1);
+            expect(this.plot1.income.modifier).toBe(1);
         });
 
         describe('when a Winter plot is revealed', function () {

--- a/test/server/cards/04.2-CtA/KingsOfWinter.spec.js
+++ b/test/server/cards/04.2-CtA/KingsOfWinter.spec.js
@@ -1,18 +1,19 @@
 import KingsOfWinter from '../../../../server/game/cards/04.2-CtA/KingsOfWinter.js';
+import { PlotStat } from '../../../../server/game/plotcard.js';
 
 describe('Kings Of Winter', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'getPlayers', 'on']);
 
         this.plot1 = jasmine.createSpyObj('plot1', ['hasTrait']);
-        this.plot1.goldModifier = 0;
-        this.plot1.reserveModifier = 0;
+        this.plot1.income = new PlotStat(0);
+        this.plot1.reserve = new PlotStat(0);
         this.plot2 = jasmine.createSpyObj('plot2', ['hasTrait']);
-        this.plot2.goldModifier = 0;
-        this.plot2.reserveModifier = 0;
+        this.plot2.income = new PlotStat(0);
+        this.plot2.reserve = new PlotStat(0);
         this.plot3 = jasmine.createSpyObj('plot3', ['hasTrait']);
-        this.plot3.goldModifier = 0;
-        this.plot3.reserveModifier = 0;
+        this.plot3.income = new PlotStat(0);
+        this.plot3.reserve = new PlotStat(0);
 
         this.plot1.hasTrait.and.callFake((trait) => {
             return trait === 'Summer';
@@ -22,16 +23,12 @@ describe('Kings Of Winter', function () {
         this.player1Fake = {};
         this.player1Fake.game = this.gameSpy;
         this.player1Fake.activePlot = this.plot1;
-        this.player1Fake.activePlot.reserveModifier = 0;
-        this.player1Fake.activePlot.goldModifier = 0;
         this.plot1.controller = this.player1Fake;
         this.plot3.controller = this.player1Fake;
 
         this.player2Fake = {};
         this.player2Fake.game = this.gameSpy;
         this.player2Fake.activePlot = this.plot2;
-        this.player2Fake.activePlot.reserveModifier = 0;
-        this.player2Fake.activePlot.goldModifier = 0;
         this.plot2.controller = this.player2Fake;
 
         this.gameSpy.getPlayers.and.returnValue([this.player1Fake, this.player2Fake]);
@@ -58,7 +55,7 @@ describe('Kings Of Winter', function () {
 
         it('should reduce the plots reserve', function () {
             this.reserveEffect.effect.apply(this.plot1, this.context);
-            expect(this.plot1.reserveModifier).toBe(-1);
+            expect(this.plot1.reserve.modifier).toBe(-1);
         });
     });
 
@@ -69,7 +66,7 @@ describe('Kings Of Winter', function () {
 
         it('should reduce the gold on the plot', function () {
             this.goldEffect.effect.apply(this.plot1, this.context);
-            expect(this.plot1.goldModifier).toBe(-1);
+            expect(this.plot1.income.modifier).toBe(-1);
         });
 
         describe('when the current player does not have a Winter', function () {

--- a/test/server/cards/04.5-GoH/DragonglassDagger.spec.js
+++ b/test/server/cards/04.5-GoH/DragonglassDagger.spec.js
@@ -51,7 +51,9 @@ describe('Dragonglass Dagger', function () {
                 it("should immunize the charcter with the dagger from Theon's effect", function () {
                     expect(this.player2).not.toHavePromptButton('Apply Claim');
                     // Challenge completed, kicked back to challenge declaration
-                    expect(this.player2).toHavePromptButton('Intrigue');
+                    expect(
+                        this.player2.currentPrompt().buttons.map((button) => button.text)
+                    ).toContain('Intrigue');
                 });
             });
         });

--- a/test/server/cards/06.2-GtR/MarriagePact.spec.js
+++ b/test/server/cards/06.2-GtR/MarriagePact.spec.js
@@ -4,6 +4,7 @@ describe('Marriage Pact', function () {
             const deck = this.buildDeck('greyjoy', [
                 'A Noble Cause',
                 'Hedge Knight',
+                'Hedge Knight',
                 'Marriage Pact'
             ]);
 
@@ -14,10 +15,14 @@ describe('Marriage Pact', function () {
 
             this.character = this.player1.findCardByName('Hedge Knight', 'hand');
             this.pact = this.player1.findCardByName('Marriage Pact', 'hand');
-            this.opponentCharacter = this.player2.findCardByName('Hedge Knight', 'hand');
+            [this.opponentCharacter, this.opponentCharacter2] = this.player2.filterCardsByName(
+                'Hedge Knight',
+                'hand'
+            );
 
             this.player1.clickCard(this.character);
             this.player2.clickCard(this.opponentCharacter);
+            this.player2.clickCard(this.opponentCharacter2);
             this.completeSetup();
 
             this.selectFirstPlayer(this.player1);

--- a/test/server/cards/06.6-TBWB/PayTheIronPrice.spec.js
+++ b/test/server/cards/06.6-TBWB/PayTheIronPrice.spec.js
@@ -9,7 +9,7 @@ describe('Pay The Iron Price', function () {
             const deck2 = this.buildDeck('greyjoy', [
                 'A Noble Cause',
                 'Iron Islands Fishmonger',
-                'Little Bird',
+                'Little Bird (Core)',
                 'Fishing Net',
                 'Milk of the Poppy',
                 'Ward (TS)'

--- a/test/server/cards/07-WotW/SeasonedWoodsman.spec.js
+++ b/test/server/cards/07-WotW/SeasonedWoodsman.spec.js
@@ -5,7 +5,7 @@ describe('Seasoned Woodsman', function () {
                 const deck = this.buildDeck('thenightswatch', [
                     'Sneak Attack',
                     'Seasoned Woodsman',
-                    'Little Bird'
+                    'Little Bird (Core)'
                 ]);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);

--- a/test/server/cards/10-SoD/SpareBoot.spec.js
+++ b/test/server/cards/10-SoD/SpareBoot.spec.js
@@ -7,7 +7,7 @@ describe('Spare Boot', function () {
                 'Bran Stark (Core)',
                 'Seal of the Hand',
                 "Syrio's Training",
-                'Little Bird'
+                'Little Bird (Core)'
             ]);
 
             this.player1.selectDeck(deck);

--- a/test/server/cards/11.2-TMoW/TradingWithQohor.spec.js
+++ b/test/server/cards/11.2-TMoW/TradingWithQohor.spec.js
@@ -9,7 +9,7 @@ describe('Trading With Qohor', function () {
                         'Trading With Qohor',
                         'A Noble Cause',
                         'Hedge Knight',
-                        'Little Bird',
+                        'Little Bird (Core)',
                         'Noble Lineage'
                     ]);
                     this.player1.selectDeck(deck);

--- a/test/server/cards/13.6-LMHR/ValyrianSteel.spec.js
+++ b/test/server/cards/13.6-LMHR/ValyrianSteel.spec.js
@@ -6,7 +6,7 @@ describe('Valyrian Steel', function () {
                     'Valyrian Steel (LMHR)',
                     'Late Summer Feast',
                     'Hedge Knight',
-                    'Little Bird'
+                    'Little Bird (Core)'
                 ]);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);

--- a/test/server/cards/17.1-R/ValyrianSteel.spec.js
+++ b/test/server/cards/17.1-R/ValyrianSteel.spec.js
@@ -6,7 +6,7 @@ describe('Valyrian Steel', function () {
                     'Valyrian Steel (R)',
                     'Late Summer Feast',
                     'Hedge Knight',
-                    'Little Bird'
+                    'Little Bird (Core)'
                 ]);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);

--- a/test/server/cards/18-FH/SerEmmonCuy.spec.js
+++ b/test/server/cards/18-FH/SerEmmonCuy.spec.js
@@ -31,10 +31,10 @@ describe('Ser Emmon Cuy', function () {
             });
 
             it('should ask to trigger for Ser Emmon to trigger and raise claim and kill ser emmon', function () {
-                expect(this.player1Object.activePlot.claimModifier).toBe(0);
+                expect(this.player1Object.activePlot.claim.modifier).toBe(0);
                 expect(this.player1).toHavePrompt('Any reactions?');
                 this.player1.clickCard(this.emmon);
-                expect(this.player1Object.activePlot.claimModifier).toBe(1);
+                expect(this.player1Object.activePlot.claim.modifier).toBe(1);
                 expect(this.emmon.location).toBe('dead pile');
             });
 

--- a/test/server/cards/25.5-TIC/PinkGraces.spec.js
+++ b/test/server/cards/25.5-TIC/PinkGraces.spec.js
@@ -1,0 +1,114 @@
+describe('Pink Graces', function () {
+    integration(function () {
+        beforeEach(function () {
+            const deck = this.buildDeck('targaryen', [
+                'Late Summer Feast',
+                'Pink Graces',
+                'Braided Warrior',
+                'Temple of the Graces',
+                'Maester Aemon (WotW)'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.pinkGraces = this.player1.findCardByName('Pink Graces', 'hand');
+            this.military1 = this.player1.findCardByName('Braided Warrior', 'hand');
+            this.temple = this.player1.findCardByName('Temple of the Graces', 'hand');
+            this.aemon = this.player2.findCardByName('Maester Aemon (WotW)', 'hand');
+            this.military2 = this.player2.findCardByName('Braided Warrior', 'hand');
+            this.player1.clickCard(this.pinkGraces);
+            this.player1.clickCard(this.temple);
+            this.player1.clickCard(this.military1);
+            this.player2.clickCard(this.aemon);
+            this.player2.clickCard(this.military2);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player2);
+            this.completeMarshalPhase();
+            // Ensure both players have at least 1 card in their draw deck (to draw for Pink Graces)
+            this.player1Object.moveCard(
+                this.player1.findCardByName('Maester Aemon', 'hand'),
+                'draw deck'
+            );
+            this.player2Object.moveCard(
+                this.player2.findCardByName('Temple of the Graces', 'hand'),
+                'draw deck'
+            );
+        });
+
+        describe('when a player applied military claim through a challenge', function () {
+            beforeEach(function () {
+                this.unopposedChallenge(this.player2, 'military', this.military2);
+                // Pass Late Summer Feast
+                this.player1.clickPrompt('No');
+                this.player2.clickPrompt('Apply Claim');
+                this.player1.clickCard(this.military1);
+                this.completeChallengesPhase();
+                // Pass Aemon trigger
+                this.player2.clickPrompt('Pass');
+            });
+
+            it('should allow you to trigger Pink Graces', function () {
+                expect(this.player1).toAllowAbilityTrigger(this.pinkGraces);
+            });
+
+            it('should prevent that player from drawing cards', function () {
+                this.player1.triggerAbility(this.pinkGraces);
+                // Player 2 would have prompt first (being first player)
+                expect(this.player2).not.toHavePrompt('Draw 1 card from Pink Graces?');
+                expect(this.player1).toHavePrompt('Draw 1 card from Pink Graces?');
+            });
+        });
+
+        describe('when a player applied military claim through an effect', function () {
+            beforeEach(function () {
+                this.completeChallengesPhase();
+                this.player2.triggerAbility(this.aemon);
+                this.player2.clickPrompt('Military');
+                this.player1.clickCard(this.military1);
+            });
+
+            it('should allow you to trigger Pink Graces', function () {
+                expect(this.player1).toAllowAbilityTrigger(this.pinkGraces);
+            });
+
+            it('should prevent that player from drawing cards', function () {
+                this.player1.triggerAbility(this.pinkGraces);
+                // Player 2 would have prompt first (being first player)
+                expect(this.player2).not.toHavePrompt('Draw 1 card from Pink Graces?');
+                expect(this.player1).toHavePrompt('Draw 1 card from Pink Graces?');
+            });
+        });
+
+        describe('when a player initiated military, but applied claim of another type', function () {
+            beforeEach(function () {
+                // Pass player2 challenges
+                this.player2.clickPrompt('Done');
+                this.unopposedChallenge(this.player1, 'military', this.military1);
+                // Pass Late Summer Feast
+                this.player2.clickPrompt('No');
+                this.player1.clickPrompt('Apply Claim');
+                this.player1.triggerAbility(this.temple);
+                this.player1.clickCard(this.temple);
+                this.player1.clickPrompt('Done');
+                // Pass Aemon trigger
+                this.player2.clickPrompt('Pass');
+            });
+
+            it('should allow you to trigger Pink Graces', function () {
+                expect(this.player1).toAllowAbilityTrigger(this.pinkGraces);
+            });
+
+            it('should not prevent that player from drawing cards', function () {
+                this.player1.triggerAbility(this.pinkGraces);
+                // Player 2 would have prompt first (being first player)
+                expect(this.player2).toHavePrompt('Draw 1 card from Pink Graces?');
+                this.player2.clickPrompt('Yes');
+                expect(this.player1).toHavePrompt('Draw 1 card from Pink Graces?');
+            });
+        });
+    });
+});

--- a/test/server/cards/25.5-TIC/RedMountains.spec.js
+++ b/test/server/cards/25.5-TIC/RedMountains.spec.js
@@ -1,0 +1,98 @@
+describe('Red Mountains', function () {
+    integration(function () {
+        beforeEach(function () {
+            const deck = this.buildDeck('martell', [
+                'Trading with the Pentoshi',
+                'Arianne Martell (Core)',
+                'Obara Sand (SoD)',
+                'Edric Dayne (Core)',
+                'Red Mountains'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.redMountains = this.player1.findCardByName('Red Mountains', 'hand');
+            this.obara = this.player2.findCardByName('Obara Sand', 'hand');
+            this.arianne = this.player2.findCardByName('Arianne Martell', 'hand');
+            this.edric = this.player2.findCardByName('Edric Dayne', 'hand');
+            this.player1.clickCard(this.redMountains);
+            this.player2.clickCard(this.obara);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player2);
+            this.selectPlotOrder(this.player1);
+            this.player2.clickCard(this.arianne);
+            this.completeMarshalPhase();
+        });
+
+        describe('when triggered before challenges', function () {
+            beforeEach(function () {
+                this.player1.clickMenu(this.redMountains, 'Force military challenge');
+            });
+
+            it('should prevent the opponent from initiating intrigue or power', function () {
+                expect(this.player2).toHaveDisabledPromptButton('Intrigue');
+                expect(this.player2).toHaveDisabledPromptButton('Power');
+            });
+
+            it('should prevent the opponent from passing challenges', function () {
+                expect(this.player2).toHaveDisabledPromptButton('Done');
+            });
+
+            describe('and opponent no longer has characters to declare for military', function () {
+                beforeEach(function () {
+                    this.player2.clickMenu(this.obara, 'Put character into play');
+                    this.player2.clickCard(this.obara);
+                    this.player2.clickCard(this.edric);
+                });
+
+                it('should allow them to initiate intrigue or power', function () {
+                    expect(this.player2).not.toHaveDisabledPromptButton('Intrigue');
+                    expect(this.player2).not.toHaveDisabledPromptButton('Power');
+                });
+
+                it('should allow them to pass challenges', function () {
+                    expect(this.player2).not.toHaveDisabledPromptButton('Done');
+                });
+
+                describe('and opponent initiates an intrigue challenge', function () {
+                    beforeEach(function () {
+                        this.unopposedChallenge(this.player2, 'intrigue', this.arianne);
+                        this.player2.clickPrompt('Continue');
+                        this.player2.clickMenu(this.arianne, 'Put character into play');
+                        this.player2.clickCard(this.obara);
+                    });
+
+                    it('should allow them to initiate a military or power, but not intrigue', function () {
+                        expect(this.player2).not.toHaveDisabledPromptButton('Military');
+                        expect(this.player2).toHaveDisabledPromptButton('Intrigue');
+                        expect(this.player2).not.toHaveDisabledPromptButton('Power');
+                    });
+
+                    it('should allow them to pass challenges', function () {
+                        expect(this.player2).not.toHaveDisabledPromptButton('Done');
+                    });
+                });
+            });
+        });
+
+        describe('when triggered after a military challenge', function () {
+            beforeEach(function () {
+                this.unopposedChallenge(this.player2, 'military', this.obara);
+                this.player1.clickMenu(this.redMountains, 'Force military challenge');
+            });
+
+            it('should allow the opponent to initiate intrigue or power', function () {
+                expect(this.player2).not.toHaveDisabledPromptButton('Intrigue');
+                expect(this.player2).not.toHaveDisabledPromptButton('Power');
+            });
+
+            it('should allow the opponent to pass challenges', function () {
+                expect(this.player2).not.toHaveDisabledPromptButton('Done');
+            });
+        });
+    });
+});

--- a/test/server/cards/25.5-TIC/TheLastGreenseer.spec.js
+++ b/test/server/cards/25.5-TIC/TheLastGreenseer.spec.js
@@ -1,0 +1,59 @@
+describe('The Last Greenseer', function () {
+    integration(function () {
+        beforeEach(function () {
+            const deck = this.buildDeck('martell', [
+                'The Last Greenseer',
+                "At Prince Doran's Behest",
+                'Snowed Under',
+                "Varys's Riddle",
+                'Summer Harvest',
+                'The Winds of Winter'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.completeSetup();
+
+            this.expectPlotStatsOf = (playerWrapper, income, claim, reserve) => {
+                expect(playerWrapper.player.activePlot.getIncome()).toBe(income);
+                expect(playerWrapper.player.activePlot.getClaim()).toBe(claim);
+                expect(playerWrapper.player.activePlot.getReserve()).toBe(reserve);
+            };
+        });
+
+        describe("when triggered on At Prince Doran's Behest", function () {
+            beforeEach(function () {
+                this.player1.selectPlot('The Last Greenseer');
+                this.player2.selectPlot("At Prince Doran's Behest");
+                // Trigger The Last Greenseer first
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+                this.player1.clickCard(this.player2.player.activePlot);
+            });
+
+            it('should swap base values', function () {
+                this.expectPlotStatsOf(this.player1, 0, 0, 0);
+                this.expectPlotStatsOf(this.player2, 4, 1, 5);
+            });
+
+            describe('and opponent reveals new plot', function () {
+                beforeEach(function () {
+                    this.player2.clickCard('The Winds of Winter', 'plot deck');
+                });
+
+                it('should no longer swap base values', function () {
+                    this.expectPlotStatsOf(this.player1, 4, 1, 5);
+                    this.expectPlotStatsOf(this.player2, 3, 2, 5);
+                });
+            });
+        });
+
+        // TODO: Add the following tests after FAQ rulings are defined clearly:
+        //       - The Last Greenseer on a non-TLG plot in melee
+        //       - Varys's Riddle (primarily in a melee game)
+        //       - Summer Harvest
+        //       - Snowed Under
+    });
+});

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -403,7 +403,7 @@ describe('EffectEngine', function () {
             this.engine.add(this.effectSpy);
             this.engine.add(this.effectSpy2);
 
-            this.handler = this.engine.createCustomDurationHandler(this.effectSpy);
+            this.handler = this.engine.createCustomDurationHandler('foo', this.effectSpy);
         });
 
         describe('when called for an unregistered event', function () {

--- a/test/server/integration/Attachments.spec.js
+++ b/test/server/integration/Attachments.spec.js
@@ -169,7 +169,7 @@ describe('attachments', function () {
                 const deck1 = this.buildDeck('stark', [
                     'A Noble Cause',
                     'Winterfell Steward',
-                    'Little Bird'
+                    'Little Bird (Core)'
                 ]);
                 const deck2 = this.buildDeck('stark', ['A Noble Cause', 'Milk of the Poppy']);
                 this.player1.selectDeck(deck1);

--- a/test/server/integration/WinningAndLosing.spec.js
+++ b/test/server/integration/WinningAndLosing.spec.js
@@ -42,7 +42,7 @@ describe('Winning and losing', function () {
 
                     expect(this.player3).not.toHavePrompt('Marshal your cards');
                     // Player 1's turn on the challenges phase
-                    expect(this.player1).toHavePromptButton('Military');
+                    expect(this.player1).toHaveDisabledPromptButton('Military');
                 });
             });
 

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -41,6 +41,7 @@ describe('challenges phase', function () {
                 const deck = this.buildDeck('thenightswatch', [
                     'A Noble Cause',
                     'Steward at the Wall',
+                    'Bastard in Hiding',
                     'The Haunted Forest',
                     'The Haunted Forest',
                     'The Shadow Tower (WotN)'
@@ -50,6 +51,7 @@ describe('challenges phase', function () {
                 this.startGame();
                 this.keepStartingHands();
                 this.player1.clickCard('Steward at the Wall', 'hand');
+                this.player1.clickCard('Bastard in Hiding', 'hand');
                 this.player2.clickCard('The Haunted Forest', 'hand');
                 this.player2.clickCard('The Haunted Forest', 'hand');
                 this.player2.clickCard('The Shadow Tower', 'hand');
@@ -282,6 +284,7 @@ describe('challenges phase', function () {
                 this.startGame();
                 this.keepStartingHands();
                 this.player1.clickCard('Winterfell Steward', 'hand');
+                this.player2.clickCard('Winterfell Steward', 'hand');
                 this.completeSetup();
 
                 this.selectFirstPlayer(this.player1);


### PR DESCRIPTION
Can expand on this, but essentially:

- Added all 20 cards
- Added engine changes to account for Red Mountains (forcing a challenge, not allowing a pass if forced)
- Added engine changes to account for The Last Greenseer (swapping/setting base plot values). This came with a slight update on plot stats, which I'd like to explore more in the future.
- Added _temporary_ engine changes to applying claim so that:
  - Claim replacement effects properly "apply" the new type, rather than the old
  - Effects which apply or satisfy claim still trigger the "onClaimApplied" event. Ruling for this to be confirmed, but agreed to count as applying (eg. Corn, Corn Corn or Maester Aemon) for now.

Notably, there are various things that could be improved in following updates:
- Applying Claim should be properly reworked into a GameAction; it has been made one, but simply queues the `SatisfyClaim` step.
- The prompt to "Apply Claim" or "Continue" should be removed. Currently it will still count for "onClaimApplied", but has been noted by the community as being a bit unnecessary & confusing for people who think claim is optional (it is not optional).
- Revealing plots via card effects (eg. Prince Doran's Behest) is not calling `emitBaseEvent` for each element of revealing plots. This becomes relevant for `The Last Greenseer` as it should identify revealing a new plot with Behest as "Behest leaving play", but currently the `onCardLeftPlay` event is never fired during Behest's ability. Likely requires a rework of plot revealing, which has been needed for a while now.