### PR TITLE
Release Winter's Kings

### DIFF
--- a/server/game/GameActions/GainIcon.js
+++ b/server/game/GameActions/GainIcon.js
@@ -6,10 +6,8 @@ class GainIcon extends GameAction {
     }
 
     canChangeGameState({ card, applying = true }) {
-        //when the effect is applying, check if the card´s location is play area
-        //when the effect is unapplying, skip the check for the location as we want the effect to be removed in any case
-        let playAreaCheck = applying ? card.location === 'play area' : true;
-        return playAreaCheck && card.getType() === 'character';
+        // Checks if effect is either unapplying (which could happen in or out of play), or character is in play area
+        return card.getType() === 'character' && (!applying || card.location === 'play area');
     }
 
     createEvent({ card, icon, applying = true }) {

--- a/server/game/GameActions/LookAtShadows.js
+++ b/server/game/GameActions/LookAtShadows.js
@@ -1,0 +1,26 @@
+import GameAction from './GameAction.js';
+
+class LookAtShadows extends GameAction {
+    constructor() {
+        super('lookAtShadows');
+    }
+
+    canChangeGameState({ opponent }) {
+        return opponent && opponent.shadows.length > 0;
+    }
+
+    createEvent({ player, opponent, context }) {
+        return this.event('onLookAtShadows', { player, opponent }, (event) => {
+            context.game.promptForSelect(event.player, {
+                activePromptTitle: `Look at ${event.opponent.name}'s shadow area`,
+                source: context.source,
+                revealTargets: true,
+                cardCondition: (card) =>
+                    card.location === 'shadows' && card.controller === event.opponent,
+                onSelect: () => true
+            });
+        });
+    }
+}
+
+export default new LookAtShadows();

--- a/server/game/GameActions/LoseIcon.js
+++ b/server/game/GameActions/LoseIcon.js
@@ -6,10 +6,8 @@ class LoseIcon extends GameAction {
     }
 
     canChangeGameState({ card, applying = true }) {
-        //when the effect is applying, check if the card´s location is play area
-        //when the effect is unapplying, skip the check for the location as we want the effect to be removed in any case
-        let playAreaCheck = applying ? card.location === 'play area' : true;
-        return playAreaCheck && card.getType() === 'character';
+        // Checks if effect is either unapplying (which could happen in or out of play), or character is in play area
+        return card.getType() === 'character' && (!applying || card.location === 'play area');
     }
 
     createEvent({ card, icon, applying = true }) {

--- a/server/game/GameActions/PlaceCardUnderneath.js
+++ b/server/game/GameActions/PlaceCardUnderneath.js
@@ -15,6 +15,7 @@ class PlaceCardUnderneath extends GameAction {
 
     canChangeGameState({ card, parentCard }) {
         return (
+            parentCard &&
             !parentCard.underneath.includes(card) &&
             (parentCard.location === 'play area' || parentCard === parentCard.controller.agenda)
         );

--- a/server/game/GameActions/index.js
+++ b/server/game/GameActions/index.js
@@ -21,6 +21,7 @@ import Kill from './Kill.js';
 import KneelCard from './KneelCard.js';
 import LookAtDeck from './LookAtDeck.js';
 import LookAtHand from './LookAtHand.js';
+import lookAtShadows from './LookAtShadows.js';
 import LoseIcon from './LoseIcon.js';
 import MayGameAction from './MayGameAction.js';
 import MovePower from './MovePower.js';
@@ -67,6 +68,7 @@ const GameActions = {
     kneelCard: (props) => new AbilityAdapter(KneelCard, props),
     lookAtDeck: (props) => new AbilityAdapter(LookAtDeck, props),
     lookAtHand: (props) => new AbilityAdapter(LookAtHand, props),
+    lookAtShadows: (props) => new AbilityAdapter(lookAtShadows, props),
     loseIcon: (props) => new AbilityAdapter(LoseIcon, props),
     may: (props) => new MayGameAction(props),
     movePower: (props) => new AbilityAdapter(MovePower, props),

--- a/server/game/cards/15-DotE/ArchmaesterMarwyn.js
+++ b/server/game/cards/15-DotE/ArchmaesterMarwyn.js
@@ -20,7 +20,7 @@ class ArchmaesterMarwyn extends DrawCard {
 
         this.reaction({
             when: {
-                onCardEntersPlay: (event) => event.card === this && this.controller.agenda
+                onCardEntersPlay: (event) => event.card === this
             },
             message:
                 '{player} uses {source} to place top 2 cards of their deck facedown under their agenda',

--- a/server/game/cards/25.6-WK/ALannistersHonor.js
+++ b/server/game/cards/25.6-WK/ALannistersHonor.js
@@ -1,0 +1,50 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class ALannistersHonor extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.isMatch({
+                        winner: this.controller,
+                        attackingPlayer: this.controller,
+                        challengeType: 'intrigue'
+                    })
+            },
+            target: {
+                choosingPlayer: (player, context) => player === context.event.challenge.loser,
+                cardCondition: {
+                    type: 'character',
+                    location: 'play area',
+                    controller: 'choosingPlayer',
+                    condition: (card, context) =>
+                        card.getStrength() ===
+                            this.getLowestStrInPlay(context.event.challenge.loser) &&
+                        GameActions.kill({ card }).allow()
+                }
+            },
+            max: ability.limit.perChallenge(1),
+            message: {
+                format: '{player} plays {source} to have {loser} choose and kill a character they control with the lowest STR',
+                args: { loser: (context) => context.event.challenge.loser }
+            },
+            handler: (context) => {
+                context.game.resolveGameAction(
+                    GameActions.kill((context) => ({ card: context.target })),
+                    context
+                );
+            }
+        });
+    }
+
+    getLowestStrInPlay(player) {
+        let characters = player.filterCardsInPlay({ type: 'character' });
+        let strengths = characters.map((card) => card.getStrength());
+        return Math.min(...strengths);
+    }
+}
+
+ALannistersHonor.code = '25106';
+
+export default ALannistersHonor;

--- a/server/game/cards/25.6-WK/AThousandEyesAndOne.js
+++ b/server/game/cards/25.6-WK/AThousandEyesAndOne.js
@@ -1,0 +1,49 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class AThousandEyesAndOne extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Look at an opponent hand or shadows',
+            cost: ability.costs.kneelFactionCard(),
+            chooseOpponent: true,
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.choose({
+                        title: (context) =>
+                            `Look at ${context.opponent.name}'s hand or shadows area?`,
+                        choices: {
+                            Hand: {
+                                message: "{player} chooses to look at {opponent}'s hand",
+                                gameAction: GameActions.simultaneously([
+                                    GameActions.lookAtHand((context) => ({
+                                        player: context.player,
+                                        opponent: context.opponent,
+                                        context
+                                    })),
+                                    GameActions.drawCards({ player: context.player, amount: 1 })
+                                ])
+                            },
+                            Shadows: {
+                                message: "{player} chooses to look at {opponent}'s shadows area",
+                                gameAction: GameActions.simultaneously([
+                                    GameActions.lookAtShadows((context) => ({
+                                        player: context.player,
+                                        opponent: context.opponent,
+                                        context
+                                    })),
+                                    GameActions.drawCards({ player: context.player, amount: 1 })
+                                ])
+                            }
+                        }
+                    }),
+                    context
+                );
+            }
+        });
+    }
+}
+
+AThousandEyesAndOne.code = '25118';
+
+export default AThousandEyesAndOne;

--- a/server/game/cards/25.6-WK/AegonTargaryen.js
+++ b/server/game/cards/25.6-WK/AegonTargaryen.js
@@ -1,0 +1,21 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class AegonTargaryen extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardEntersPlay: (event) =>
+                    this.game.currentPhase === 'challenge' &&
+                    event.card.isMatch({ type: 'character', loyal: false, faction: 'targaryen' })
+            },
+            limit: ability.limit.perPhase(2),
+            message: '{player} uses {source} to stand {source}',
+            gameAction: GameActions.standCard({ card: this })
+        });
+    }
+}
+
+AegonTargaryen.code = '25113';
+
+export default AegonTargaryen;

--- a/server/game/cards/25.6-WK/BlackwaterForces.js
+++ b/server/game/cards/25.6-WK/BlackwaterForces.js
@@ -1,0 +1,27 @@
+import DrawCard from '../../drawcard.js';
+
+class BlackwaterForces extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardStood: (event) => event.card === this && this.game.isDuringChallenge()
+            },
+            target: {
+                cardCondition: { location: 'play area', type: 'character', participating: true }
+            },
+            limit: ability.limit.perPhase(3),
+            message:
+                '{player} uses {source} to give {target} +2 STR until the end of the challenge',
+            handler: (context) => {
+                this.untilEndOfChallenge((ability) => ({
+                    match: context.target,
+                    effect: ability.effects.modifyStrength(2)
+                }));
+            }
+        });
+    }
+}
+
+BlackwaterForces.code = '25115';
+
+export default BlackwaterForces;

--- a/server/game/cards/25.6-WK/BranTheBreaker.js
+++ b/server/game/cards/25.6-WK/BranTheBreaker.js
@@ -1,0 +1,42 @@
+import DrawCard from '../../drawcard.js';
+
+class BranTheBreaker extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({
+            type: 'location',
+            faction: 'stark',
+            controller: 'current',
+            unique: true
+        });
+        this.action({
+            title: 'Raise claim by 1',
+            condition: () =>
+                this.game.isDuringChallenge({
+                    match: (challenge) =>
+                        challenge.attackers.filter((card) => this.isUniqueStark(card)).length >= 2
+                }),
+            cost: ability.costs.kneelSelf(),
+            message:
+                '{player} kneels {source} to raise the claim value on their revealed plot card by 1 until the end of the challenge',
+            handler: () => {
+                this.untilEndOfChallenge((ability) => ({
+                    match: (card) => card === this.controller.activePlot,
+                    effect: ability.effects.modifyClaim(1)
+                }));
+            }
+        });
+    }
+
+    isUniqueStark(card) {
+        return (
+            card.controller === this.controller &&
+            card.getType() === 'character' &&
+            card.isUnique() &&
+            card.isFaction('stark')
+        );
+    }
+}
+
+BranTheBreaker.code = '25112';
+
+export default BranTheBreaker;

--- a/server/game/cards/25.6-WK/BurningTheBooks.js
+++ b/server/game/cards/25.6-WK/BurningTheBooks.js
@@ -1,0 +1,54 @@
+import GameActions from '../../GameActions/index.js';
+import PlotCard from '../../plotcard.js';
+
+class BurningTheBooks extends PlotCard {
+    setupCardAbilities(ability) {
+        this.whenRevealed({
+            target: {
+                choosingPlayer: 'eachOpponent',
+                ifAble: true,
+                cardCondition: {
+                    type: 'attachment',
+                    not: { trait: 'The Seven' },
+                    location: 'play area',
+                    controller: 'choosingPlayer'
+                }
+            },
+            message: '{player} uses {source} to discard {target}',
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.simultaneously(
+                        context.targets
+                            .getTargets()
+                            .map((card) => GameActions.discardCard({ card, source: this }))
+                    ).then((originalContext) => ({
+                        condition: () => this.hasValidTargets(originalContext.player),
+                        cost: ability.costs.discardPower(
+                            1,
+                            (card) => card.getType() === 'character'
+                        ),
+                        message:
+                            'Then, {player} discards 1 power from {costs.discardPower} to initiate this effect again',
+                        handler: () => {
+                            let newContext = originalContext.ability.createContext(
+                                originalContext.event
+                            );
+                            this.game.resolveAbility(newContext.ability, newContext);
+                        }
+                    })),
+                    context
+                );
+            }
+        });
+    }
+
+    hasValidTargets(player) {
+        return this.game
+            .getOpponents(player)
+            .some((opponent) => opponent.anyCardsInPlay((card) => card.getType() === 'attachment'));
+    }
+}
+
+BurningTheBooks.code = '25119';
+
+export default BurningTheBooks;

--- a/server/game/cards/25.6-WK/DeepwoodMotte.js
+++ b/server/game/cards/25.6-WK/DeepwoodMotte.js
@@ -1,0 +1,33 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class DeepwoodMotte extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onPlotRevealed: (event) => event.plot.hasTrait('Winter')
+            },
+            cost: ability.costs.kneelSelf(),
+            target: {
+                activePromptTitle: 'Select a location',
+                cardCondition: {
+                    type: 'location',
+                    location: 'play area',
+                    limited: false,
+                    condition: (card) => card !== this
+                }
+            },
+            message: '{player} kneels {costs.kneel} to kneel {target}',
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.kneelCard((context) => ({ card: context.target, source: this })),
+                    context
+                );
+            }
+        });
+    }
+}
+
+DeepwoodMotte.code = '25102';
+
+export default DeepwoodMotte;

--- a/server/game/cards/25.6-WK/DesperateDeserter.js
+++ b/server/game/cards/25.6-WK/DesperateDeserter.js
@@ -1,0 +1,32 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class DesperateDeserter extends DrawCard {
+    setupCardAbilities() {
+        this.plotModifiers({
+            gold: -1,
+            initiative: -1
+        });
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card.controller === this.controller
+            },
+            chooseOpponent: true,
+            message: '{player} uses {source} to give control of {source} to {opponent}',
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.takeControl((context) => ({
+                        player: context.opponent,
+                        card: this,
+                        context
+                    })),
+                    context
+                );
+            }
+        });
+    }
+}
+
+DesperateDeserter.code = '25109';
+
+export default DesperateDeserter;

--- a/server/game/cards/25.6-WK/GarthGreenhand.js
+++ b/server/game/cards/25.6-WK/GarthGreenhand.js
@@ -1,0 +1,28 @@
+import DrawCard from '../../drawcard.js';
+
+class GarthGreenhand extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({
+            type: 'location',
+            faction: 'tyrell',
+            controller: 'current',
+            unique: true
+        });
+        this.plotModifiers({
+            gold: 1
+        });
+        this.persistentEffect({
+            condition: () => this.game.isDuringChallenge(),
+            match: (card) =>
+                card.controller === this.controller &&
+                card.isUnique() &&
+                card.isParticipating() &&
+                card.isFaction('tyrell'),
+            effect: ability.effects.modifyStrength(1)
+        });
+    }
+}
+
+GarthGreenhand.code = '25116';
+
+export default GarthGreenhand;

--- a/server/game/cards/25.6-WK/GreyWormsSpear.js
+++ b/server/game/cards/25.6-WK/GreyWormsSpear.js
@@ -1,0 +1,20 @@
+import DrawCard from '../../drawcard.js';
+
+class GreyWormsSpear extends DrawCard {
+    setupCardAbilities(ability) {
+        this.whileAttached({
+            match: (card) => card.name === 'Grey Worm',
+            effect: [ability.effects.addIcon('power'), ability.effects.addKeyword('intimidate')]
+        });
+        this.persistentEffect({
+            condition: () => this.parent && this.parent.isAttacking(),
+            match: (card) => card.isDefending(),
+            targetController: 'any',
+            effect: ability.effects.modifyStrength(-1)
+        });
+    }
+}
+
+GreyWormsSpear.code = '25114';
+
+export default GreyWormsSpear;

--- a/server/game/cards/25.6-WK/MaesterCressen.js
+++ b/server/game/cards/25.6-WK/MaesterCressen.js
@@ -1,0 +1,28 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class MaesterCressen extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this,
+                onCardPlaced: (event) => event.card === this && event.card.location === 'dead pile'
+            },
+            message:
+                '{player} uses {source} to place the top 2 cards of their deck under their agenda',
+            gameAction: GameActions.simultaneously((context) =>
+                context.player.drawDeck.slice(0, 2).map((card) =>
+                    GameActions.placeCardUnderneath({
+                        card,
+                        parentCard: context.player.agenda,
+                        facedown: false
+                    })
+                )
+            )
+        });
+    }
+}
+
+MaesterCressen.code = '25101';
+
+export default MaesterCressen;

--- a/server/game/cards/25.6-WK/MaesterJoseran.js
+++ b/server/game/cards/25.6-WK/MaesterJoseran.js
@@ -1,0 +1,27 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class MaesterJoseran extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onFirstPlayerDetermined: (event) => this.controller === event.player
+            },
+            message:
+                '{player} uses {source} to have each player put the top card of their deck facedown under their agenda',
+            gameAction: GameActions.simultaneously(() =>
+                this.game.getPlayers().map((player) =>
+                    GameActions.placeCardUnderneath({
+                        card: player.drawDeck[0],
+                        parentCard: player.agenda,
+                        facedown: false
+                    })
+                )
+            )
+        });
+    }
+}
+
+MaesterJoseran.code = '25103';
+
+export default MaesterJoseran;

--- a/server/game/cards/25.6-WK/RooseBolton.js
+++ b/server/game/cards/25.6-WK/RooseBolton.js
@@ -1,0 +1,27 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class RooseBolton extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this && this.game.isDuringChallenge()
+            },
+            message: '{player} uses {source} to kill each participating loyal character',
+            gameAction: GameActions.simultaneously(() =>
+                this.game
+                    .filterCardsInPlay(
+                        (card) =>
+                            card.getType() === 'character' &&
+                            card.isLoyal() &&
+                            card.isParticipating()
+                    )
+                    .map((card) => GameActions.kill({ card }))
+            )
+        });
+    }
+}
+
+RooseBolton.code = '25111';
+
+export default RooseBolton;

--- a/server/game/cards/25.6-WK/SeptaUnella.js
+++ b/server/game/cards/25.6-WK/SeptaUnella.js
@@ -1,0 +1,20 @@
+import DrawCard from '../../drawcard.js';
+
+class SeptaUnella extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.isParticipating(),
+            match: (card) =>
+                card !== this &&
+                !card.hasTrait('The Seven') &&
+                card.getType() === 'character' &&
+                card.power > 0,
+            targetController: 'any',
+            effect: ability.effects.blankExcludingTraits
+        });
+    }
+}
+
+SeptaUnella.code = '25117';
+
+export default SeptaUnella;

--- a/server/game/cards/25.6-WK/TheDornishWars.js
+++ b/server/game/cards/25.6-WK/TheDornishWars.js
@@ -1,0 +1,50 @@
+import PlotCard from '../../plotcard.js';
+
+class TheDornishWars extends PlotCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'opponent',
+            match: (card) => card.getType() === 'character',
+            // Note: This currently will not prevent triggered abilities which give icons from being "triggerable", but will prevent the icon from actually being gained.
+            //       eg. Sea Dragon Tower will be allowed to trigger, but the character will not actually gain the icon.
+            //       This is unavoidable until all "Until end of X" effects are converted to GameActions & can be checked for changing the game state.
+            // Note: Even though ability does not say "by card effects", we need to ensure this is not applying when an icon lose ability unapplies.
+            effect: ability.effects.cannotGainIcons(
+                (context) => context.resolutionStage === 'effect'
+            )
+        });
+
+        this.reaction({
+            when: {
+                afterChallenge: (event) => event.challenge.winner === this.controller
+            },
+            target: {
+                cardCondition: { type: 'character', location: 'play area' },
+                gameAction: 'loseIcon'
+            },
+            limit: ability.limit.perPhase(2),
+            handler: (context) => {
+                this.game.promptForIcon(context.player, this, (icon) => {
+                    this.untilEndOfPhase((ability) => ({
+                        match: context.target,
+                        effect: ability.effects.removeIcon(icon)
+                    }));
+
+                    this.game.addMessage(
+                        '{0} uses {1} to have {2} lose {4} {5} icon until the end of the phase',
+                        context.player,
+                        this,
+                        context.target,
+                        icon === 'intrigue' ? 'an' : 'a',
+                        icon
+                    );
+                });
+                return true;
+            }
+        });
+    }
+}
+
+TheDornishWars.code = '25108';
+
+export default TheDornishWars;

--- a/server/game/cards/25.6-WK/TyeneSand.js
+++ b/server/game/cards/25.6-WK/TyeneSand.js
@@ -1,0 +1,43 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class TyeneSand extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onDominanceDetermined: (event) => event.winner && this.controller !== event.winner
+            },
+            target: {
+                cardCondition: {
+                    location: 'play area',
+                    type: 'character',
+                    controller: 'current',
+                    condition: (card, context) =>
+                        GameActions.movePower({
+                            from: context.event.winner.faction,
+                            to: card,
+                            amount: 1
+                        }).allow()
+                }
+            },
+            message: {
+                format: "{player} uses {source} to move 1 power from {winner}'s faction card to {target}",
+                args: { winner: (context) => context.event.winner }
+            },
+            handler: (context) => {
+                context.game.resolveGameAction(
+                    GameActions.movePower((context) => ({
+                        from: context.event.winner.faction,
+                        to: context.target,
+                        amount: 1
+                    })),
+                    context
+                );
+            }
+        });
+    }
+}
+
+TyeneSand.code = '25107';
+
+export default TyeneSand;

--- a/server/game/cards/25.6-WK/TywinsWhisperer.js
+++ b/server/game/cards/25.6-WK/TywinsWhisperer.js
@@ -1,0 +1,33 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class TywinsWhisperer extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardReturnedToHand: (event) =>
+                    event.card.controller !== this.controller &&
+                    event.card.isMatch({ type: 'character', printedCostOrLower: 2 })
+            },
+            location: 'hand',
+            message:
+                '{player} uses {source} to put {source} into play from their hand, and have it gain a power icon and stealth until the end of the phase',
+            gameAction: GameActions.simultaneously([
+                GameActions.putIntoPlay({ card: this }),
+                GameActions.genericHandler(() => {
+                    this.untilEndOfPhase((ability) => ({
+                        match: this,
+                        effect: [
+                            ability.effects.addIcon('power'),
+                            ability.effects.addKeyword('stealth')
+                        ]
+                    }));
+                })
+            ])
+        });
+    }
+}
+
+TywinsWhisperer.code = '25105';
+
+export default TywinsWhisperer;

--- a/server/game/cards/25.6-WK/WeirwoodGrove.js
+++ b/server/game/cards/25.6-WK/WeirwoodGrove.js
@@ -1,0 +1,30 @@
+import GameActions from '../../GameActions/index.js';
+import DrawCard from '../../drawcard.js';
+
+class WeirwoodGrove extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onPlotRevealed: (event) =>
+                    event.plot.controller !== this.controller &&
+                    !!event.plot.getWhenRevealedAbility()
+            },
+            cost: [ability.costs.kneelFactionCard(), ability.costs.removeSelfFromGame()],
+            message: {
+                format: '{player} kneels their faction card and removes {costs.removeFromGame} from the game to initiate the when revealed ability of {plot}',
+                args: { plot: (context) => context.event.plot }
+            },
+            gameAction: GameActions.genericHandler((context) => {
+                let whenRevealed = context.event.plot.getWhenRevealedAbility();
+                // Attach the current When Revealed event to the new context
+                let newContext = whenRevealed.createContext(context.event);
+                newContext.player = context.player;
+                this.game.resolveAbility(whenRevealed, newContext);
+            })
+        });
+    }
+}
+
+WeirwoodGrove.code = '25110';
+
+export default WeirwoodGrove;

--- a/server/game/cards/25.6-WK/Winterfell.js
+++ b/server/game/cards/25.6-WK/Winterfell.js
@@ -1,0 +1,34 @@
+import DrawCard from '../../drawcard.js';
+
+class Winterfell extends DrawCard {
+    setupCardAbilities(ability) {
+        this.plotModifiers({
+            initiative: -2
+        });
+        this.reaction({
+            when: {
+                afterChallenge: (event) =>
+                    event.challenge.winner === this.controller && event.challenge.isUnopposed()
+            },
+            cost: ability.costs.kneelSelf(),
+            target: {
+                cardCondition: {
+                    type: 'character',
+                    condition: (card, context) => card.controller === context.event.challenge.loser
+                }
+            },
+            message:
+                '{player} kneels {costs.kneel} to take control of {target} until the end of the phase',
+            handler: (context) => {
+                this.untilEndOfPhase((ability) => ({
+                    match: context.target,
+                    effect: ability.effects.takeControl(this.controller)
+                }));
+            }
+        });
+    }
+}
+
+Winterfell.code = '25104';
+
+export default Winterfell;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1017,6 +1017,8 @@ const Effects = {
             }
         };
     },
+    cannotGainIcons: cannotEffect('gainIcon'),
+    cannotLoseIcons: cannotEffect('loseIcon'),
     cannotTarget: cannotEffect('target'),
     cannotTargetUsingAssault: cannotEffect('assault'),
     cannotTargetUsingStealth: cannotEffect('stealth'),

--- a/test/server/cards/01-Core/StannisBaratheon.spec.js
+++ b/test/server/cards/01-Core/StannisBaratheon.spec.js
@@ -6,7 +6,7 @@ describe('Stannis Baratheon', function () {
                 'Stannis Baratheon (Core)',
                 'Robert Baratheon (Core)',
                 'Dragonstone Faithful',
-                'Maester Cressen',
+                'Maester Cressen (Core)',
                 'The Roseroad',
                 'Bodyguard',
                 'Recruiter for the Watch'

--- a/test/server/cards/02.3-TKP/SerGregorClegane.spec.js
+++ b/test/server/cards/02.3-TKP/SerGregorClegane.spec.js
@@ -8,7 +8,7 @@ describe('Ser Gregor Clegane (TKP)', function () {
             const deck2 = this.buildDeck('baratheon', [
                 'Sneak Attack',
                 'Hedge Knight',
-                'Maester Cressen',
+                'Maester Cressen (Core)',
                 'Hedge Knight',
                 'Shireen Baratheon (Core)',
                 'The Roseroad'

--- a/test/server/cards/18-FH/HaldonHalfmaester.spec.js
+++ b/test/server/cards/18-FH/HaldonHalfmaester.spec.js
@@ -6,7 +6,7 @@ describe('Haldon Halfmaester', function () {
             const deck1 = this.buildDeck('tyrell', [
                 'Marching Orders',
                 'Haldon Halfmaester',
-                'Aegon Targaryen',
+                'Aegon Targaryen (TSC)',
                 'Bribery (R)',
                 'Hedge Knight',
                 'Hedge Knight'

--- a/test/server/cards/22-BtB/TheMadKingsCommand.spec.js
+++ b/test/server/cards/22-BtB/TheMadKingsCommand.spec.js
@@ -3,7 +3,7 @@ describe("The Mad King's Command", function () {
         beforeEach(function () {
             const deck = this.buildDeck('targaryen', [
                 "The Mad King's Command",
-                'Aegon Targaryen',
+                'Aegon Targaryen (TSC)',
                 'Septa Lemore',
                 'Beggar King'
             ]);

--- a/test/server/integration/TimeLimitExpired.spec.js
+++ b/test/server/integration/TimeLimitExpired.spec.js
@@ -5,7 +5,7 @@ describe('time limit', function () {
                 const deck = this.buildDeck('baratheon', [
                     'Time of Plenty',
                     'Tycho Nestoris',
-                    'Maester Cressen',
+                    'Maester Cressen (Core)',
                     'Tycho Nestoris',
                     'Robert Baratheon (Core)',
                     'Ser Davos Seaworth (Core)',

--- a/test/server/integration/intimidate.spec.js
+++ b/test/server/integration/intimidate.spec.js
@@ -6,7 +6,7 @@ describe('intimidate', function () {
                 'Robert Baratheon (Core)',
                 'Dragonstone Faithful',
                 'Bastard in Hiding',
-                'Maester Cressen',
+                'Maester Cressen (Core)',
                 'Gendry (NMG)',
                 'Grey Wind (Core)'
             ]);


### PR DESCRIPTION
Implemented all 20 cards of Winter's Kings.

Additional comments:
- Slightly refined logic for "Gaining" and "Losing" icon game state checker.
- Added "LookAtShadows" GameAction; note that this should eventually be reworked into a more custom "look at" prompt, rather than simply calling `promptForSelect` as we have in the past.
- Fixed logic for `GameActions.PlaceCardUnderneath` to be invalid if the parent card does not exist (eg. someone tries to place a card underneath an agenda when they have no agenda).
- Added `cannotGainIcons` and `cannotLoseIcons` for The Dornish Wars. Left a note on Dornish Wars that abilities which only make you lose an icon (such as Sea Dragon Tower) will be allowed to trigger, but will not actually give an icon. This will be naturally fixed once "Until end of X" abilities are converted to GameActions & their effects are checked appropriately during the `allow` step.