### PR TITLE
Fixing plot stat functions

### DIFF
--- a/server/game/cards/02.1-TtB/TheWatchHasNeed.js
+++ b/server/game/cards/02.1-TtB/TheWatchHasNeed.js
@@ -5,10 +5,10 @@ class TheWatchHasNeed extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Search for a character',
-            condition: () => this.controller.getTotalReserve() > 0,
+            condition: () => this.controller.getReserve() > 0,
             message: {
                 format: '{player} plays {source} to name a trait and search the top {reserve} cards of their deck',
-                args: { reserve: (context) => context.player.getTotalReserve() }
+                args: { reserve: (context) => context.player.getReserve() }
             },
             gameAction: GameActions.choose({
                 player: () => this.controller,
@@ -27,8 +27,8 @@ class TheWatchHasNeed extends DrawCard {
         return GameActions.search({
             title: 'Select a character',
             match: { trait: trait },
-            numToSelect: (context) => context.player.getTotalReserve(),
-            topCards: (context) => context.player.getTotalReserve(),
+            numToSelect: (context) => context.player.getReserve(),
+            topCards: (context) => context.player.getReserve(),
             message: '{player} adds {searchTarget} to their hand',
             gameAction: GameActions.simultaneously((context) =>
                 context.searchTarget.map((card) => GameActions.addToHand({ card }))

--- a/server/game/cards/04.3-FFH/NightGathers.js
+++ b/server/game/cards/04.3-FFH/NightGathers.js
@@ -6,7 +6,7 @@ class NightGathers extends DrawCard {
             title: 'Allow marshaling from opponent discard',
             phase: 'marshal',
             chooseOpponent: (opponent) =>
-                opponent.getTotalReserve() < this.controller.getTotalReserve(),
+                opponent.getReserve() < this.controller.getReserve(),
             handler: (context) => {
                 this.game.addMessage(
                     "{0} plays {1} to allow cards from {2}'s discard pile to be marshaled",

--- a/server/game/cards/04.6-TC/FistOfTheFirstMen.js
+++ b/server/game/cards/04.6-TC/FistOfTheFirstMen.js
@@ -12,7 +12,7 @@ class FistOfTheFirstMen extends DrawCard {
     hasHigherReserveThanOpponent() {
         let opponents = this.game.getOpponents(this.controller);
         return opponents.some(
-            (opponent) => this.controller.getTotalReserve() > opponent.getTotalReserve()
+            (opponent) => this.controller.getReserve() > opponent.getReserve()
         );
     }
 }

--- a/server/game/cards/06.1-AMAF/EastwatchByTheSea.js
+++ b/server/game/cards/06.1-AMAF/EastwatchByTheSea.js
@@ -23,7 +23,7 @@ class EastwatchByTheSea extends DrawCard {
     hasHigherReserveThanOpponent() {
         let opponents = this.game.getOpponents(this.controller);
         return opponents.some(
-            (opponent) => this.controller.getTotalReserve() > opponent.getTotalReserve()
+            (opponent) => this.controller.getReserve() > opponent.getReserve()
         );
     }
 }

--- a/server/game/cards/07-WotW/CrowKillers.js
+++ b/server/game/cards/07-WotW/CrowKillers.js
@@ -18,7 +18,7 @@ class CrowKillers extends DrawCard {
 
         return (
             challenge.attackingPlayer === this.controller &&
-            this.controller.getTotalReserve() < challenge.defendingPlayer.getTotalReserve()
+            this.controller.getReserve() < challenge.defendingPlayer.getReserve()
         );
     }
 }

--- a/server/game/cards/08.6-SAT/Godswood.js
+++ b/server/game/cards/08.6-SAT/Godswood.js
@@ -13,7 +13,7 @@ class Godswood extends DrawCard {
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {
-                let cards = this.controller.activePlot.getClaim();
+                let cards = this.controller.getClaim();
                 cards = this.controller.drawCardsToHand(cards).length;
 
                 this.game.addMessage(

--- a/server/game/cards/09-HoT/SmallPaul.js
+++ b/server/game/cards/09-HoT/SmallPaul.js
@@ -9,12 +9,12 @@ class SmallPaul extends DrawCard {
             },
             message: {
                 format: '{player} uses {source} to search the top {reserve} cards of their deck for any number of Steward characters',
-                args: { reserve: () => this.controller.getTotalReserve() }
+                args: { reserve: () => this.controller.getReserve() }
             },
             gameAction: GameActions.search({
                 title: 'Select any number of characters',
-                numToSelect: (context) => context.player.getTotalReserve(),
-                topCards: (context) => context.player.getTotalReserve(),
+                numToSelect: (context) => context.player.getReserve(),
+                topCards: (context) => context.player.getReserve(),
                 match: { type: 'character', trait: 'Steward' },
                 message: '{player} adds {searchTarget} to their hand',
                 gameAction: GameActions.simultaneously((context) =>

--- a/server/game/cards/11.5-IDP/ThreeFingerHobb.js
+++ b/server/game/cards/11.5-IDP/ThreeFingerHobb.js
@@ -6,7 +6,7 @@ class ThreeFingerHobb extends DrawCard {
         this.reaction({
             when: {
                 onReserveChecked: () =>
-                    this.controller.hand.length < this.controller.getTotalReserve() &&
+                    this.controller.hand.length < this.controller.getReserve() &&
                     this.controller.canDraw()
             },
             handler: (context) => {

--- a/server/game/cards/14-FotS/ProtectorsOfTheRealm.js
+++ b/server/game/cards/14-FotS/ProtectorsOfTheRealm.js
@@ -9,7 +9,7 @@ class ProtectorsOfTheRealm extends DrawCard {
     }
 
     getSTR() {
-        return this.controller.getTotalReserve();
+        return this.controller.getReserve();
     }
 }
 

--- a/server/game/cards/14-FotS/SiegePreparations.js
+++ b/server/game/cards/14-FotS/SiegePreparations.js
@@ -8,9 +8,9 @@ class SiegePreparations extends PlotCard {
             phase: 'dominance',
             condition: () =>
                 this.controller.canDraw() &&
-                this.controller.getTotalReserve() > this.controller.hand.length,
+                this.controller.getReserve() > this.controller.hand.length,
             handler: (context) => {
-                let cardsToDraw = context.player.getTotalReserve() - context.player.hand.length;
+                let cardsToDraw = context.player.getReserve() - context.player.hand.length;
                 let numDrawn = context.player.drawCardsToHand(cardsToDraw).length;
                 this.game.addMessage(
                     '{0} uses {1} to draw {2}',

--- a/server/game/cards/17.1-R/ThreeFingerHobb.js
+++ b/server/game/cards/17.1-R/ThreeFingerHobb.js
@@ -6,12 +6,12 @@ class ThreeFingerHobb extends DrawCard {
         this.reaction({
             when: {
                 onReserveChecked: () =>
-                    this.controller.hand.length < this.controller.getTotalReserve() &&
+                    this.controller.hand.length < this.controller.getReserve() &&
                     this.controller.canDraw()
             },
             handler: (context) => {
                 let cards =
-                    context.player.getTotalReserve() > context.player.hand.length + 4 ? 2 : 1;
+                    context.player.getReserve() > context.player.hand.length + 4 ? 2 : 1;
                 cards = context.player.drawCardsToHand(cards).length;
                 this.game.addMessage(
                     '{0} uses {1} to draw {2}',

--- a/server/game/cards/20-HMW/OldTattersalt.js
+++ b/server/game/cards/20-HMW/OldTattersalt.js
@@ -16,11 +16,11 @@ class OldTattersalt extends DrawCard {
             },
             message: {
                 format: '{player} uses {source} to search the top {reserve} cards of their deck for a card with printed cost 1 or lower',
-                args: { reserve: (context) => context.player.getTotalReserve() }
+                args: { reserve: (context) => context.player.getReserve() }
             },
             gameAction: GameActions.search({
                 title: 'Select a card',
-                topCards: (context) => context.player.getTotalReserve(),
+                topCards: (context) => context.player.getReserve(),
                 match: { printedCostOrLower: 1 },
                 message: '{player} {gameAction}',
                 gameAction: GameActions.addToHand((context) => ({

--- a/server/game/cards/22-BtB/FleetFromTenTowers.js
+++ b/server/game/cards/22-BtB/FleetFromTenTowers.js
@@ -6,7 +6,7 @@ class FleetFromTenTowers extends DrawCard {
             condition: () =>
                 this.isAttacking() &&
                 this.game.isDuringChallenge({
-                    match: (challenge) => challenge.defendingPlayer.getTotalReserve() <= 4
+                    match: (challenge) => challenge.defendingPlayer.getReserve() <= 4
                 }),
             match: this,
             effect: [ability.effects.modifyStrength(3), ability.effects.addKeyword('Renown')]

--- a/server/game/cards/22-BtB/SamwellTarly.js
+++ b/server/game/cards/22-BtB/SamwellTarly.js
@@ -38,7 +38,7 @@ class SamwellTarly extends DrawCard {
     }
 
     satisfiableBonuses() {
-        let reserve = this.controller.getTotalReserve();
+        let reserve = this.controller.getReserve();
         let satisfiable = [];
         if (reserve >= 6 && this.controller.canDraw()) {
             satisfiable.push('draw');

--- a/server/game/cards/23-AHaH/BannerOfTheFalcon.js
+++ b/server/game/cards/23-AHaH/BannerOfTheFalcon.js
@@ -10,7 +10,7 @@ class BannerOfTheFalcon extends AgendaCard {
         this.persistentEffect({
             condition: () =>
                 this.controller.filterCardsInPlay((card) => card.hasTrait('House Arryn')).length >
-                this.controller.getTotalInitiative(),
+                this.controller.getInitiative(),
             match: (card) =>
                 card.controller === this.controller &&
                 card.getType() === 'character' &&

--- a/server/game/cards/23-AHaH/KnightsOfTheVale.js
+++ b/server/game/cards/23-AHaH/KnightsOfTheVale.js
@@ -34,7 +34,7 @@ class KnightsOfTheVale extends DrawCard {
     }
 
     calculateSTR(context) {
-        return context.player.getTotalInitiative() === 0 ? 4 : 2;
+        return context.player.getInitiative() === 0 ? 4 : 2;
     }
 }
 

--- a/server/game/cards/23-AHaH/Mord.js
+++ b/server/game/cards/23-AHaH/Mord.js
@@ -11,7 +11,7 @@ class Mord extends DrawCard {
                     location: 'play area',
                     type: 'character',
                     condition: (card, context) =>
-                        card.controller.getTotalInitiative() >= context.player.getTotalInitiative()
+                        card.controller.getInitiative() >= context.player.getInitiative()
                 }
             },
             message:

--- a/server/game/cards/23-AHaH/Sweetrobin.js
+++ b/server/game/cards/23-AHaH/Sweetrobin.js
@@ -7,7 +7,7 @@ class Sweetrobin extends DrawCard {
             when: {
                 onCardRevealed: (event) =>
                     event.card.hasPrintedCost() &&
-                    event.card.getPrintedCost() <= event.card.owner.getTotalInitiative() &&
+                    event.card.getPrintedCost() <= event.card.owner.getInitiative() &&
                     ['hand', 'draw deck', 'shadows'].includes(event.card.location)
             },
             limit: ability.limit.perPhase(1),

--- a/server/game/cards/23-AHaH/TheEyrie.js
+++ b/server/game/cards/23-AHaH/TheEyrie.js
@@ -9,7 +9,7 @@ class TheEyrie extends DrawCard {
         });
 
         this.persistentEffect({
-            condition: () => this.controller.getTotalInitiative() === 0,
+            condition: () => this.controller.getInitiative() === 0,
             match: this,
             effect: ability.effects.immuneTo(
                 (card) => card.controller !== this.controller && card.getType() !== 'plot'

--- a/server/game/cards/23-AHaH/TorrhensSquare.js
+++ b/server/game/cards/23-AHaH/TorrhensSquare.js
@@ -20,7 +20,7 @@ class TorrhensSquare extends DrawCard {
                     location: 'play area',
                     condition: (card, context) =>
                         card.hasPrintedCost() &&
-                        card.getPrintedCost() > context.player.getTotalInitiative()
+                        card.getPrintedCost() > context.player.getInitiative()
                 }
             },
             cost: ability.costs.kneelSelf(),

--- a/server/game/gamesteps/marshalingphase.js
+++ b/server/game/gamesteps/marshalingphase.js
@@ -31,7 +31,7 @@ class MarshalingPhase extends Phase {
 
     collectIncome(player) {
         if (player.canGainGold()) {
-            let gold = this.game.addGold(player, player.getTotalIncome());
+            let gold = this.game.addGold(player, player.getIncome());
             this.game.addMessage('{0} collects {1} gold', player, gold);
         }
 

--- a/server/game/gamesteps/revealplots.js
+++ b/server/game/gamesteps/revealplots.js
@@ -88,7 +88,7 @@ class RevealPlots extends BaseStep {
         let playerInitiatives = this.game.getPlayers().map((player) => {
             return {
                 player: player,
-                initiative: player.getTotalInitiative(),
+                initiative: player.getInitiative(),
                 power: player.getTotalPower()
             };
         });

--- a/server/game/gamesteps/taxation/DiscardToReservePrompt.js
+++ b/server/game/gamesteps/taxation/DiscardToReservePrompt.js
@@ -23,7 +23,7 @@ class DiscardToReservePrompt extends BaseStep {
     }
 
     promptPlayerToDiscard(currentPlayer) {
-        let overReserve = currentPlayer.hand.length - currentPlayer.getTotalReserve();
+        let overReserve = currentPlayer.hand.length - currentPlayer.getReserve();
         this.game.promptForSelect(currentPlayer, {
             ordered: true,
             mode: 'exactly',

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1253,36 +1253,24 @@ class Player extends Spectator {
         }
     }
 
-    getTotalInitiative() {
-        if (!this.activePlot) {
-            return 0;
-        }
-
-        return this.activePlot.getInitiative();
+    getIncome() {
+        return this.activePlot ? this.activePlot.getIncome() : 0;
     }
 
-    getTotalIncome() {
-        if (!this.activePlot) {
-            return 0;
-        }
-
-        return this.activePlot.getIncome();
-    }
-
-    getTotalReserve() {
-        if (!this.activePlot) {
-            return 0;
-        }
-
-        return Math.max(this.activePlot.getReserve(), this.minReserve);
+    getInitiative() {
+        return this.activePlot ? this.activePlot.getInitiative() : 0;
     }
 
     getClaim() {
         return this.activePlot ? this.activePlot.getClaim() : 0;
     }
 
+    getReserve() {
+        return this.activePlot ? Math.max(this.activePlot.getReserve(), this.minReserve) : 0;
+    }
+
     isBelowReserve() {
-        return this.hand.length <= this.getTotalReserve();
+        return this.hand.length <= this.getReserve();
     }
 
     isRival(opponent) {
@@ -1374,9 +1362,9 @@ class Player extends Spectator {
     getStats(isActivePlayer) {
         return {
             claim: this.getClaim(),
-            initiative: this.getTotalInitiative(),
+            initiative: this.getInitiative(),
             gold: !isActivePlayer && this.game.currentPhase === 'setup' ? 0 : this.gold,
-            reserve: this.getTotalReserve(),
+            reserve: this.getReserve(),
             totalPower: this.getTotalPower()
         };
     }

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -257,7 +257,7 @@ class PlayerInteractionWrapper {
     }
 
     discardToReserve() {
-        let needsDiscard = this.player.hand.length - this.player.getTotalReserve();
+        let needsDiscard = this.player.hand.length - this.player.getReserve();
         for (let i = 0; i < needsDiscard; ++i) {
             this.clickCard(this.player.hand[i]);
         }

--- a/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
+++ b/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
@@ -38,7 +38,7 @@ describe('WraithsInTheirMidst', function () {
 
             it('should reduce the reserve by the full amount', function () {
                 // Reduce 6 reserve by 2 from plot, 1 by Alannys
-                expect(this.player2Object.getTotalReserve()).toBe(3);
+                expect(this.player2Object.getReserve()).toBe(3);
             });
         });
 
@@ -51,7 +51,7 @@ describe('WraithsInTheirMidst', function () {
 
             it('should reduce the reserve and cap at the 2 minimum', function () {
                 // Reduce 4 reserve by 2 from plot, 1 by Alannys, min 2.
-                expect(this.player2Object.getTotalReserve()).toBe(2);
+                expect(this.player2Object.getReserve()).toBe(2);
             });
         });
 
@@ -71,7 +71,7 @@ describe('WraithsInTheirMidst', function () {
 
             it('should reduce the new plot revealed', function () {
                 // Reduce 6 by 2 from plot, 0 from Alannys since not first player
-                expect(this.player2Object.getTotalReserve()).toBe(4);
+                expect(this.player2Object.getReserve()).toBe(4);
             });
         });
 
@@ -94,7 +94,7 @@ describe('WraithsInTheirMidst', function () {
             });
 
             it('should not get a NaN reserve prompt', function () {
-                expect(this.player2Object.getTotalReserve()).toBe(4);
+                expect(this.player2Object.getReserve()).toBe(4);
             });
         });
     });

--- a/test/server/cards/13.1-AtG/AtTheGates.spec.js
+++ b/test/server/cards/13.1-AtG/AtTheGates.spec.js
@@ -32,8 +32,8 @@ describe('At The Gates', function () {
             });
 
             it('modifies income correctly', function () {
-                expect(this.player1Object.getTotalIncome()).toBe(7);
-                expect(this.player2Object.getTotalIncome()).toBe(8);
+                expect(this.player1Object.getIncome()).toBe(7);
+                expect(this.player2Object.getIncome()).toBe(8);
             });
         });
 

--- a/test/server/gamesteps/revealplots.spec.js
+++ b/test/server/gamesteps/revealplots.spec.js
@@ -9,11 +9,11 @@ describe('RevealPlots', function () {
     describe('getInitiativeResult()', function () {
         beforeEach(function () {
             this.player1Spy = jasmine.createSpyObj('player', [
-                'getTotalInitiative',
+                'getInitiative',
                 'getTotalPower'
             ]);
             this.player2Spy = jasmine.createSpyObj('player', [
-                'getTotalInitiative',
+                'getInitiative',
                 'getTotalPower'
             ]);
             this.gameSpy.getPlayers.and.returnValue([this.player1Spy, this.player2Spy]);
@@ -21,10 +21,10 @@ describe('RevealPlots', function () {
 
         describe('when one player has higher initiative', function () {
             beforeEach(function () {
-                this.player1Spy.getTotalInitiative.and.returnValue(4);
+                this.player1Spy.getInitiative.and.returnValue(4);
                 this.player1Spy.getTotalPower.and.returnValue(3);
 
-                this.player2Spy.getTotalInitiative.and.returnValue(5);
+                this.player2Spy.getInitiative.and.returnValue(5);
                 this.player2Spy.getTotalPower.and.returnValue(5);
 
                 this.phase.determineInitiative();
@@ -43,10 +43,10 @@ describe('RevealPlots', function () {
 
         describe('when initiative is tied but one player has lower power', function () {
             beforeEach(function () {
-                this.player1Spy.getTotalInitiative.and.returnValue(5);
+                this.player1Spy.getInitiative.and.returnValue(5);
                 this.player1Spy.getTotalPower.and.returnValue(3);
 
-                this.player2Spy.getTotalInitiative.and.returnValue(5);
+                this.player2Spy.getInitiative.and.returnValue(5);
                 this.player2Spy.getTotalPower.and.returnValue(5);
 
                 this.phase.determineInitiative();
@@ -66,10 +66,10 @@ describe('RevealPlots', function () {
 
         describe('when initiative and power are tied', function () {
             beforeEach(function () {
-                this.player1Spy.getTotalInitiative.and.returnValue(5);
+                this.player1Spy.getInitiative.and.returnValue(5);
                 this.player1Spy.getTotalPower.and.returnValue(3);
 
-                this.player2Spy.getTotalInitiative.and.returnValue(5);
+                this.player2Spy.getInitiative.and.returnValue(5);
                 this.player2Spy.getTotalPower.and.returnValue(3);
 
                 // Set up sampling function to just return the last entry.


### PR DESCRIPTION
Primarily to fix a bug where the +/- for some of the plot stat values were simply not working as they were calling the wrong function name in `player` object. Then made me think of whether "Total" was appropriate for these functions, and ultimately it does not make sense as it's simply passing the same value being calculated by the plot - there is no "total" calculation being made.

Done a simple find & replace for these functions, as well as fixing `Godswood` to properly look at the players claim, rather than the plots claim.

+/- buttons now also work!