### PR TITLE
Attempting to disable password autocomplete on game passwords

### DIFF
--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -129,7 +129,7 @@ const NewGame = ({
                                             </div>
                                             <div>
                                                 <Input
-                                                    autocomplete='new-password'
+                                                    autoComplete='off'
                                                     label='Password'
                                                     type='password'
                                                     placeholder={'Enter a password'}

--- a/client/Components/Games/PasswordGame.jsx
+++ b/client/Components/Games/PasswordGame.jsx
@@ -59,6 +59,7 @@ const PasswordGame = () => {
                     ) : null}
                     <div className='game-password'>
                         <Input
+                            autoComplete='off'
                             type='password'
                             onChange={onPasswordChange}
                             value={password}


### PR DESCRIPTION
This has been lightly tested locally, but best to confirm it actually works after pushing live.

NextUI Input expects `autoComplete` (with capital C) to then pass through to the inner `input` element it creates.