### PR TITLE
Some adjustments to Card Piles

### DIFF
--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -16,7 +16,7 @@ const Card = ({
     className,
     disableMouseOver,
     hideTokens,
-    menu,
+    menu = [{ hideable: true, command: 'click', text: 'Select Card' }],
     onClick,
     onMenuItemClick,
     onMouseOut,

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -26,7 +26,7 @@ const CardPile = ({
     onMouseOut,
     onMouseOver,
     onTouchMove,
-    onMenuItemClick,
+    onMenuItemClick: propsOnMenuItemClick,
     size,
     popupMenu,
     title,
@@ -112,6 +112,19 @@ const CardPile = ({
             }
         },
         [closeOnClick, propsOnCardClick, updatePopupVisibility]
+    );
+
+    const onMenuItemClick = useCallback(
+        (card, menuItem) => {
+            if (menuItem.showPopup !== undefined) {
+                updatePopupVisibility(menuItem.showPopup);
+            }
+
+            if (propsOnMenuItemClick) {
+                propsOnMenuItemClick(card, menuItem);
+            }
+        },
+        [updatePopupVisibility, propsOnMenuItemClick]
     );
 
     const onPopupMenuItemClick = useCallback(
@@ -200,7 +213,7 @@ const CardPile = ({
                     return (
                         <Button
                             color='primary'
-                            className='flex-1 mx-2 mt-2'
+                            className='flex-1 m-2'
                             key={linkIndex++}
                             onClick={() => onPopupMenuItemClick(menuItem)}
                         >
@@ -270,10 +283,22 @@ const CardPile = ({
     }
 
     let menu;
-    // Note "Open/Close Popup" item will never be available for CardPiles in locations that use select in non-triggerable ways (eg. click to force stand or kneel)
-    // For example, if CardPile is ever used in play area, it will need to know when "clicking" on it is a valid option to do something
-    if (!disablePopup && topCard?.selectable) {
-        menu = [{ showPopup: true, text: `${showPopup ? 'Close' : 'Open'} Popup` }];
+    // If popup is available, that should always be a menu item
+    // Note: If popup is disabled, default Card menu will be used
+    if (!disablePopup) {
+        menu = [
+            {
+                hideable: true,
+                showPopup: !showPopup,
+                text: `${showPopup ? 'Close' : 'Open'} Popup`
+            }
+        ];
+
+        // Additionally, if the top card is currently selectable, that also needs to be an option
+        // Note: If CardPiles ever become available in locations where "Select Card" is always an option (such as "play area"), this will need to be permenantly enabled for those cards
+        if (topCard?.selectable) {
+            menu.push({ hideable: true, command: 'click', text: 'Select Card' });
+        }
     }
 
     return (

--- a/client/Components/GameBoard/CardPileLink.scss
+++ b/client/Components/GameBoard/CardPileLink.scss
@@ -22,7 +22,7 @@
 
         .inner {
             @include calculate-tiled-card-prop(width, 5, width);
-            @include calculate-tiled-card-prop(height, 1, height, 0rem);
+            @include calculate-tiled-card-prop(height, 1, height);
         }
     }
 }

--- a/client/Components/GameBoard/MovablePanel.jsx
+++ b/client/Components/GameBoard/MovablePanel.jsx
@@ -3,7 +3,7 @@ import $ from 'jquery';
 
 import { ItemTypes } from '../../constants';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { PopupDefaults } from './PopupDefaults';
 import { useDndMonitor, useDraggable } from '@dnd-kit/core';
 
@@ -103,7 +103,7 @@ const MovablePanel = ({ name, side, title, onCloseClick, children, size }) => {
                 <span className='flex-1 text-center'>{title}</span>
                 <span className='cursor-pointer'>
                     <a onClick={onCloseClick}>
-                        <FontAwesomeIcon icon={faTimes} />
+                        <FontAwesomeIcon icon={faXmark} />
                     </a>
                 </span>
             </div>

--- a/client/Components/GameBoard/MovablePanel.jsx
+++ b/client/Components/GameBoard/MovablePanel.jsx
@@ -3,7 +3,7 @@ import $ from 'jquery';
 
 import { ItemTypes } from '../../constants';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { PopupDefaults } from './PopupDefaults';
 import { useDndMonitor, useDraggable } from '@dnd-kit/core';
 
@@ -103,7 +103,7 @@ const MovablePanel = ({ name, side, title, onCloseClick, children, size }) => {
                 <span className='flex-1 text-center'>{title}</span>
                 <span className='cursor-pointer'>
                     <a onClick={onCloseClick}>
-                        <FontAwesomeIcon icon={faXmark} />
+                        <FontAwesomeIcon icon={faTimes} />
                     </a>
                 </span>
             </div>

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -603,9 +603,7 @@ class BaseCard {
             return action.allowPlayer(player) && !action.isClickToActivate() && action.allowMenu();
         });
 
-        return [{ command: 'click', text: 'Select Card' }].concat(
-            menuActionPairs.map(([action, index]) => action.getMenuItem(index, player))
-        );
+        return menuActionPairs.map(([action, index]) => action.getMenuItem(index, player));
     }
 
     isCopyOf(card) {


### PR DESCRIPTION
These are primarily noticeable within playtesting (specifically with [Armed to the Teeth](https://thronesdb.com/card/26618)), but are applicable to the site in general.

These changes:
- Moves the "Select Card" option to be a client side option, rather than something sent from the server. The intent here is that the "Select Card" option is not always appropriate for scenarios where that card is the top of a cardpile, and there is no simple way to alter or remove that option when it's coming from serverside.
- Adds better logic to when the "Open/Close Popup" menu item is available
- Adds better logic on when to show the menu on card click with a `hidable` menu item options (currently only for toggling the popup or select card)
- Adjusted the agenda popup to show some of the second row like the deck popup; this is better considering there's usually 2 rows and players are missing that at first glance.
- Added a better "X" button for popup close :)