### PR TITLE
Fixing event set game options for World Cup

### DIFF
--- a/client/Components/Games/GameOptions.jsx
+++ b/client/Components/Games/GameOptions.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, Switch } from '@heroui/react';
 
-const GameOptions = ({ formProps }) => {
+const GameOptions = ({ formProps, isDisabled }) => {
     const options = [
         { name: 'allowSpectators', label: 'Allow spectators' },
         { name: 'showHand', label: 'Show hands to spectators' },
@@ -28,6 +28,7 @@ const GameOptions = ({ formProps }) => {
                                 onChange={formProps.handleChange}
                                 value='true'
                                 isSelected={formProps.values[option.name]}
+                                isDisabled={isDisabled}
                             >
                                 {option.label}
                             </Switch>
@@ -50,6 +51,7 @@ const GameOptions = ({ formProps }) => {
                                     formProps.touched.gameTimeLimit
                                 }
                                 errorMessage={formProps.errors.gameTimeLimit}
+                                isDisabled={isDisabled}
                             />
                         </div>
                     </div>
@@ -68,6 +70,7 @@ const GameOptions = ({ formProps }) => {
                                     formProps.touched.chessClockTimeLimit
                                 }
                                 errorMessage={formProps.errors.chessClockTimeLimit}
+                                isDisabled={isDisabled}
                             />
                             <Input
                                 label={'Delay (seconds)'}
@@ -79,6 +82,7 @@ const GameOptions = ({ formProps }) => {
                                     formProps.touched.chessClockDelay
                                 }
                                 errorMessage={formProps.errors.chessClockDelay}
+                                isDisabled={isDisabled}
                             />
                         </div>
                     </div>

--- a/client/Components/Games/GameTypes.jsx
+++ b/client/Components/Games/GameTypes.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import GameTypeInfo from './GameTypeInfo';
 import { Radio, RadioGroup } from '@heroui/react';
 
-const GameTypes = ({ formProps }) => {
+const GameTypes = ({ formProps, isDisabled }) => {
     const types = [
         { name: 'beginner', label: 'Beginner' },
         { name: 'casual', label: 'Casual' },
@@ -21,6 +21,7 @@ const GameTypes = ({ formProps }) => {
                     orientation='horizontal'
                     value={formProps.values.gameType}
                     onValueChange={(value) => formProps.setFieldValue('gameType', value)}
+                    isDisabled={isDisabled}
                 >
                     {types.map((type) => (
                         <Radio

--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Formik } from 'formik';
 import { Button, Input, Select, SelectItem } from '@heroui/react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -26,6 +26,7 @@ const NewGame = ({
     const connected = useSelector((state) => state.lobby.connected);
     const user = useSelector((state) => state.auth.user);
     const [restrictedList, setRestrictedList] = useState(restrictedLists?.[0]._id);
+    const [usingEventOptions, setUsingEventOptions] = useState(false);
 
     useEffect(() => {
         if (!restrictedList && restrictedLists?.length) {
@@ -39,6 +40,22 @@ const NewGame = ({
             return acc;
         }, {});
     }, [restrictedLists]);
+
+    const syncGameOptions = useCallback(
+        (formProps, restirctedListId) => {
+            const restrictedList = restrictedListsById[restirctedListId];
+            if (restrictedList.useEventGameOptions) {
+                formProps.setFieldValue('gameType', 'competitive');
+                for (const [key, value] of Object.entries(restrictedList.eventGameOptions)) {
+                    formProps.setFieldValue(key, value);
+                }
+                setUsingEventOptions(true);
+            } else {
+                setUsingEventOptions(false);
+            }
+        },
+        [restrictedListsById]
+    );
 
     const schema = yup.object({
         name: yup
@@ -147,9 +164,10 @@ const NewGame = ({
                                                 <Select
                                                     label={'Mode'}
                                                     selectedKeys={new Set([restrictedList])}
-                                                    onChange={(e) =>
-                                                        setRestrictedList(e.target.value)
-                                                    }
+                                                    onChange={(e) => {
+                                                        setRestrictedList(e.target.value);
+                                                        syncGameOptions(formProps, e.target.value);
+                                                    }}
                                                 >
                                                     {restrictedLists?.map((rl) => (
                                                         <SelectItem key={rl._id} value={rl._id}>
@@ -161,10 +179,13 @@ const NewGame = ({
                                         </div>
                                     }
 
-                                    <GameOptions formProps={formProps} />
+                                    <GameOptions
+                                        formProps={formProps}
+                                        isDisabled={usingEventOptions}
+                                    />
                                 </>
                             )}
-                            {<GameTypes formProps={formProps} />}
+                            {<GameTypes formProps={formProps} isDisabled={usingEventOptions} />}
                             <div className='mt-4'>
                                 <Button color='success' type='submit'>
                                     Start


### PR DESCRIPTION
Reported that event game options are not being applied, even though they are set in events. Turns out there is nothing to actually set them.

This is to be treated as a hotfix, as I plan to refine/rework how events + restricted lists work in the mobile update. :)