### PR TITLE
notConsideredToBeInPlotDeck is now independent of phase

### DIFF
--- a/server/game/cards/05-LoCR/TheRainsOfCastamere.js
+++ b/server/game/cards/05-LoCR/TheRainsOfCastamere.js
@@ -45,7 +45,6 @@ class TheRainsOfCastamere extends AgendaCard {
         });
 
         this.persistentEffect({
-            condition: () => this.game.currentPhase === 'plot',
             match: (card) => card.getType() === 'plot' && card.hasTrait('Scheme'),
             targetController: 'current',
             targetLocation: 'plot deck',

--- a/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
@@ -194,4 +194,55 @@ describe('The Rains of Castamere', function () {
             expect(this.player1).not.toAllowAbilityTrigger('The Red Wedding');
         });
     });
+
+    integration(function () {
+        beforeEach(function () {
+            const starkDeck = this.buildDeck('stark', ['Trading with the Pentoshi']);
+            const martellRainsDeck = this.buildDeck('martell',[
+                '"The Rains of Castamere"',
+                'Trading with the Pentoshi',
+                'Filthy Accusations',
+                'A Song of Summer',
+                'Dorne (R)',
+                'Nymeria of Ny Sar',
+                'The Red Viper (Core)',
+                'House Dayne Knight'
+            ]);
+
+            this.player1.selectDeck(starkDeck);
+            this.player2.selectDeck(martellRainsDeck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.dorne = this.player2.findCardByName('Dorne', 'hand');
+            this.nym = this.player2.findCardByName('Nymeria of Ny Sar', 'hand');
+            this.viper = this.player2.findCardByName('The Red Viper', 'hand');
+            this.martellPentoshi = this.player2.findCardByName(
+                'Trading with the Pentoshi',
+                'plot deck'
+            );
+            this.songOfSummer = this.player2.findCardByName('A Song of Summer', 'plot deck');
+
+            this.player2.clickCard(this.viper);
+
+            this.completeSetup();
+        });
+
+        it('should not prevent plot recycling when usable plots are exhausted in the challenge phase', function () {
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player2);
+            this.selectPlotOrder(this.player2);
+            this.player2.clickCard(this.dorne);
+            this.player2.clickCard(this.nym);
+            this.player2.clickCard(this.dorne);
+
+            this.completeMarshalPhase();
+            this.unopposedChallenge(this.player2, 'Power', this.viper);
+
+            this.player2.triggerAbility(this.nym);
+            this.player2.clickCard('A Song of Summer');
+
+            expect(this.martellPentoshi.location).toBe('plot deck');
+        });
+    });
 });

--- a/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
@@ -198,7 +198,7 @@ describe('The Rains of Castamere', function () {
     integration(function () {
         beforeEach(function () {
             const starkDeck = this.buildDeck('stark', ['Trading with the Pentoshi']);
-            const martellRainsDeck = this.buildDeck('martell',[
+            const martellRainsDeck = this.buildDeck('martell', [
                 '"The Rains of Castamere"',
                 'Trading with the Pentoshi',
                 'Filthy Accusations',


### PR DESCRIPTION
https://github.com/throneteki/throneteki/issues/3602 occurred because the notConsideredToBeInPlotDeck flag on the scheme cards did not apply when recyclePlots() was triggered in the challenges phase as a result of Nymeria of Ny Sar, causing the recyclePlots function to behave as if the plot deck was not empty. I removed the condition from the persistentEffect so that the flag applies in all phases, not just the plot phase.

Other cases where notConsideredToBeInPlotDeck can be checked outside the plot phase are:
 - When At Prince Doran's Behest (SoD) is revealed by Nymeria of Ny Sar - I think it is correct for notConsideredToBeInPlotDeck to be active in this case.
 - In the Taste The Blood (ChoS) reaction - I don't see the relevance of notConsideredToBeInPlotDeck for Taste The Blood because I don't see a way a card with that flag could be in the revealed plots pile