### PR TITLE
Fix for issue 3592: kill effect from Tarle

### DIFF
--- a/server/game/cards/25.3-FUtG/TarleTheThriceDrowned.js
+++ b/server/game/cards/25.3-FUtG/TarleTheThriceDrowned.js
@@ -22,7 +22,8 @@ class TarleTheThriceDrowned extends DrawCard {
                         type: 'character',
                         location: 'play area',
                         controller: 'current'
-                    }
+                    },
+                    gameAction: 'kill'
                 },
                 message: 'Then, {player} kills {target}',
                 handler: (context) => {


### PR DESCRIPTION
Issue https://github.com/throneteki/throneteki/issues/3592 - Tarle the Thrice Drowned's kill effect was able to target characters that could not be killed, due to the target matcher properties not specifying the 'kill' action as eg on Mag the Mighty, meaning the action didn't filter possible targets based on whether or not a kill action would affect game state.

Tested with Valyrian Steel Armor and The Eyrie, but not Long May He Reign