### PR TITLE
Incorporated queing of RecyclePlots into  RevealPlots process

### DIFF
--- a/server/game/cards/21-FtR/BattleoftheTrident.js
+++ b/server/game/cards/21-FtR/BattleoftheTrident.js
@@ -92,7 +92,6 @@ class BattleoftheTrident extends AgendaCard {
         this.game.queueStep(new RevealPlots(this.game, [context.target]));
         this.game.queueStep(
             new SimpleStep(this.game, () => {
-                context.player.recyclePlots();
                 if (context.player.plotDiscard.length > 0) {
                     let removeFromGameAction = this.abilities.reactions.find(
                         (reaction) => reaction.title === 'removeFromGameMarker'

--- a/server/game/cards/25.4-TTS/NymeriaOfNySar.js
+++ b/server/game/cards/25.4-TTS/NymeriaOfNySar.js
@@ -51,11 +51,6 @@ class NymeriaOfNySar extends DrawCard {
     trigger(context) {
         context.player.selectedPlot = context.target;
         this.game.queueStep(new RevealPlots(this.game, [context.target]));
-        this.game.queueStep(
-            new SimpleStep(this.game, () => {
-                context.player.recyclePlots();
-            })
-        );
     }
 }
 

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -70,6 +70,12 @@ class EventWindow extends BaseStep {
 
         if (this.event.getConcurrentEvents().some((event) => event.name === 'onPlotRevealed')) {
             this.openAbilityWindow('whenrevealed');
+            this.event
+                .getConcurrentEvents()
+                .filter((event) => event.name === 'onPlotRevealed')
+                .forEach((event) =>
+                    this.game.queueSimpleStep(() => event.plot.controller.recyclePlots())
+                );
         }
     }
 }

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -14,7 +14,6 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.announceForcedPlotSelection()),
             new SimpleStep(game, () => this.choosePlots()),
             () => new RevealPlots(game, this.getSelectedPlots()),
-            new SimpleStep(game, () => this.recyclePlots()),
             () => new ChooseTitlePrompt(game, game.titlePool),
             new ActionWindow(this.game, 'After plots revealed', 'plot')
         ]);

--- a/server/game/gamesteps/revealplots.js
+++ b/server/game/gamesteps/revealplots.js
@@ -61,7 +61,8 @@ class RevealPlots extends BaseStep {
         });
 
         for (let plot of plots) {
-            event.addChildEvent(new Event('onPlotRevealed', { plot: plot }));
+            let plotRevealedEvent = new Event('onPlotRevealed', { plot: plot });
+            event.addChildEvent(plotRevealedEvent);
         }
 
         return event;

--- a/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
@@ -194,4 +194,137 @@ describe('The Rains of Castamere', function () {
             expect(this.player1).not.toAllowAbilityTrigger('The Red Wedding');
         });
     });
+
+    integration(function () {
+        beforeEach(function () {
+            const starkDeck = this.buildDeck('stark', [
+                'Trading with the Pentoshi',
+                'A Noble Cause'
+            ]);
+            const martellRainsDeck = this.buildDeck('martell', [
+                "At Prince Doran's Behest",
+                '"The Rains of Castamere"',
+                'Trading with the Pentoshi',
+                'Filthy Accusations',
+                'A Song of Summer',
+                'The Long Plan',
+                'Dorne (R)',
+                'Nymeria of Ny Sar',
+                'The Red Viper (Core)',
+                'House Dayne Knight'
+            ]);
+
+            this.player1.selectDeck(starkDeck);
+            this.player2.selectDeck(martellRainsDeck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.dorne = this.player2.findCardByName('Dorne', 'hand');
+            this.nym = this.player2.findCardByName('Nymeria of Ny Sar', 'hand');
+            this.viper = this.player2.findCardByName('The Red Viper', 'hand');
+            this.martellScheme = this.player2.findCardByName('The Long Plan', 'plot deck');
+            this.neutralScheme = this.player2.findCardByName('Filthy Accusations', 'plot deck');
+            this.behest = this.player2.findCardByName("At Prince Doran's Behest", 'plot deck');
+            this.martellPentoshi = this.player2.findCardByName(
+                'Trading with the Pentoshi',
+                'plot deck'
+            );
+            this.songOfSummer = this.player2.findCardByName('A Song of Summer', 'plot deck');
+            this.rains = this.player2.findCardByName('"The Rains of Castamere"');
+
+            this.player2.clickCard(this.viper);
+
+            this.completeSetup();
+        });
+
+        /*************************************************
+         * This test is for a case that requires a change in the game rules to fix
+         ***************************************************/
+        // it('should recycle plots when the plot deck consists only of cards not considered to be in the plot deck', function () {
+        //     this.player1.selectPlot('Trading with the Pentoshi');
+        //     this.player2.selectPlot("At Prince Doran's Behest");
+        //     this.selectFirstPlayer(this.player2);
+        //     this.selectPlotOrder(this.player1);
+        //     this.player2.clickCard(this.martellPentoshi);
+        //     this.player2.clickCard(this.dorne);
+        //     this.player2.clickCard(this.nym);
+        //     this.player2.clickCard(this.dorne);
+
+        //     this.completeMarshalPhase();
+        //     this.unopposedChallenge(this.player2, 'Power', this.viper);
+
+        //     this.player2.triggerAbility(this.nym);
+        //     this.player2.clickCard(this.songOfSummer);
+        //     this.player2.clickCard(this.viper);
+        //     this.player2.clickPrompt('Apply Claim');
+
+        //     expect(this.martellPentoshi.location).toBe('revealed plots');
+        //     this.completeChallengesPhase();
+        //     //game engine resolves dominance and taxation without player input
+        //     expect(this.martellPentoshi.location).toBe('plot deck');
+        // });
+
+        it('should not prevent Nymeria of Ny Sar from revealing a scheme plot', function () {
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player2);
+            this.selectPlotOrder(this.player2);
+            this.player2.clickCard(this.dorne);
+            this.player2.clickCard(this.nym);
+            this.player2.clickCard(this.dorne);
+
+            this.completeMarshalPhase();
+            this.unopposedChallenge(this.player2, 'Power', this.viper);
+
+            this.player2.triggerAbility(this.nym);
+            this.player2.clickCard(this.martellScheme);
+            expect(this.martellScheme.location).toBe('active plot');
+        });
+
+        it("should not prevent Nymeria of Ny Sar from revealing a scheme plot indirectly with At Prince Doran's Behest", function () {
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player2);
+            this.selectPlotOrder(this.player2);
+            this.player2.clickCard(this.dorne);
+            this.player2.clickCard(this.nym);
+            this.player2.clickCard(this.dorne);
+
+            this.completeMarshalPhase();
+            this.unopposedChallenge(this.player2, 'Power', this.viper);
+
+            this.player2.triggerAbility(this.nym);
+            this.player2.clickCard(this.behest);
+            this.player2.clickCard(this.neutralScheme);
+            expect(this.neutralScheme.location).toBe('active plot');
+        });
+
+        it('should recycle plots immediately when its reaction causes the plot deck to be exhausted', function () {
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player2);
+            this.selectPlotOrder(this.player1);
+            this.player2.clickCard(this.dorne);
+            this.player2.clickCard(this.nym);
+            this.player2.clickCard(this.dorne);
+
+            this.completeMarshalPhase();
+            this.completeChallengesPhase();
+            this.player2.selectPlot('A Song of Summer');
+            this.selectFirstPlayer(this.player2);
+            this.completeMarshalPhase();
+
+            this.unopposedChallenge(this.player2, 'Intrigue', this.viper);
+
+            this.player2.triggerAbility(this.nym);
+            this.player2.clickCard(this.behest);
+            this.player2.clickCard(this.martellScheme);
+            this.player2.clickCard(this.viper);
+            this.player2.triggerAbility(this.rains);
+            this.player2.clickCard(this.neutralScheme);
+            this.player2.clickPrompt('Apply Claim');
+
+            expect(this.player2Object.getNumberOfUsedPlots()).toBe(0);
+        });
+    });
 });

--- a/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
+++ b/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
@@ -5,7 +5,9 @@ describe("At Prince Doran's Behest", function () {
                 "At Prince Doran's Behest",
                 'Valar Morghulis',
                 'Desert Scavenger',
-                "Caswell's Keep"
+                "Caswell's Keep",
+                'Brimstone',
+                'Nymeria of Ny Sar'
             ]);
             const deck2 = this.buildDeck('stark', [
                 'Marched to the Wall',
@@ -125,6 +127,33 @@ describe("At Prince Doran's Behest", function () {
                 expect(this.player1).toAllowAbilityTrigger("Caswell's Keep");
             });
         });
+
+        describe('when it is the last card in the plot deck', function () {
+            beforeEach(function () {
+                this.completeSetup();
+
+                this.player1.selectPlot('Valar Morghulis');
+                this.player2.selectPlot('Marched to the Wall');
+                this.selectFirstPlayer(this.player1);
+
+                this.selectPlotOrder(this.player1);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+                var cardsToDiscard =
+                    this.player2.filterCards((card) => card.location === 'hand').length -
+                    this.player2.findCardByName('Marched to the Wall').reserve;
+                for (let i = 0; i < cardsToDiscard; ++i) {
+                    this.player2.clickCard(this.player2.findCardByName('Old Nan', 'hand'));
+                }
+                this.player2.clickPrompt('Done');
+            });
+
+            it('should proceed without prompting to choose a plot', function () {
+                this.selectFirstPlayer(this.player1);
+                expect(this.game.currentPhase).toBe('marshal');
+            });
+        });
     });
 
     describe("vs Varys's Riddle", function () {
@@ -194,6 +223,158 @@ describe("At Prince Doran's Behest", function () {
                     expect(this.player2).toHavePromptButton('player1 - Valar Morghulis');
                     expect(this.player2).toHavePromptButton('player2 - Valar Morghulis');
                 });
+            });
+        });
+    });
+
+    describe('vs a rains-triggered Pulling The Strings', function () {
+        integration(function () {
+            beforeEach(function () {
+                const martell = this.buildDeck('martell', [
+                    "At Prince Doran's Behest",
+                    'A Storm of Swords',
+                    'A Feast for Crows'
+                ]);
+                const tyrellRains = this.buildDeck('tyrell', [
+                    '"The Rains of Castamere"',
+                    'A Game of Thrones',
+                    'A Clash of Kings',
+                    'Pulling the Strings',
+                    'A Noble Cause',
+                    'Highgarden Honor Guard'
+                ]);
+                this.player1.selectDeck(martell);
+                this.player2.selectDeck(tyrellRains);
+
+                this.startGame();
+                this.keepStartingHands();
+
+                this.fiveStrIntrigue = this.player2.findCardByName(
+                    'Highgarden Honor Guard',
+                    'hand'
+                );
+                this.behest = this.player1.findCardByName("At Prince Doran's Behest", 'plot deck');
+                this.crows = this.player1.findCardByName('A Feast for Crows', 'plot deck');
+                this.swords = this.player1.findCardByName('A Storm of Swords', 'plot deck');
+
+                this.kings = this.player2.findCardByName('A Clash of Kings', 'plot deck');
+                this.thrones = this.player2.findCardByName('A Game of Thrones', 'plot deck');
+                this.strings = this.player2.findCardByName('Pulling the Strings', 'plot deck');
+                this.cause = this.player2.findCardByName('A Noble Cause', 'plot deck');
+                this.rains = this.player2.findCardByName('"The Rains of Castamere"');
+
+                this.player2.clickCard(this.fiveStrIntrigue);
+                this.completeSetup();
+                this.player1.selectPlot(this.behest);
+                this.player2.selectPlot(this.kings);
+                this.selectFirstPlayer(this.player2);
+                this.player1.clickCard(this.swords);
+                this.completeMarshalPhase();
+            });
+
+            it('should allow the Rains player to reveal a scheme', function () {
+                this.unopposedChallenge(this.player2, 'intrigue', this.fiveStrIntrigue);
+                this.player2.triggerAbility(this.rains);
+                this.player2.clickCard(this.strings);
+                this.player2.clickCard(this.behest);
+                this.player2.clickCard(this.thrones);
+                this.player2.clickPrompt('Apply Claim');
+                expect(this.thrones.location).toBe('active plot');
+            });
+
+            it('should not trigger a plot deck recycle while schemes remain', function () {
+                this.unopposedChallenge(this.player2, 'intrigue', this.fiveStrIntrigue);
+                this.player2.triggerAbility(this.rains);
+                this.player2.clickCard(this.strings);
+                this.player2.clickCard(this.behest);
+                this.player2.clickCard(this.cause);
+                this.player2.clickPrompt('Apply Claim');
+                expect(this.player2Object.getNumberOfUsedPlots()).toBe(2);
+            });
+
+            it('should trigger the rains players plot deck to recycle if it reveals the last card altogether', function () {
+                this.player2.dragCard(this.thrones, 'revealed plots');
+                this.unopposedChallenge(this.player2, 'intrigue', this.fiveStrIntrigue);
+                this.player2.triggerAbility(this.rains);
+                this.player2.clickCard(this.strings);
+                this.player2.clickCard(this.behest);
+                this.player2.clickCard(this.cause);
+                this.player2.clickPrompt('Apply Claim');
+                expect(this.player2Object.getNumberOfUsedPlots()).toBe(0);
+            });
+        });
+    });
+
+    describe('vs city of secrets', function () {
+        integration(function () {
+            beforeEach(function () {
+                const behestDeck = this.buildDeck('martell', [
+                    "At Prince Doran's Behest",
+                    'City Blockade',
+                    'Trading with the Pentoshi',
+                    'The Red Viper (Core)',
+                    'The Red Viper (Core)',
+                    'The Red Viper (Core)',
+                    'Ellaria Sand (SoD)',
+                    'Ellaria Sand (SoD)',
+                    'Ellaria Sand (SoD)',
+                    'The Fowler Twins',
+                    'The Fowler Twins',
+                    'The Fowler Twins',
+                    'House Dayne Knight',
+                    'House Dayne Knight',
+                    'House Dayne Knight'
+                ]);
+                const cityOfSecretsDeck = this.buildDeck('baratheon', [
+                    'City of Secrets',
+                    'City of Wealth',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer',
+                    'Vanguard Lancer'
+                ]);
+
+                this.player1.selectDeck(behestDeck);
+                this.player2.selectDeck(cityOfSecretsDeck);
+
+                this.startGame();
+                this.keepStartingHands();
+
+                this.behest = this.player1.findCardByName("At Prince Doran's Behest", 'plot deck');
+                this.blockade = this.player1.findCardByName('City Blockade', 'plot deck');
+                this.pentoshi = this.player1.findCardByName(
+                    'Trading with the Pentoshi',
+                    'plot deck'
+                );
+
+                this.secrets = this.player2.findCardByName('City of Secrets', 'plot deck');
+                this.wealth = this.player2.findCardByName('City of Wealth', 'plot deck');
+
+                this.completeSetup();
+            });
+
+            it('should not recycle the used plots pile before City of Secrets is evaluated', function () {
+                this.player1.dragCard(this.blockade, 'revealed plots');
+                this.player2.dragCard(this.wealth, 'revealed plots');
+
+                this.player1.selectPlot(this.behest);
+                //player 2 is forced to select City of Secrets
+                this.selectFirstPlayer(this.player2);
+                this.selectPlotOrder(this.player1);
+                this.player1.clickCard(this.pentoshi);
+                this.selectPlotOrder(this.player1);
+                //phase should now complete without prompting for discard as both players have a city plot in used pile
+
+                expect(this.game.currentPhase).toBe('marshal');
+                //used pile should have recycled after evaluating all when revealeds
+                expect(this.player1Object.getNumberOfUsedPlots()).toBe(0);
             });
         });
     });


### PR DESCRIPTION
Work on the **Nymeria of Ny Sar**/ **"The Rains of Castamere"** interaction revealed inconsistencies in the use of recyclePlots - some actions that could empty the plot deck, such as revealing plots in the plot phase and **Nymeria of Ny Sar**, queued a recyclePlots step while others such as **"The Rains of Castamere"** did not.

This PR:
 - causes the code that creates a WhenRevealed window to be queued to queue a recyclePlots step immediately after
 - removes recyclePlots steps that are now redundant
 - introduces integration tests for motivating cases and edge cases where I anticipated an incorrect approach to this issue causing problems (mainly **At Prince Doran's Behest** interactions)