### PR TITLE
Fixing hanging prompts when active player leaves or eliminated

### DIFF
--- a/server/game/ChessClock.js
+++ b/server/game/ChessClock.js
@@ -71,7 +71,7 @@ class ChessClock {
             if (timeRemaining === 0) {
                 this.stop();
                 this.player.game.addAlert('warning', "{0}'s clock has run out", this.player);
-                this.player.eliminated = true;
+                this.player.eliminate();
                 // Check if there is only one non-eliminated player remaining. If so, they win!
                 const remainingPlayers = this.player.game.getPlayers();
                 if (remainingPlayers.length === 1) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -181,7 +181,7 @@ class Game extends EventEmitter {
     }
 
     getPlayers() {
-        return this.getAllPlayers().filter((player) => !player.eliminated);
+        return this.getAllPlayers().filter((player) => !player.eliminated && !player.left);
     }
 
     getNumberOfPlayers() {
@@ -616,10 +616,10 @@ class Game extends EventEmitter {
                 '{0} is eliminated from the game because their draw deck is empty',
                 player
             );
-            player.eliminated = true;
+            player.eliminate();
         }
 
-        let remainingPlayers = players.filter((player) => !player.eliminated);
+        const remainingPlayers = players.filter((player) => !player.eliminated);
 
         // If the first player is eliminated, the next non-eliminated player in order becomes first player
         if (players[0].eliminated && remainingPlayers.length > 1) {
@@ -829,9 +829,9 @@ class Game extends EventEmitter {
         }
 
         this.addAlert('info', '{0} concedes', player);
-        player.eliminated = true;
+        player.eliminate();
 
-        let remainingPlayers = this.getPlayers().filter((player) => !player.eliminated);
+        const remainingPlayers = this.getPlayers();
 
         if (remainingPlayers.length === 1) {
             this.recordWinner(remainingPlayers[0], 'concede');
@@ -1409,9 +1409,9 @@ class Game extends EventEmitter {
             delete this.playersAndSpectators[playerName];
         } else {
             this.addAlert('info', '{0} has left the game', player);
-            player.left = true;
+            player.leave();
 
-            if (!this.finishedAt) {
+            if (this.getPlayers().length < 2 && !this.finishedAt) {
                 this.finishedAt = new Date();
             }
         }
@@ -1639,7 +1639,10 @@ class Game extends EventEmitter {
                 };
             }),
             muteSpectators: this.muteSpectators,
-            restrictedList: this.restrictedList,
+            restrictedList: this.restrictedList && {
+                name: this.restrictedList.name,
+                cardSet: this.restrictedList.cardSet
+            },
             useChessClocks: this.useChessClocks
         };
     }

--- a/server/game/gamesteps/AcknowledgeRevealCardsPrompt.js
+++ b/server/game/gamesteps/AcknowledgeRevealCardsPrompt.js
@@ -7,15 +7,12 @@ class AcknowledgeRevealCardsPrompt extends UiPrompt {
         this.cards = cards;
         this.revealLocations = [...new Set(cards.map((card) => card.location))];
         this.revealers = player ? [player] : [...new Set(cards.map((card) => card.controller))];
-        this.acknowledgers = this.game
-            .getPlayers()
-            .filter((player) => cards.some((card) => card.controller !== player));
+        this.acknowledged = new Set(this.revealers);
         this.source = source;
-        this.clickedButton = {};
     }
 
     activeCondition(player) {
-        return this.acknowledgers.includes(player) && !this.completionCondition(player);
+        return !this.completionCondition(player);
     }
 
     activePrompt() {
@@ -33,19 +30,19 @@ class AcknowledgeRevealCardsPrompt extends UiPrompt {
     }
 
     onMenuCommand(player) {
-        this.clickedButton[player.name] = true;
+        this.acknowledged.add(player);
 
         return true;
     }
 
     completionCondition(player) {
-        return !!this.clickedButton[player.name];
+        return this.acknowledged.has(player);
     }
 
     isComplete() {
         return (
             this.game.disableRevealAcknowledgement ||
-            this.acknowledgers.every((acknowledger) => this.completionCondition(acknowledger))
+            this.game.getPlayers().every((player) => this.completionCondition(player))
         );
     }
 

--- a/server/game/gamesteps/plot/ChooseTitlePrompt.js
+++ b/server/game/gamesteps/plot/ChooseTitlePrompt.js
@@ -6,6 +6,7 @@ class ChooseTitlePrompt extends BaseStep {
 
         this.titlePool = titlePool;
         this.remainingPlayers = game.getPlayersInFirstPlayerOrder();
+        this.remainingTitles = titlePool.getCardsForSelection();
         this.selections = [];
     }
 
@@ -14,12 +15,8 @@ class ChooseTitlePrompt extends BaseStep {
             return true;
         }
 
-        if (this.selections.length === 0) {
-            this.remainingTitles = this.titlePool.getCardsForSelection();
-        }
-
         if (this.remainingPlayers.length !== 0) {
-            let currentPlayer = this.remainingPlayers.shift();
+            const currentPlayer = this.remainingPlayers.shift();
             this.promptForTitle(currentPlayer);
             return false;
         }
@@ -28,7 +25,7 @@ class ChooseTitlePrompt extends BaseStep {
     }
 
     promptForTitle(player) {
-        let buttons = this.remainingTitles.map((title) => {
+        const buttons = this.remainingTitles.map((title) => {
             return { method: 'chooseTitle', card: title };
         });
         this.game.promptWithMenu(player, this, {

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -60,8 +60,12 @@ class UiPrompt extends BaseStep {
     }
 
     continue() {
-        var completed = this.isComplete();
+        const player = this.getPlayer();
+        if (player && (player.left || player.eliminated)) {
+            this.complete();
+        }
 
+        const completed = this.isComplete();
         if (completed) {
             this.clearPrompts();
             this.onCompleted();

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -12,7 +12,6 @@ import BestowPrompt from './gamesteps/bestowprompt.js';
 import AllowedChallenges from './AllowedChallenges.js';
 import PlayableLocation from './playablelocation.js';
 import PlayActionPrompt from './gamesteps/playactionprompt.js';
-import PlayerPromptState from './playerpromptstate.js';
 import MinMaxProperty from './PropertyTypes/MinMaxProperty.js';
 import ReferenceCountedSetProperty from './PropertyTypes/ReferenceCountedSetProperty.js';
 import GoldSource from './GoldSource.js';
@@ -1245,6 +1244,17 @@ class Player extends Spectator {
                 originalPile.filter((c) => c.uuid !== card.uuid)
             );
         }
+    }
+
+    leave() {
+        this.left = true;
+    }
+
+    eliminate() {
+        this.eliminated = true;
+        this.setPrompt({
+            menuTitle: 'You have been eliminated'
+        });
     }
 
     getIncome() {

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -445,6 +445,8 @@ class GameServer {
             this.gameSocket.send('GAMECLOSED', { game: game.id });
         }
 
+        game.continue();
+
         this.sendGameState(game);
     }
 

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -23,6 +23,8 @@ describe('the UiPrompt', function () {
         this.waitingPrompt = {};
 
         this.prompt = new UiPrompt(this.game);
+        spyOn(this.prompt, 'getPlayer').and.returnValue(this.player2);
+        spyOn(this.prompt, 'complete');
         spyOn(this.prompt, 'activePrompt').and.returnValue(this.activePrompt);
         spyOn(this.prompt, 'waitingPrompt').and.returnValue(this.waitingPrompt);
         spyOn(this.prompt, 'activeCondition').and.callFake((player) => {
@@ -59,6 +61,28 @@ describe('the UiPrompt', function () {
 
             it('should return false', function () {
                 expect(this.prompt.continue()).toBe(false);
+            });
+
+            describe('and the prompted player leaves', function () {
+                beforeEach(function () {
+                    this.player2.left = true;
+                    this.prompt.continue();
+                });
+
+                it('should complete the prompt', function () {
+                    expect(this.prompt.complete).toHaveBeenCalled();
+                });
+            });
+
+            describe('and the prompted player is eliminated', function () {
+                beforeEach(function () {
+                    this.player2.eliminated = true;
+                    this.prompt.continue();
+                });
+
+                it('should complete the prompt', function () {
+                    expect(this.prompt.complete).toHaveBeenCalled();
+                });
             });
         });
 


### PR DESCRIPTION
Attempts the following:
- Automatically completing prompts if its player has left or is eliminated
- Fixing Acknowledgement prompt to use `game.getPlayers()` so it naturally filters out inactive players
- Slight improvement to title prompt if one leaves on first selection
- Game server continues game after handling "leave game" code (similar to when a regular command is run)
- Added basic test for the above