### PR TITLE
Bugfix: Set Claim to Zero.

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -130,6 +130,7 @@ function setCardModifier(propName) {
             unapply: function (card, context) {
                 card[propName].setValue = context[propName][card.uuid];
                 delete context[propName][card.uuid];
+                card[propName].setValue = null;
             },
             isStateDependent
         };

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -702,7 +702,7 @@ class Game extends EventEmitter {
             let valueGetter;
             switch (stat) {
                 case 'claim':
-                    if (!player.activePlot.claim.setValue) {
+                    if (player.activePlot.claim.setValue === null) {
                         effect = Effects.modifyClaim(value);
                     } else {
                         effect = Effects.setClaim(Math.max(player.getClaim() + value, 0));
@@ -710,7 +710,7 @@ class Game extends EventEmitter {
                     valueGetter = () => player.getClaim();
                     break;
                 case 'initiative':
-                    if (!player.activePlot.initiative.setValue) {
+                    if (player.activePlot.initiative.setValue === null) {
                         effect = Effects.modifyInitiative(value);
                     } else {
                         effect = Effects.setInitiative(Math.max(player.getInitiative() + value, 0));
@@ -718,7 +718,7 @@ class Game extends EventEmitter {
                     valueGetter = () => player.getInitiative();
                     break;
                 case 'reserve':
-                    if (!player.activePlot.reserve.setValue) {
+                    if (player.activePlot.reserve.setValue === null) {
                         effect = Effects.modifyReserve(value);
                     } else {
                         effect = Effects.setReserve(Math.max(player.getReserve() + value, 0));

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -67,7 +67,7 @@ export class PlotStat {
     }
 
     calculate() {
-        if (!this.setValue) {
+        if (this.setValue === null) {
             return Math.max(this.baseValue + this.modifier, 0);
         }
         return this.setValue;

--- a/test/server/cards/23-AHaH/LysasLetter.spec.js
+++ b/test/server/cards/23-AHaH/LysasLetter.spec.js
@@ -1,0 +1,49 @@
+describe("Lysa's Letter", function () {
+    integration(function () {
+        beforeEach(function () {
+            const stark = this.buildDeck('stark', ['Maester Luwin', 'A Noble Cause']);
+            const martell = this.buildDeck('martell', [
+                "Lysa's Letter",
+                'A Noble Cause',
+                'Burning on the Sand'
+            ]);
+
+            this.player1.selectDeck(stark);
+            this.player2.selectDeck(martell);
+
+            this.startGame();
+
+            this.keepStartingHands();
+
+            this.luwin = this.player1.findCardByName('Maester Luwin', 'hand');
+            this.letter = this.player2.findCardByName("Lysa's Letter", 'hand');
+            this.burning = this.player2.findCardByName('Burning on the Sand', 'hand');
+
+            this.player1.clickCard(this.luwin);
+
+            this.completeSetup();
+            this.selectFirstPlayer(this.player1);
+            this.completeMarshalPhase();
+            this.player2.clickCard(this.letter);
+            this.player2.clickPrompt(this.player1.name);
+            this.player2.clickPrompt('Power');
+        });
+
+        it("should set the target player's claim to 0", function () {
+            expect(this.player1Object.getClaim()).toBe(0);
+        });
+
+        it('should restore the claim after an appropriate challenge', function () {
+            this.unopposedChallenge(this.player1, 'Power', this.luwin);
+            expect(this.player1Object.getClaim()).toBe(1);
+        });
+
+        //TODO: The issue exposed by this test is to be addressed in a separate PR - restore the test then
+        // it('should keep the claim at 0 if another set claim effect is applied before the appropriate challenge', function () {
+        //     this.unopposedChallenge(this.player1, 'Intrigue', this.luwin);
+        //     this.player2.clickCard(this.burning);
+        //     this.player1.clickPrompt('Apply Claim');
+        //     expect(this.player1Object.getClaim()).toBe(0);
+        // });
+    });
+});


### PR DESCRIPTION
Fixed cases where game checks claim value to avoid case where set to zero is confused with not set - the issue was causing **Burning on the Sand** and **Lysa's Letter** not to have their required effect on the game state.