### PR TITLE
Attempting to fix the issue crashing server

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -568,7 +568,7 @@ class Game extends EventEmitter {
     }
 
     checkWinAndLossConditions() {
-        if (this.currentPhase === 'setup' || this.winner) {
+        if (this.currentPhase === 'setup' || this.winner || this.disableWinning) {
             return;
         }
 
@@ -590,7 +590,7 @@ class Game extends EventEmitter {
                 this.recordDraw(deckedPlayers);
             } else if (potentialWinners.length === 1) {
                 this.recordWinner(potentialWinners[0], 'decked');
-            } else if (!this.disableWonPrompt) {
+            } else {
                 this.addAlert(
                     'info',
                     '{0} will be eliminated because their draw decks are empty. {1} chooses the winner because they are first player',
@@ -1407,10 +1407,11 @@ class Game extends EventEmitter {
     }
 
     removePlayer(player) {
-        // Move first player to left if there are more than 2 remaining players (ie. there will
+        // Considering this method is called before a player is left/eliminated,
+        // move first player to left only if there are 2 or more remaining players (ie. there will
         // be 1 or more players remaining after this player has been removed)
         const remainingPlayers = this.getPlayersInFirstPlayerOrder();
-        if (player.firstPlayer && remainingPlayers.length > 2) {
+        if (player.firstPlayer && remainingPlayers.length >= 2) {
             this.setFirstPlayer(remainingPlayers[1]);
             this.addAlert('info', '{0} has become the first player', remainingPlayers[1]);
         }

--- a/server/game/gamesteps/GameWonPrompt.js
+++ b/server/game/gamesteps/GameWonPrompt.js
@@ -9,7 +9,7 @@ class GameWonPrompt extends AllPlayerPrompt {
     }
 
     completionCondition(player) {
-        return !!this.clickedButton[player.name] || this.game.disableWonPrompt;
+        return !!this.clickedButton[player.name];
     }
 
     activePrompt() {

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -42,13 +42,14 @@ class GameFlowWrapper {
             noTitleSetAside: true,
             maxPlayers: options.maxPlayers || numOfPlayers,
             players: this.generatePlayerDetails(numOfPlayers),
-            useGameTimeLimit: options.useGameTimeLimit || false,
+            useGameTimeLimit: options.useGameTimeLimit ?? false,
             gameTimeLimit: options.gameTimeLimit
         };
         this.game = new Game(details, { router: gameRouter, titleCardData: titleCardData });
         this.game.started = true;
-        this.game.disableWonPrompt = true;
-        this.game.disableRevealAcknowledgement = true;
+
+        this.game.disableWinning = options.disableWinning ?? true;
+        this.game.disableRevealAcknowledgement = options.disableRevealAcknowledgement ?? true;
 
         this.allPlayers = this.game
             .getPlayers()

--- a/test/server/integration/WinningAndLosing.spec.js
+++ b/test/server/integration/WinningAndLosing.spec.js
@@ -1,10 +1,5 @@
 describe('Winning and losing', function () {
-    integration({ gameFormat: 'melee' }, function () {
-        beforeEach(function () {
-            // Enable losing / winning prompts
-            this.game.disableWonPrompt = false;
-        });
-
+    integration({ gameFormat: 'melee', disableWinning: false }, function () {
         describe('losing the game', function () {
             describe('when a player draws their last card', function () {
                 beforeEach(function () {

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -318,6 +318,8 @@ describe('effects', function () {
 
         describe('when/until phase ends vs at end of phase', function () {
             beforeEach(function () {
+                this.game.disableWinning = false;
+
                 const deck = this.buildDeck('stark', [
                     'Sneak Attack',
                     'Winter Festival',
@@ -392,6 +394,14 @@ describe('effects', function () {
                 // power up to 15 just before the character dies, a winner should
                 // be recorded.
                 expect(this.game.winner.name).toBe(this.player1Object.name);
+
+                // Character should not be dead yet (during won prompt)
+                expect(this.character.location).toBe('play area');
+                expect(this.player1Object.getTotalPower()).toBe(15);
+
+                // Continue playing to resolve the poison effect
+                this.player1.clickPrompt('Continue Playing');
+                this.player2.clickPrompt('Continue Playing');
                 expect(this.character.location).toBe('dead pile');
                 expect(this.player1Object.getTotalPower()).toBe(2);
             });

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -781,6 +781,8 @@ describe('take control', function () {
 
         describe('taking control of a card with power', function () {
             beforeEach(function () {
+                this.game.disableWinning = false;
+
                 const deck = this.buildDeck('greyjoy', [
                     'A Noble Cause',
                     // Add enough cards so that a winner isn't chosen by the players being decked


### PR DESCRIPTION
This fix attempts to:
- Fix the `removePlayer` function to transfer first player if 1 or more players will remain after that first player has left
- Alter tests so that, rather than disabling the "winning" prompt, it be default disables winning all-together as for 99% of tests this isn't relevant, and preventing win checks prevents test players being eliminated by being "decked" (ie. 0 cards in deck)
  - Configurable option like before; the tests which relate to testing winning will have it enabled
  
As a reminder, this is what was happening before with tests failing:
- Player was made first
- That player drew 2 cards, resulting in 0 in their draw deck
- Player was eliminated from being decked, and transferred FP to the other player
- When the test continued, it expected that old player to be first player, but they werent, and it failed