### PR TITLE
Fixing game loop issue + smaller fixes

### DIFF
--- a/server/game/ChessClock.js
+++ b/server/game/ChessClock.js
@@ -76,6 +76,8 @@ class ChessClock {
                 const remainingPlayers = this.player.game.getPlayers();
                 if (remainingPlayers.length === 1) {
                     this.player.game.recordWinner(remainingPlayers[0], 'time');
+                } else {
+                    this.player.game.checkFirstPlayer();
                 }
                 // Re-sends the game state to clients due to time expiring
                 this.player.game.timeExpired();

--- a/server/game/cards/11.1-TSC/SeizeTheInitiative.js
+++ b/server/game/cards/11.1-TSC/SeizeTheInitiative.js
@@ -7,8 +7,8 @@ class SeizeTheInitiative extends DrawCard {
                 onPhaseEnded: (event) => event.phase === 'marshal' && !this.controller.firstPlayer
             },
             handler: () => {
-                this.game.setFirstPlayer(this.controller);
                 this.game.addMessage('{0} plays {1} to become first player', this.controller, this);
+                this.game.setFirstPlayer(this.controller);
             }
         });
     }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -849,6 +849,8 @@ class Game extends EventEmitter {
 
         if (remainingPlayers.length === 1) {
             this.recordWinner(remainingPlayers[0], 'concede');
+        } else {
+            this.checkFirstPlayer();
         }
     }
 
@@ -857,7 +859,6 @@ class Game extends EventEmitter {
         player.setPrompt({
             menuTitle: 'You have been eliminated'
         });
-        this.checkFirstPlayer();
     }
 
     selectDeck(playerName, deck) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -678,6 +678,8 @@ class Game extends EventEmitter {
                     }
                 })
             );
+        } else {
+            this.checkFirstPlayer();
         }
     }
 

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -45,7 +45,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
     filterPlayers(players) {
         return players.filter(
             (player) =>
-                !(player.left || player.eliminated) &&
+                player.isPlaying() &&
                 (this.cancelTimer.isEnabled(player) ||
                     this.abilityChoices.some((abilityChoice) => abilityChoice.player === player))
         );

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -10,7 +10,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         this.cancelTimer = new CancelTimer(this.event, this.abilityType);
         this.forceWindowPerPlayer = {};
 
-        for (let player of game.getPlayersInFirstPlayerOrder()) {
+        for (const player of game.getPlayersInFirstPlayerOrder()) {
             if (this.cancelTimer.isEnabled(player)) {
                 this.forceWindowPerPlayer[player.name] = true;
             }
@@ -25,9 +25,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
 
         this.gatherChoices();
 
-        this.players = this.filterChoicelessPlayers(
-            this.players || this.game.getPlayersInFirstPlayerOrder()
-        );
+        this.players = this.filterPlayers(this.players || this.game.getPlayersInFirstPlayerOrder());
 
         if (
             this.players.length === 0 ||
@@ -41,11 +39,15 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         return false;
     }
 
-    filterChoicelessPlayers(players) {
+    /**
+     * Filters out players who are no longer playing, have cancelled their timer, or have no valid choices
+     */
+    filterPlayers(players) {
         return players.filter(
             (player) =>
-                this.cancelTimer.isEnabled(player) ||
-                this.abilityChoices.some((abilityChoice) => abilityChoice.player === player)
+                !(player.left || player.eliminated) &&
+                (this.cancelTimer.isEnabled(player) ||
+                    this.abilityChoices.some((abilityChoice) => abilityChoice.player === player))
         );
     }
 

--- a/server/game/gamesteps/playerorderprompt.js
+++ b/server/game/gamesteps/playerorderprompt.js
@@ -46,7 +46,7 @@ class PlayerOrderPrompt extends UiPrompt {
     }
 
     checkPlayer() {
-        if (this.currentPlayer && (this.currentPlayer.left || this.currentPlayer.eliminated)) {
+        if (this.currentPlayer && !this.currentPlayer.isPlaying()) {
             this.completePlayer();
         }
     }

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -52,8 +52,8 @@ class FirstPlayerPrompt extends UIPrompt {
             return;
         }
 
-        this.game.setFirstPlayer(firstPlayer);
         this.game.addMessage('{0} has selected {1} to be the first player', player, firstPlayer);
+        this.game.setFirstPlayer(firstPlayer);
 
         this.complete();
     }

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -61,7 +61,7 @@ class UiPrompt extends BaseStep {
 
     checkPlayer() {
         const player = this.getPlayer();
-        if (player && (player.left || player.eliminated)) {
+        if (player && !player.isPlaying()) {
             this.complete();
         }
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -109,6 +109,10 @@ class Player extends Spectator {
         return false;
     }
 
+    isPlaying() {
+        return !this.isSpectator() && !this.left && !this.eliminated;
+    }
+
     anyCardsInPlay(predicateOrMatcher) {
         const predicate =
             typeof predicateOrMatcher === 'function'

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -462,7 +462,7 @@ class GameServer {
                 game[command](socket.user.username, ...args);
             }
 
-            if (!game.isEmpty()) {
+            if (!game.isEmpty(false)) {
                 game.continue();
             }
 

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -64,7 +64,8 @@ class GameFlowWrapper {
         return range(1, numOfPlayers + 1).map((i) => {
             return {
                 id: i.toString(),
-                user: Settings.getUserWithDefaultsSet({ username: `player${i}` })
+                user: Settings.getUserWithDefaultsSet({ username: `player${i}` }),
+                seatNo: i
             };
         });
     }

--- a/test/server/game/getplayers.spec.js
+++ b/test/server/game/getplayers.spec.js
@@ -2,7 +2,8 @@ import Game from '../../../server/game/game.js';
 
 describe('Game', function () {
     function createPlayerSpy(props) {
-        let spy = jasmine.createSpyObj(props.name, ['isSpectator']);
+        let spy = jasmine.createSpyObj(props.name, ['isSpectator', 'isPlaying']);
+        spy.isPlaying.and.returnValue(true);
         Object.assign(spy, { id: props.id, firstPlayer: props.firstPlayer });
         return spy;
     }

--- a/test/server/gamesteps/TriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TriggeredAbilityWindow.spec.js
@@ -6,17 +6,21 @@ describe('TriggeredAbilityWindow', function () {
             'setPrompt',
             'cancelPrompt',
             'user',
-            'isTimerEnabled'
+            'isTimerEnabled',
+            'isPlaying'
         ]);
         this.player2Spy = jasmine.createSpyObj('player', [
             'setPrompt',
             'cancelPrompt',
             'user',
-            'isTimerEnabled'
+            'isTimerEnabled',
+            'isPlaying'
         ]);
 
         this.player1Spy.noTimer = true;
+        this.player1Spy.isPlaying.and.returnValue(true);
         this.player2Spy.noTimer = true;
+        this.player2Spy.isPlaying.and.returnValue(true);
 
         this.gameSpy = jasmine.createSpyObj('game', [
             'getPlayersInFirstPlayerOrder',

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -9,13 +9,17 @@ describe('the PlayerOrderPrompt', function () {
         this.player1 = jasmine.createSpyObj('player1', [
             'setPrompt',
             'cancelPrompt',
-            'setIsActivePrompt'
+            'setIsActivePrompt',
+            'isPlaying'
         ]);
+        this.player1.isPlaying.and.returnValue(true);
         this.player2 = jasmine.createSpyObj('player1', [
             'setPrompt',
             'cancelPrompt',
-            'setIsActivePrompt'
+            'setIsActivePrompt',
+            'isPlaying'
         ]);
+        this.player2.isPlaying.and.returnValue(true);
 
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);
         this.game.getPlayersInFirstPlayerOrder.and.returnValue([this.player2, this.player1]);

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -21,8 +21,10 @@ describe('the SelectCardPrompt', function () {
             'clearSelectedCards',
             'setSelectableCards',
             'setSelectedCards',
-            'setIsActivePrompt'
+            'setIsActivePrompt',
+            'isPlaying'
         ]);
+        this.player.isPlaying.and.returnValue(true);
         this.player.cardsInPlay = [];
         this.otherPlayer = jasmine.createSpyObj('player2', [
             'setPrompt',
@@ -31,8 +33,10 @@ describe('the SelectCardPrompt', function () {
             'clearSelectedCards',
             'setSelectableCards',
             'setSelectedCards',
-            'setIsActivePrompt'
+            'setIsActivePrompt',
+            'isPlaying'
         ]);
+        this.otherPlayer.isPlaying.and.returnValue(true);
         this.game.getPlayers.and.returnValue([this.player, this.otherPlayer]);
         this.card = createCardSpy({ name: 'card', controller: this.player });
 

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -7,11 +7,13 @@ describe('the UiPrompt', function () {
             'cancelPrompt',
             'setIsActivePrompt'
         ]);
+        this.player1.isPlaying = () => !this.player1.eliminated && !this.player1.left;
         this.player2 = jasmine.createSpyObj('player', [
             'setPrompt',
             'cancelPrompt',
             'setIsActivePrompt'
         ]);
+        this.player2.isPlaying = () => !this.player2.eliminated && !this.player2.left;
 
         this.game = jasmine.createSpyObj('game', ['getPlayers']);
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);


### PR DESCRIPTION
The infinite loop was found to be when there is a `TriggeredAbilityWindow` currently open, one or more spectators, and all playing players leave.

This has been addressed in a few ways:
1. `TriggeredAbilityWindow` will now filter out non-playing players when checking who to prompt.
2. Games will now properly _not_ continue() if the only players remaining are spectators

Additionally, there has been a primitive (ie. it should be refined later) check for first player after one is eliminated or has left, to ensure the next active player to their left is made first player instead.