### PR TITLE
Implementing Disconnect Handler + Bugfixes

### DIFF
--- a/client/Components/Games/GameList.jsx
+++ b/client/Components/Games/GameList.jsx
@@ -11,7 +11,7 @@ import {
 } from '../../redux/reducers/lobby';
 import { toast } from 'react-toastify';
 
-const GameList = ({ gameFilter, games, onJoinOrWatch }) => {
+const GameList = ({ gameFilter, games, onJoinOrWatch = () => true }) => {
     const dispatch = useDispatch();
     const currentGame = useSelector((state) => state.lobby.currentGame);
     const user = useSelector((state) => state.auth.user);

--- a/client/Components/Games/GameLobby.jsx
+++ b/client/Components/Games/GameLobby.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import GameFilter from './GameFilter';
 import GameList from './GameList';
@@ -37,8 +37,6 @@ const GameLobby = ({ gameId }) => {
     const games = useSelector((state) => state.lobby.games);
     const passwordGame = useSelector((state) => state.lobby.passwordGame);
 
-    const topRef = useRef(null);
-
     useEffect(() => {
         const filter = localStorage.getItem('gameFilter');
         if (filter) {
@@ -75,11 +73,23 @@ const GameLobby = ({ gameId }) => {
         }
     }, [currentGame, dispatch, gameId, games]);
 
+    // Manages the auto-scrolling, depending on which ref just appeared
+    const scrollRef = (node, block = 'start') => {
+        if (node !== null) {
+            node.scrollIntoView({
+                behavior: 'smooth',
+                block
+            });
+        }
+    };
+
     return (
-        <Page ref={topRef}>
-            {newGame && <NewGame quickJoin={quickJoin} onClosed={() => setNewGame(false)} />}
-            {currentGame?.started === false && <PendingGame />}
-            {passwordGame && <PasswordGame />}
+        <Page>
+            {newGame && (
+                <NewGame quickJoin={quickJoin} onClosed={() => setNewGame(false)} ref={scrollRef} />
+            )}
+            {currentGame?.started === false && <PendingGame ref={(n) => scrollRef(n, 'center')} />}
+            {passwordGame && <PasswordGame ref={scrollRef} />}
             <Panel title={'Current Games'}>
                 {!user && (
                     <div className='mb-2 text-center'>
@@ -117,16 +127,7 @@ const GameLobby = ({ gameId }) => {
                                 one.
                             </AlertPanel>
                         ) : (
-                            <GameList
-                                games={games}
-                                gameFilter={currentFilter}
-                                onJoinOrWatch={() =>
-                                    topRef.current?.scrollIntoView({
-                                        behavior: 'smooth',
-                                        block: 'end'
-                                    })
-                                }
-                            />
+                            <GameList games={games} gameFilter={currentFilter} />
                         )}
                     </div>
                 </div>

--- a/client/Components/Games/NewGame.jsx
+++ b/client/Components/Games/NewGame.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useMemo, useState } from 'react';
 import { Formik } from 'formik';
 import { Button, Input, Select, SelectItem, Switch } from '@heroui/react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -14,13 +14,10 @@ import { GameFormats } from '../../constants';
 
 const GameNameMaxLength = 64;
 
-const NewGame = ({
-    quickJoin = false,
-    defaultGameType,
-    defaultPrivate,
-    defaultTimeLimit,
-    onClosed
-}) => {
+const NewGame = forwardRef(function NewGame(
+    { quickJoin = false, defaultGameType, defaultPrivate, defaultTimeLimit, onClosed },
+    ref
+) {
     const dispatch = useDispatch();
     const { data: restrictedLists } = useGetRestrictedListQuery({});
 
@@ -110,7 +107,7 @@ const NewGame = ({
     }
     const canStart = gameFormat && restrictedList;
     return (
-        <Panel title={quickJoin ? 'Quick Join' : 'New game'}>
+        <Panel title={quickJoin ? 'Quick Join' : 'New game'} ref={ref}>
             <Formik
                 validationSchema={schema}
                 onSubmit={(values) => {
@@ -270,6 +267,6 @@ const NewGame = ({
             </Formik>
         </Panel>
     );
-};
+});
 
 export default NewGame;

--- a/client/Components/Games/PasswordGame.jsx
+++ b/client/Components/Games/PasswordGame.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, forwardRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AlertPanel from '../Site/AlertPanel';
@@ -10,7 +10,7 @@ import {
 } from '../../redux/reducers/lobby';
 import { Button, Input } from '@heroui/react';
 
-const PasswordGame = () => {
+const PasswordGame = forwardRef(function PasswordGame(_, ref) {
     const [password, setPassword] = useState('');
     const dispatch = useDispatch();
     const { passwordJoinType, passwordGame, passwordError } = useSelector((state) => state.lobby);
@@ -36,7 +36,7 @@ const PasswordGame = () => {
 
     return (
         <div>
-            <Panel title={passwordGame.name}>
+            <Panel title={passwordGame.name} ref={ref}>
                 <div className='flex gap-2 flex-col'>
                     {passwordError ? (
                         <AlertPanel variant='danger'>{passwordError}</AlertPanel>
@@ -64,6 +64,6 @@ const PasswordGame = () => {
             </Panel>
         </div>
     );
-};
+});
 
 export default PasswordGame;

--- a/client/Components/Games/PendingGame.jsx
+++ b/client/Components/Games/PendingGame.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { forwardRef, useCallback, useState } from 'react';
 import Panel from '../Site/Panel';
 import Messages from '../GameBoard/Messages';
 import SelectDeckModal from './SelectDeckModal';
@@ -21,7 +21,7 @@ import LoadingSpinner from '../Site/LoadingSpinner';
 import { GameFormats } from '../../constants';
 import ChatArea from '../Site/ChatArea';
 
-const PendingGame = () => {
+const PendingGame = forwardRef(function PendingGame(_, ref) {
     const dispatch = useDispatch();
     const [waiting, setWaiting] = useState(false);
     const [showModal, setShowModal] = useState(false);
@@ -172,7 +172,7 @@ const PendingGame = () => {
                     </div>
                 </div>
             </Panel>
-            <div>
+            <div ref={ref}>
                 <PendingGamePlayers
                     currentGame={currentGame}
                     user={user}
@@ -212,6 +212,6 @@ const PendingGame = () => {
             )}
         </div>
     );
-};
+});
 
 export default PendingGame;

--- a/client/Components/Navigation/ContextMenu.jsx
+++ b/client/Components/Navigation/ContextMenu.jsx
@@ -13,38 +13,9 @@ const ContextMenu = ({ onPress = () => true }) => {
     const [lastSpectatorCount, setLastSpectatorCount] = useState(0);
     const [showSpectatorWarning, setShowSpectatorWarning] = useState(false);
 
-    const isGameActive = useMemo(() => {
-        if (!currentGame || !user) {
-            return false;
-        }
-
-        if (currentGame.winner) {
-            return false;
-        }
-
-        let thisPlayer = currentGame.players[user.username];
-        if (!thisPlayer) {
-            thisPlayer = Object.values(currentGame.players)[0];
-        }
-
-        let otherPlayer = Object.values(currentGame.players).find((player) => {
-            return player.name !== thisPlayer.name;
-        });
-
-        if (!otherPlayer) {
-            return false;
-        }
-
-        if (otherPlayer.disconnected || otherPlayer.left) {
-            return false;
-        }
-
-        return true;
-    }, [currentGame, user]);
-
     const onLeaveClick = useCallback(() => {
-        const spectating = user && currentGame && !currentGame.players[user.username];
-        if (!spectating && isGameActive) {
+        const all = { ...currentGame.players, ...currentGame.spectators };
+        if (user && !all[user.username].canSafelyLeave) {
             onPress(true);
 
             return;
@@ -52,7 +23,7 @@ const ContextMenu = ({ onPress = () => true }) => {
 
         onPress(false);
         dispatch(sendLeaveGameMessage());
-    }, [currentGame, dispatch, isGameActive, onPress, user]);
+    }, [currentGame, dispatch, onPress, user]);
 
     const onConcedeClick = useCallback(() => {
         onPress(false);

--- a/client/Components/Navigation/ContextMenu.jsx
+++ b/client/Components/Navigation/ContextMenu.jsx
@@ -14,8 +14,8 @@ const ContextMenu = ({ onPress = () => true }) => {
     const [showSpectatorWarning, setShowSpectatorWarning] = useState(false);
 
     const onLeaveClick = useCallback(() => {
-        const all = { ...currentGame.players, ...currentGame.spectators };
-        if (user && !all[user.username].canSafelyLeave) {
+        const all = Object.values({ ...currentGame.players, ...currentGame.spectators });
+        if (user && all.some((a) => a.name === user.username && !a.canSafelyLeave)) {
             onPress(true);
 
             return;

--- a/client/Components/Navigation/NavBar.jsx
+++ b/client/Components/Navigation/NavBar.jsx
@@ -258,7 +258,7 @@ const NavBar = () => {
             </Navbar>
             <ConfirmDialog
                 isOpen={showConfirmLeave}
-                message='Your game is not finished, are you sure you want to leave?'
+                message='Your game is not finished, and you will automatically concede when leaving. Are you sure you want to leave?'
                 onOpenChange={setShowConfirmLeave}
                 onCancel={() => setShowConfirmLeave(false)}
                 onOk={async () => {

--- a/client/Components/Site/Panel.jsx
+++ b/client/Components/Site/Panel.jsx
@@ -1,6 +1,6 @@
 import { Card, CardBody, CardHeader } from '@heroui/react';
 import classNames from 'classnames';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 const PanelType = Object.freeze({
     Default: 'default',
@@ -10,7 +10,10 @@ const PanelType = Object.freeze({
     Danger: 'danger'
 });
 
-const Panel = ({ className, type = PanelType.Primary, title, children }) => {
+const Panel = forwardRef(function Panel(
+    { className, type = PanelType.Primary, title, children },
+    ref
+) {
     let border = 'border-default';
     if (type === PanelType.Primary) {
         border = 'border-primary';
@@ -24,11 +27,11 @@ const Panel = ({ className, type = PanelType.Primary, title, children }) => {
     const cardClass = classNames('shadow-lg border-2 bg-black/65 h-full', className, border);
     const titleClass = classNames('justify-center rounded-none font-bold', `bg-${type}`);
     return (
-        <Card className={cardClass} classNames={{ body: 'h-full overflow-y-auto' }}>
+        <Card className={cardClass} classNames={{ body: 'h-full overflow-y-auto' }} ref={ref}>
             {title && <CardHeader className={titleClass}>{title}</CardHeader>}
             <CardBody>{children}</CardBody>
         </Card>
     );
-};
+});
 
 export default Panel;

--- a/server/game/ChessClock.js
+++ b/server/game/ChessClock.js
@@ -12,6 +12,11 @@ class ChessClock {
         this.paused = false;
 
         this.player.game.on('onSetupFinished', () => (this.enabled = true));
+        this.player.game.on('onPlayerEliminated', ({ player, reason }) => {
+            if (player === this.player && reason !== 'time') {
+                this.enabled = false;
+            }
+        });
         this.player.game.on('onGameOver', () => (this.enabled = false));
     }
 
@@ -72,9 +77,9 @@ class ChessClock {
             if (timeRemaining === 0) {
                 this.stop();
                 this.game.chessClockExpired(this.player);
-
-                clearInterval(this.timer);
-                delete this.timer;
+                this.enabled = false;
+                // Game state needs to explicitly be sent, as this method was triggered by a server-side timer
+                this.game.sendGameState();
             }
         }
     }

--- a/server/game/GameHandlers/DisconnectHandler.js
+++ b/server/game/GameHandlers/DisconnectHandler.js
@@ -1,0 +1,143 @@
+import moment from 'moment';
+import WaitForPlayerPrompt from './WaitForPlayerPrompt.js';
+import TextHelper from '../TextHelper.js';
+
+class DisconnectHandler {
+    constructor(game, waitSeconds = 30) {
+        this.game = game;
+        this.waitSeconds = waitSeconds;
+
+        this.disconnections = {};
+    }
+
+    /** Checks if player is currently disconnected */
+    isDisconnected(player) {
+        return !!this.disconnections[player.name];
+    }
+
+    /** Checks if player is has been disconnected longer than the allocated wait period (default 30 seconds) */
+    isLongDisconnected(player) {
+        return this.disconnections[player.name]?.longDisconnected || false;
+    }
+
+    waitForReconnect(player, handler = () => true) {
+        if (!this.isDisconnected(player)) {
+            return;
+        }
+        const timer = setTimeout(() => {
+            handler(player);
+            clearTimeout(timer);
+            this.game.sendGameState();
+        }, this.waitSeconds * 1000);
+        this.disconnections[player.name].timer = timer;
+    }
+
+    /** Marks a player as disconnected, alerting as such and tracking if they do not reconnect beyond wait period (default 30 seconds) */
+    disconnected(player) {
+        if (this.isDisconnected(player)) {
+            return;
+        }
+        if (this.game.isGameOver && !this.game.isPostGameOver) {
+            // No need to wait for them to reconnect for complete game, just alert other players they disconnected
+            this.game.addAlert('warning', '{0} has disconnected', player);
+            return;
+        }
+        this.game.addAlert(
+            'warning',
+            '{0} has disconnected. The game will wait up to {1} for them to reconnect',
+            player,
+            TextHelper.duration(this.waitSeconds)
+        );
+        const playerData = {
+            disconnectedAt: new Date(),
+            reason: 'disconnected'
+        };
+        this.disconnections[player.name] = playerData;
+
+        const initialWaitedFunc = (player) => {
+            // Mark as a long disconnection
+            this.disconnections[player.name].longDisconnected = true;
+
+            if (this.game.isJoust) {
+                this.game.addAlert(
+                    'warning',
+                    '{0} has been disconnected for more than {1}. You can continue to wait or can leave the game and it will conclude with no winner',
+                    player,
+                    TextHelper.duration(this.waitSeconds)
+                );
+            } else if (this.game.isMelee) {
+                this.voteToEliminate(player, true);
+            }
+        };
+        this.waitForReconnect(player, initialWaitedFunc);
+    }
+
+    voteToEliminate(player, initial = false) {
+        if (!this.isDisconnected(player)) {
+            return;
+        }
+
+        const disconnectedSeconds = () => {
+            if (initial) {
+                return this.waitSeconds;
+            }
+            const disconnectedAt = this.disconnections[player.name].disconnectedAt;
+            const duration = moment.duration(moment().diff(moment(disconnectedAt)));
+            return duration.asSeconds();
+        };
+
+        this.game.addAlert(
+            'warning',
+            '{0} has been disconnected for more than {1}. You may vote to wait an additional {2} for them to reconnect or eliminate them (must be unanimous)',
+            player,
+            TextHelper.duration(disconnectedSeconds()),
+            TextHelper.duration(this.waitSeconds)
+        );
+        const waitFunc = () => {
+            this.game.addAlert(
+                'info',
+                'Waiting an additional {0} for {1} to reconnect',
+                TextHelper.duration(this.waitSeconds),
+                player
+            );
+            this.waitForReconnect(player, (player) => this.voteToEliminate(player));
+        };
+        this.game.queueStep(new WaitForPlayerPrompt(this.game, player, waitFunc));
+        this.game.continue();
+    }
+
+    /** Marks a player as to have been failed to connect to the game to begin with */
+    failedConnection(player) {
+        if (this.isDisconnected(player)) {
+            return;
+        }
+        this.game.addAlert('danger', '{0} has failed to connect to the game node', player);
+        this.disconnected(player);
+    }
+
+    /** Marks a disconnected player as reconnected */
+    reconnected(player) {
+        if (!this.isDisconnected(player)) {
+            return;
+        }
+        this.game.addAlert('info', '{0} has reconnected', player);
+        // Clears the timer, if they have one (can be undefined)
+        clearTimeout(this.disconnections[player.name].timer);
+        delete this.disconnections[player.name];
+    }
+
+    /** Whether a player is in a state where they must wait for an opponent to reconnect, mostly for checking if they can safely leave the game */
+    mustWaitForReconnections(player) {
+        if (this.game.isJoust) {
+            return !this.game
+                .getOpponents(player)
+                .every((opponent) => this.isLongDisconnected(opponent));
+        }
+        if (this.game.isMelee) {
+            return true;
+        }
+        return false;
+    }
+}
+
+export default DisconnectHandler;

--- a/server/game/GameHandlers/DisconnectHandler.js
+++ b/server/game/GameHandlers/DisconnectHandler.js
@@ -2,6 +2,16 @@ import moment from 'moment';
 import WaitForPlayerPrompt from './WaitForPlayerPrompt.js';
 import TextHelper from '../TextHelper.js';
 
+/**
+ * Handles the disconnection & reconnection logic for all in-game players (not spectators).
+ *
+ * Logic for handling a disconnected player is slightly different for each game format:
+ * - Joust: Players will have X seconds to reconnect. Following that, the opponent can leave without penalty, resulting in a concluded game with no winner.
+ * - Melee: Players will have X seconds to reconnect. Following that, opponents will vote to wait an additional X seconds, or eliminate them.
+ *          Eliminations must be a unanimous vote, and re-votes keep happening until they reconnect or are voted for elimination.
+ *
+ * X is configurable, but defaulted to 30 seconds
+ */
 class DisconnectHandler {
     constructor(game, waitSeconds = 30) {
         this.game = game;

--- a/server/game/GameHandlers/GameOverHandler.js
+++ b/server/game/GameHandlers/GameOverHandler.js
@@ -149,13 +149,16 @@ class GameOverHandler {
     }
 
     playerLeft(player) {
-        if (!player.eliminated) {
+        if (this.game.canSafelyLeave(player)) {
+            this.gameOver();
+        } else if (!player.eliminated) {
             this.eliminate(player, 'left');
         }
     }
 
     playerDisconnected(player) {
         if (!player.eliminated) {
+            this.game.addAlert('info', '{0} has been eliminated', player);
             this.eliminate(player, 'disconnected');
         }
     }

--- a/server/game/GameHandlers/WaitForPlayerPrompt.js
+++ b/server/game/GameHandlers/WaitForPlayerPrompt.js
@@ -1,0 +1,56 @@
+import AllPlayerPrompt from '../gamesteps/allplayerprompt.js';
+
+class WaitForPlayerPrompt extends AllPlayerPrompt {
+    constructor(game, targetPlayer, waitFunc = () => true) {
+        super(game);
+
+        this.targetPlayer = targetPlayer;
+        this.waitFunc = waitFunc;
+        this.clickedButton = {};
+    }
+
+    completionCondition(player) {
+        return this.cancelled || this.clickedButton[player.name];
+    }
+
+    activePrompt() {
+        return {
+            menuTitle: `Wait for ${this.targetPlayer.name}?`,
+            buttons: [
+                { arg: 'yes', text: 'Yes' },
+                { arg: 'no', text: 'No (Eliminate)' }
+            ]
+        };
+    }
+
+    waitingPrompt() {
+        return {
+            menuTitle: 'Waiting for opponent(s) to agree to wait'
+        };
+    }
+
+    onMenuCommand(player, arg) {
+        this.clickedButton[player.name] = arg;
+        if (arg === 'yes') {
+            this.game.addMessage('{0} would like to wait for {1}', player, this.targetPlayer);
+        } else {
+            this.game.addMessage('{0} would like to eliminate {1}', player, this.targetPlayer);
+        }
+
+        return true;
+    }
+
+    getPromptablePlayers() {
+        return this.game.getPlayers().filter((player) => !this.game.isDisconnected(player));
+    }
+
+    onCompleted() {
+        if (Object.values(this.clickedButton).some((arg) => arg === 'yes')) {
+            this.waitFunc();
+        } else {
+            this.game.gameOverHandler.playerDisconnected(this.targetPlayer);
+        }
+    }
+}
+
+export default WaitForPlayerPrompt;

--- a/server/game/TextHelper.js
+++ b/server/game/TextHelper.js
@@ -41,6 +41,20 @@ const TextHelper = {
         var s = ['th', 'st', 'nd', 'rd'];
         var v = n % 100;
         return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    },
+    duration(sec) {
+        const totalSeconds = Math.floor(sec);
+
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+
+        if (minutes > 0 && seconds > 0) {
+            return `${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${seconds !== 1 ? 's' : ''}`;
+        } else if (minutes > 0) {
+            return `${minutes} minute${minutes !== 1 ? 's' : ''}`;
+        } else {
+            return `${seconds} second${seconds !== 1 ? 's' : ''}`;
+        }
     }
 };
 

--- a/server/game/TitleCard.js
+++ b/server/game/TitleCard.js
@@ -8,6 +8,7 @@ class TitleCard extends BaseCard {
         this.supporterNames = this.supporterNames || [];
         this.rivalNames = this.rivalNames || [];
         this.isContributing = false;
+        this.location = 'title pool';
     }
 
     supports(...values) {

--- a/server/game/TitlePool.js
+++ b/server/game/TitlePool.js
@@ -12,11 +12,9 @@ const titles = [
 class TitlePool {
     constructor(game, cardData) {
         this.game = game;
-        this.cards = titles.map((titleClass) => {
-            const title = new titleClass({ game: game }, cardData[titleClass.code] || {});
-            title.moveTo('title pool');
-            return title;
-        });
+        this.cards = titles.map(
+            (titleClass) => new titleClass({ game: game }, cardData[titleClass.code] || {})
+        );
     }
 
     getCardsForSelection() {

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -739,12 +739,12 @@ class ChatCommands {
     }
 
     rematch(player) {
-        if (this.game.finishedAt) {
+        if (this.game.isGameOver) {
             this.game.addAlert('info', '{0} is requesting a rematch', player);
         } else {
             this.game.addAlert(
                 'danger',
-                '{0} is requesting a rematch.  The current game is not finished',
+                '{0} is requesting a rematch. The current game is not finished',
                 player
             );
         }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1369,9 +1369,8 @@ class Game extends EventEmitter {
     }
 
     rematch() {
-        if (!this.finishedAt) {
-            this.finishedAt = new Date();
-            this.winReason = 'rematch';
+        if (!this.isGameOver) {
+            this.gameOverHandler.gameOver('rematch');
         }
 
         this.router.rematch(this);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -883,12 +883,6 @@ class Game extends EventEmitter {
         }
     }
 
-    checkForTimeExpired() {
-        if (this.useGameTimeLimit && this.timeLimit.isTimeLimitReached && !this.finishedAt) {
-            this.determineWinnerAfterTimeLimitExpired();
-        }
-    }
-
     beginRound() {
         // Reset phases to the standard game flow.
         this.remainingPhases = Phases.names();
@@ -1308,7 +1302,7 @@ class Game extends EventEmitter {
             this.addAlert('info', '{0} has left the game', player);
             // To ensure game over handler behaves as expected, we eliminate a player who leaves mid-game (without conceding)
             if (!this.isGameOver && !player.eliminated) {
-                this.gameOverHandler.eliminate(player, 'left');
+                this.gameOverHandler.playerLeft(player);
             }
             player.left = true;
         }
@@ -1348,10 +1342,7 @@ class Game extends EventEmitter {
             this.addAlert('danger', '{0} has failed to connect to the game', player);
 
             player.disconnectedAt = new Date();
-
-            if (!this.finishedAt) {
-                this.finishedAt = new Date();
-            }
+            this.gameOverHandler.playerDisconnected(player);
         }
     }
 
@@ -1376,8 +1367,8 @@ class Game extends EventEmitter {
         this.router.rematch(this);
     }
 
-    timeExpired() {
-        this.emit('onTimeExpired');
+    sendGameState() {
+        this.emit('sendGameState');
     }
 
     activatePersistentEffects() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1,5 +1,4 @@
 import EventEmitter from 'events';
-import moment from 'moment';
 import AttachmentValidityCheck from './AttachmentValidityCheck.js';
 import ChatCommands from './chatcommands.js';
 import GameChat from './gamechat.js';
@@ -42,7 +41,8 @@ import PrizedKeywordListener from './PrizedKeywordListener.js';
 import GameOverPrompt from './gamesteps/GameOverPrompt.js';
 import shuffle from 'lodash.shuffle';
 import StartRound from './GameActions/StartRound.js';
-import GameOverHandler from './GameOverConditions/GameOverHandler.js';
+import GameOverHandler from './GameHandlers/GameOverHandler.js';
+import DisconnectHandler from './GameHandlers/DisconnectHandler.js';
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -86,7 +86,7 @@ class Game extends EventEmitter {
         this.clockPaused = false;
         this.savedGameId = details.savedGameId;
         this.gamePrivate = details.gamePrivate;
-        this.gameFormat = details.gameFormat;
+        this.gameFormat = details.gameFormat ?? 'joust';
         this.gameType = details.gameType;
         this.maxPlayers = details.maxPlayers;
         this.abilityContextStack = [];
@@ -111,6 +111,7 @@ class Game extends EventEmitter {
 
         this.allowMultipleWinners = options.allowMultipleWinners || false;
         this.gameOverHandler = new GameOverHandler(this);
+        this.disconnectHandler = new DisconnectHandler(this, 30);
 
         let players = Object.values(details.players || {});
 
@@ -589,6 +590,7 @@ class Game extends EventEmitter {
             winReason: reason,
             finishedAt
         };
+        this.finishedAt = this.results.finishedAt;
 
         this.router.gameOver(this);
         this.queueStep(new GameOverPrompt(this, winners));
@@ -1278,10 +1280,9 @@ class Game extends EventEmitter {
                 return true;
             }
 
-            // Player has disconnected for longer than 30 seconds
-            if (player.disconnectedAt) {
-                const difference = moment().diff(moment(player.disconnectedAt), 'seconds');
-                return difference > 30;
+            // Player has disconnected longer than wait time
+            if (this.isLongDisconnected(player)) {
+                return true;
             }
 
             // Player is still within the game
@@ -1300,12 +1301,27 @@ class Game extends EventEmitter {
             delete this.playersAndSpectators[playerName];
         } else {
             this.addAlert('info', '{0} has left the game', player);
-            // To ensure game over handler behaves as expected, we eliminate a player who leaves mid-game (without conceding)
-            if (!this.isGameOver && !player.eliminated) {
-                this.gameOverHandler.playerLeft(player);
-            }
+            // Handle player leaving, in case game over needs to be triggered
+            this.gameOverHandler.playerLeft(player);
             player.left = true;
         }
+    }
+
+    /** Whether this player can leave the game without automatically conceding */
+    canSafelyLeave(player) {
+        return (
+            !player.isPlaying() ||
+            this.isGameOver ||
+            !this.disconnectHandler.mustWaitForReconnections(player)
+        );
+    }
+
+    isDisconnected(player) {
+        return this.disconnectHandler.isDisconnected(player);
+    }
+
+    isLongDisconnected(player) {
+        return this.disconnectHandler.isLongDisconnected(player);
     }
 
     disconnect(playerName) {
@@ -1318,12 +1334,7 @@ class Game extends EventEmitter {
         if (player.isSpectator()) {
             delete this.playersAndSpectators[playerName];
         } else {
-            this.addAlert(
-                'warning',
-                '{0} has disconnected.  The game will wait up to 30 seconds for them to reconnect',
-                player
-            );
-            player.disconnectedAt = new Date();
+            this.disconnectHandler.disconnected(player);
         }
 
         player.socket = undefined;
@@ -1339,10 +1350,7 @@ class Game extends EventEmitter {
         if (player.isSpectator() || !this.started) {
             delete this.playersAndSpectators[playerName];
         } else {
-            this.addAlert('danger', '{0} has failed to connect to the game', player);
-
-            player.disconnectedAt = new Date();
-            this.gameOverHandler.playerDisconnected(player);
+            this.disconnectHandler.failedConnection(player);
         }
     }
 
@@ -1354,9 +1362,7 @@ class Game extends EventEmitter {
 
         player.id = socket.id;
         player.socket = socket;
-        player.disconnectedAt = undefined;
-
-        this.addAlert('info', '{0} has reconnected', player);
+        this.disconnectHandler.reconnected(player);
     }
 
     rematch() {
@@ -1398,7 +1404,7 @@ class Game extends EventEmitter {
     }
 
     getSaveState() {
-        var players = this.getPlayers().map((player) => {
+        var players = this.getAllPlayers().map((player) => {
             return {
                 name: player.name,
                 faction: player.faction.name || player.faction.value,
@@ -1442,7 +1448,8 @@ class Game extends EventEmitter {
                 showHand: this.showHand,
                 spectators: this.getSpectators().map((spectator) => spectator.getState()),
                 started: this.started,
-                winner: this.winner ? this.winner.name : undefined,
+                gameOver: this.isGameOver,
+                winner: this.results?.winner?.name,
                 gameFormat: this.gameFormat,
                 maxPlayers: this.maxPlayers,
                 cancelPromptUsed: this.cancelPromptUsed,
@@ -1509,6 +1516,7 @@ class Game extends EventEmitter {
             showHand: this.showHand,
             started: this.started,
             startedAt: this.startedAt,
+            finishedAt: this.finishedAt,
             spectators: this.getSpectators().map((spectator) => {
                 return {
                     id: spectator.id,

--- a/server/game/gamesteps/GameOverPrompt.js
+++ b/server/game/gamesteps/GameOverPrompt.js
@@ -46,7 +46,7 @@ class GameOverPrompt extends AllPlayerPrompt {
         let message = arg === 'continue' ? 'to continue' : 'a rematch';
         this.game.addMessage('{0} would like {1}', player, message);
 
-        this.clickedButton[player.name] = true;
+        this.clickedButton[player.name] = arg;
 
         if (arg === 'rematch') {
             this.game.queueStep(new RematchPrompt(this.game, player));
@@ -55,6 +55,13 @@ class GameOverPrompt extends AllPlayerPrompt {
         }
 
         return true;
+    }
+
+    onCompleted() {
+        const responses = Object.values(this.clickedButton);
+        if (responses.every((r) => r === 'continue')) {
+            this.game.isPostGameOver = true;
+        }
     }
 
     getPromptablePlayers() {

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -1,11 +1,11 @@
 import UIPrompt from '../uiprompt.js';
 
 class FirstPlayerPrompt extends UIPrompt {
-    constructor(game, player, reprocessSteps = []) {
+    constructor(game, player, reprocess = () => true) {
         super(game);
 
         this.player = player;
-        this.reprocessSteps = reprocessSteps;
+        this.reprocess = reprocess;
     }
 
     activeCondition(player) {
@@ -62,9 +62,7 @@ class FirstPlayerPrompt extends UIPrompt {
     checkPlayer() {
         const checkPlayer = super.checkPlayer();
         if (!checkPlayer) {
-            for (const step of this.reprocessSteps) {
-                this.game.queueStep(step);
-            }
+            this.reprocess();
         }
         return checkPlayer;
     }

--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -119,7 +119,7 @@ class SelectPlotPrompt extends AllPlayerPrompt {
     }
 
     continue() {
-        for (let player of this.game.getPlayers()) {
+        for (let player of this.getPromptablePlayers()) {
             if (!this.completionCondition(player)) {
                 this.highlightSelectableCards(player);
             }

--- a/server/game/gamesteps/revealplots.js
+++ b/server/game/gamesteps/revealplots.js
@@ -55,13 +55,15 @@ class RevealPlots extends BaseStep {
             this.game.addSimultaneousEffects(this.getPlotEffects(plots));
             if (this.needsFirstPlayerChoice()) {
                 this.game.raiseEvent('onCompareInitiative', {});
-                const initiativeSteps = [
-                    () => new SimpleStep(this.game, () => this.determineInitiative()),
-                    () => new FirstPlayerPrompt(this.game, this.initiativeWinner, initiativeSteps)
-                ];
-                for (const step of initiativeSteps) {
-                    this.game.queueStep(step);
-                }
+                const initiativeSteps = () => {
+                    this.game.queueStep(
+                        new SimpleStep(this.game, () => this.determineInitiative())
+                    );
+                    this.game.queueStep(
+                        new FirstPlayerPrompt(this.game, this.initiativeWinner, initiativeSteps)
+                    );
+                };
+                initiativeSteps();
             }
         });
 
@@ -86,7 +88,8 @@ class RevealPlots extends BaseStep {
     }
 
     needsFirstPlayerChoice() {
-        return this.game.getPlayers().every((player) => !player.firstPlayer);
+        const players = this.game.getPlayers();
+        return players.length > 0 && players.every((player) => !player.firstPlayer);
     }
 
     determineInitiative() {

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -1,3 +1,4 @@
+import sample from 'lodash.sample';
 import Phase from './phase.js';
 import SimpleStep from './simplestep.js';
 import KeepOrMulliganPrompt from './setup/keepormulliganprompt.js';
@@ -12,6 +13,7 @@ class SetupPhase extends Phase {
         this.initialise([
             new SimpleStep(game, () => this.announceFactionAndAgenda()),
             new SimpleStep(game, () => this.prepareDecks()),
+            new SimpleStep(game, () => this.randomFirstPlayer()),
             new SimpleStep(game, () => this.turnOnEffects()),
             new SimpleStep(game, () => this.drawSetupHand()),
             new KeepOrMulliganPrompt(game),
@@ -22,6 +24,7 @@ class SetupPhase extends Phase {
             new CheckAttachmentsPrompt(game),
             new SimpleStep(game, () => game.activatePersistentEffects())
         ]);
+        this.sampleFunc = sample;
     }
 
     announceFactionAndAgenda() {
@@ -42,6 +45,12 @@ class SetupPhase extends Phase {
         }
         this.game.gatherAllCards();
         this.game.raiseEvent('onDecksPrepared');
+    }
+
+    randomFirstPlayer() {
+        const firstPlayer = this.sampleFunc(this.game.getPlayers());
+        this.game.addMessage('{0} has been randomly selected to be first player', firstPlayer);
+        this.game.setFirstPlayer(firstPlayer);
     }
 
     turnOnEffects() {

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -79,7 +79,7 @@ class UiPrompt extends BaseStep {
             this.setPrompt();
         }
 
-        return completed;
+        return completed && !this.game.isEmpty(false);
     }
 
     clearPrompts() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -110,7 +110,7 @@ class Player extends Spectator {
     }
 
     isPlaying() {
-        return !this.isSpectator() && !this.left && !this.eliminated;
+        return !this.isSpectator() && !this.left && (!this.eliminated || this.game.isPostGameOver);
     }
 
     anyCardsInPlay(predicateOrMatcher) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1403,7 +1403,9 @@ class Player extends Spectator {
             isPlaying: this.isPlaying(),
             left: this.left,
             eliminated: !!this.eliminated,
-            disconnected: !!this.disconnectedAt,
+            disconnected: this.game.isDisconnected(this),
+            longDisconnected: this.game.isLongDisconnected(this),
+            canSafelyLeave: this.game.canSafelyLeave(this),
             seatNo: this.seatNo,
             activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
             agendas: this.agendas

--- a/server/game/spectator.js
+++ b/server/game/spectator.js
@@ -41,7 +41,8 @@ class Spectator {
             timerSettings: this.timerSettings,
             keywordSettings: this.keywordSettings,
             promptedActionWindows: this.promptedActionWindows,
-            ...promptState
+            ...promptState,
+            canSafelyLeave: this.game.canSafelyLeave(this)
         };
     }
 }

--- a/server/game/spectator.js
+++ b/server/game/spectator.js
@@ -42,7 +42,7 @@ class Spectator {
             keywordSettings: this.keywordSettings,
             promptedActionWindows: this.promptedActionWindows,
             ...promptState,
-            canSafelyLeave: this.game.canSafelyLeave(this)
+            canSafelyLeave: true
         };
     }
 }

--- a/server/game/timeLimit.js
+++ b/server/game/timeLimit.js
@@ -67,11 +67,10 @@ class TimeLimit {
             const timeLeft = this.calculateTimeLeft();
             if (timeLeft === 0) {
                 this.stop();
-                this.enabled = false;
                 this.game.timeLimitExpired();
-
-                clearInterval(this.timer);
-                delete this.timer;
+                this.enabled = false;
+                // Game state needs to explicitly be sent, as this method was triggered by a server-side timer
+                this.game.sendGameState();
             }
         }
     }

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -256,7 +256,7 @@ class GameServer {
             packData: this.packData,
             restrictedListData: this.restrictedListData
         });
-        game.on('onTimeExpired', () => {
+        game.on('sendGameState', () => {
             this.sendGameState(game);
         });
         this.games[pendingGame.id] = game;

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -380,6 +380,8 @@ class GameServer {
         if (game.isDisconnected(player)) {
             logger.info("user '%s' reconnected to game", socket.user.username);
             game.reconnect(socket, player.name);
+        } else {
+            game.addAlert('info', '{0} has connected to the game server', player);
         }
 
         socket.joinChannel(game.id);

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -377,11 +377,13 @@ class GameServer {
         player.lobbyId = player.id;
         player.id = socket.id;
         player.connectionSucceeded = true;
-        if (game.isDisconnected(player)) {
-            logger.info("user '%s' reconnected to game", socket.user.username);
-            game.reconnect(socket, player.name);
-        } else {
-            game.addAlert('info', '{0} has connected to the game server', player);
+        if (!player.isSpectator()) {
+            if (game.isDisconnected(player)) {
+                logger.info("user '%s' reconnected to game", socket.user.username);
+                game.reconnect(socket, player.name);
+            } else {
+                game.addAlert('info', '{0} has connected to the game server', player);
+            }
         }
 
         socket.joinChannel(game.id);

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -856,16 +856,20 @@ class Lobby {
             name: game.name,
             event: game.event,
             restrictedList: game.restrictedList,
-            spectators: game.allowSpectators,
+            allowSpectators: game.allowSpectators,
             showHand: game.showHand,
+            gamePrivate: game.gamePrivate,
             gameFormat: game.gameFormat,
             gameType: game.gameType,
-            gamePrivate: game.gamePrivate,
             useGameTimeLimit: game.useGameTimeLimit,
             gameTimeLimit: game.gameTimeLimit,
+            muteSpectators: game.muteSpectators,
             useChessClocks: game.useChessClocks,
             chessClockTimeLimit: game.chessClockTimeLimit,
-            chessClockDelay: game.chessClockDelay
+            chessClockDelay: game.chessClockDelay,
+            maxPlayers: game.maxPlayers,
+            randomSeats: game.randomSeats,
+            allowMultipleWinners: game.allowMultipleWinners
         });
         newGame.rematch = true;
 
@@ -887,7 +891,7 @@ class Lobby {
         socket.joinChannel(newGame.id);
         this.sendGameState(newGame);
 
-        let promises = [this.onSelectDeck(socket, newGame.id, owner.deck._id)];
+        let promises = [this.onSelectDeck(socket, owner.deck._id)];
 
         for (let player of Object.values(game.getPlayers()).filter(
             (player) => player.name !== newGame.owner.username
@@ -902,7 +906,7 @@ class Lobby {
             }
 
             newGame.join(socket.id, player.user);
-            promises.push(this.onSelectDeck(socket, newGame.id, player.deck._id));
+            promises.push(this.onSelectDeck(socket, player.deck._id));
         }
 
         for (let spectator of game.getSpectators()) {
@@ -1020,7 +1024,7 @@ class Lobby {
             }
 
             let syncGame = new PendingGame(new User(owner.user), game.instance, {
-                spectators: game.allowSpectators,
+                allowSpectators: game.allowSpectators,
                 name: game.name,
                 event: game.event
             });

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -41,9 +41,7 @@ class GameFlowWrapper {
             gameFormat: options.gameFormat,
             noTitleSetAside: true,
             maxPlayers: options.maxPlayers || numOfPlayers,
-            players: this.generatePlayerDetails(numOfPlayers),
-            useGameTimeLimit: options.useGameTimeLimit ?? false,
-            gameTimeLimit: options.gameTimeLimit
+            players: this.generatePlayerDetails(numOfPlayers)
         };
         this.game = new Game(details, { router: gameRouter, titleCardData: titleCardData });
         this.game.started = true;

--- a/test/server/game/playermanagement.spec.js
+++ b/test/server/game/playermanagement.spec.js
@@ -112,6 +112,7 @@ describe('Game', function () {
 
             describe('when the game has started', function () {
                 beforeEach(function () {
+                    this.game.join('2', { username: 'bar', settings: {} });
                     this.game.started = true;
                 });
 
@@ -121,7 +122,6 @@ describe('Game', function () {
                     });
 
                     it('should mark the player as left', function () {
-                        this.game.leave('foo');
                         expect(this.game.playersAndSpectators['foo'].left).toBe(true);
                     });
 
@@ -162,22 +162,111 @@ describe('Game', function () {
         describe('when the user is a player', function () {
             beforeEach(function () {
                 this.game.join('1', { username: 'foo', settings: {} });
+                this.game.join('2', { username: 'bar', settings: {} });
+                this.player1 = this.game.playersAndSpectators['foo'];
+                this.player2 = this.game.playersAndSpectators['bar'];
             });
 
             it('should mark the player as disconnected', function () {
-                this.game.disconnect('foo');
-                expect(this.game.playersAndSpectators['foo'].disconnectedAt).not.toBe(undefined);
+                this.game.disconnect(this.player1.name);
+                expect(this.game.isDisconnected(this.player1)).toBe(true);
+            });
+
+            it('should initially wait for the player to reconnect', function () {
+                spyOn(this.game.disconnectHandler, 'waitForReconnect').and.callFake(() => true);
+                this.game.disconnect(this.player1.name);
+                expect(this.game.disconnectHandler.waitForReconnect).toHaveBeenCalledWith(
+                    this.player1,
+                    jasmine.any(Function)
+                );
+            });
+
+            it('should not allow opponents to leave safely', function () {
+                expect(this.game.canSafelyLeave(this.player2)).toBe(false);
+            });
+
+            describe('and they have disconnected beyond the wait period', function () {
+                beforeEach(function () {
+                    // Call "handler" without waiting
+                    spyOn(this.game.disconnectHandler, 'waitForReconnect').and.callFake(
+                        (player, handler) => handler(player)
+                    );
+                });
+
+                it('should mark the player as long disconnected', function () {
+                    this.game.disconnect(this.player1.name);
+                    expect(this.game.isLongDisconnected(this.player1)).toBe(true);
+                });
+
+                describe('and it is joust', function () {
+                    beforeEach(function () {
+                        this.game.gameFormat = 'joust';
+                        this.game.started = true;
+
+                        this.game.disconnect(this.player1.name);
+                    });
+
+                    it('should allow the opponent to safely leave without auto-conceding', function () {
+                        expect(this.game.canSafelyLeave(this.player2)).toBe(true);
+                    });
+                });
+
+                describe('and it is melee', function () {
+                    beforeEach(function () {
+                        this.game.gameFormat = 'melee';
+                        this.game.maxPlayers = 3;
+                        this.game.join('2', { username: 'bar', settings: {} });
+                        this.game.join('3', { username: 'baz', settings: {} });
+                        this.player2 = this.game.playersAndSpectators['bar'];
+                        this.player3 = this.game.playersAndSpectators['baz'];
+                        // Populate player decks so they are not auto-eliminated
+                        for (const player of [this.player1, this.player2, this.player3]) {
+                            player.drawCards = [
+                                { name: 'card1' },
+                                { name: 'card2' },
+                                { name: 'card3' }
+                            ];
+                        }
+                        this.game.started = true;
+
+                        this.game.disconnect(this.player1.name);
+                    });
+
+                    it('should not allow opponents to safely leave without auto-conceding', function () {
+                        expect(this.game.canSafelyLeave(this.player2)).toBe(false);
+                        expect(this.game.canSafelyLeave(this.player3)).toBe(false);
+                    });
+                    it('should allow the opponents to vote on waiting or eliminating that player', function () {
+                        expect(this.player2).toHavePrompt('Wait for foo?');
+                        expect(this.player2).toHavePromptButton('Yes');
+                        expect(this.player2).toHavePromptButton('No (Eliminate)');
+                        expect(this.player3).toHavePrompt('Wait for foo?');
+                        expect(this.player3).toHavePromptButton('Yes');
+                        expect(this.player3).toHavePromptButton('No (Eliminate)');
+                    });
+
+                    describe('and all but 1 player has left', function () {
+                        beforeEach(function () {
+                            this.game.disconnect(this.player2.name);
+                        });
+
+                        it('should not allow last opponent to leave without auto-conceding', function () {
+                            expect(this.game.canSafelyLeave(this.player3)).toBe(false);
+                        });
+                    });
+                });
             });
         });
 
         describe('when the user is a spectator', function () {
             beforeEach(function () {
                 this.game.watch('1', { username: 'foo', settings: {} });
-                this.game.disconnect('foo');
+                this.spectator1 = this.game.playersAndSpectators['foo'];
+                this.game.disconnect(this.spectator1.name);
             });
 
             it('should delete the spectator', function () {
-                expect(this.game.playersAndSpectators['foo']).toBeUndefined();
+                expect(this.game.playersAndSpectators[this.spectator1.name]).toBeUndefined();
             });
         });
     });
@@ -185,6 +274,7 @@ describe('Game', function () {
     describe('reconnect()', function () {
         beforeEach(function () {
             this.game.join('1', { username: 'foo', settings: {} });
+            this.player1 = this.game.playersAndSpectators['foo'];
             this.game.disconnect('foo');
             this.game.reconnect({ id: '2' }, 'foo');
         });
@@ -198,7 +288,7 @@ describe('Game', function () {
         });
 
         it('should mark the player as no longer disconnected', function () {
-            expect(this.game.playersAndSpectators['foo'].disconnectedAt).toBe(undefined);
+            expect(this.game.isDisconnected(this.player1)).toBe(false);
         });
     });
 
@@ -232,10 +322,27 @@ describe('Game', function () {
                 expect(this.game.isEmpty()).toBe(false);
             });
 
-            it('should return true if everyone has left or disconnected', function () {
+            it('should return true if everyone has left', function () {
                 this.game.leave('foo');
                 this.game.leave('bar');
                 this.game.leave('baz');
+                expect(this.game.isEmpty()).toBe(true);
+            });
+
+            it('should return false if everyone has disconnected for a short period of time', function () {
+                this.game.disconnect('foo');
+                this.game.disconnect('bar');
+                this.game.disconnect('baz');
+                expect(this.game.isEmpty()).toBe(false);
+            });
+
+            it('should return true if everyone has disconnected for a long period of time', function () {
+                spyOn(this.game.disconnectHandler, 'waitForReconnect').and.callFake(
+                    (player, handler) => handler(player)
+                );
+                this.game.disconnect('foo');
+                this.game.disconnect('bar');
+                this.game.disconnect('baz');
                 expect(this.game.isEmpty()).toBe(true);
             });
         });

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -5,7 +5,11 @@ describe('the PlayerOrderPrompt', function () {
         this.activePrompt = { active: true };
         this.waitingPrompt = { active: false };
 
-        this.game = jasmine.createSpyObj('game', ['getPlayers', 'getPlayersInFirstPlayerOrder']);
+        this.game = jasmine.createSpyObj('game', [
+            'getPlayers',
+            'getPlayersInFirstPlayerOrder',
+            'isEmpty'
+        ]);
         this.player1 = jasmine.createSpyObj('player1', [
             'setPrompt',
             'cancelPrompt',

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -13,7 +13,12 @@ describe('the SelectCardPrompt', function () {
     }
 
     beforeEach(function () {
-        this.game = jasmine.createSpyObj('game', ['getPlayers', 'getNumberOfPlayers', 'allCards']);
+        this.game = jasmine.createSpyObj('game', [
+            'getPlayers',
+            'getNumberOfPlayers',
+            'allCards',
+            'isEmpty'
+        ]);
         this.player = jasmine.createSpyObj('player1', [
             'setPrompt',
             'cancelPrompt',

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -15,7 +15,7 @@ describe('the UiPrompt', function () {
         ]);
         this.player2.isPlaying = () => !this.player2.eliminated && !this.player2.left;
 
-        this.game = jasmine.createSpyObj('game', ['getPlayers']);
+        this.game = jasmine.createSpyObj('game', ['getPlayers', 'isEmpty']);
         this.game.getPlayers.and.returnValue([this.player1, this.player2]);
 
         this.activePrompt = {


### PR DESCRIPTION
- Added `DisconnectHandler` which has more refined logic for how to handle both Joust & Melee games for when players disconnect. In essence:
  - For Joust games, if a player disconnects over 30 seconds, the opponent can leave without penalty/conceding
  - For Melee games, if a player disconnects over 30 seconds, opponents will vote to wait an additional 30 seconds or eliminate them, repeating until they reconnect or are eliminated
  - 30 seconds is default, is configurable on the backend and might be worth configuring on the front end (or only for events?)
- Fixed the bug causing the game node to crash by ensuring the `Rematch` prompt stops the game loop once rematching.
  - Also ensured initiative cannot be re-compared if there are no players
- Added a warning message for game closing 1 minute before its cut off
- Other minor bugfixes or improvements