### PR TITLE
bugfixes

### DIFF
--- a/server/game/GameActions/RevealTopCards.js
+++ b/server/game/GameActions/RevealTopCards.js
@@ -13,7 +13,7 @@ class RevealTopCards extends GameAction {
 
     canChangeGameState({ amount = 1, player, context }) {
         player = player || context.player;
-        return amount > 0 && player.drawDeck.length >= amount;
+        return amount > 0 && player.drawDeck.length > 0;
     }
 
     createEvent({

--- a/server/game/gamesteps/AbilityChoicePrompt.js
+++ b/server/game/gamesteps/AbilityChoicePrompt.js
@@ -38,14 +38,16 @@ class AbilityChoicePrompt extends BaseStep {
                     card: choice.card,
                     mapCard: true,
                     method: 'chooseAbilityChoice',
-                    disabled: () => !choice.gameAction.allow(this.context)
+                    disabled: () =>
+                        !choice.gameAction.allow(this.context) || !choice.condition(this.context)
                 };
             }
             return {
                 text: choice.text,
                 arg: choice.text,
                 method: 'chooseAbilityChoice',
-                disabled: () => !choice.gameAction.allow(this.context)
+                disabled: () =>
+                    !choice.gameAction.allow(this.context) || !choice.condition(this.context)
             };
         });
 


### PR DESCRIPTION
- `RevealTopCards.js`: bug where "reveal the top x" cards would not reveal anything if there are fewer than x cards left in the deck
- `AbilityChoicePrompt.js`: bug where choice prompts would disregard choice conditions when determining if choices are allowed. This is related to #3615 and specifically happens when using choices with `genericHandler` in which case `allow()` always returns true.