### PR TITLE
Hotfix for leaving & clearing

### DIFF
--- a/server/game/GameHandlers/GameOverHandler.js
+++ b/server/game/GameHandlers/GameOverHandler.js
@@ -237,6 +237,9 @@ class GameOverHandler {
      * @param  {...Player} winners the players who have won the game (if multiple players can win the game)
      */
     gameOver(reason = 'draw', ...winners) {
+        if (this.isGameOver) {
+            return;
+        }
         const finishedAt = new Date();
         this.isGameOver = true;
 

--- a/server/game/TextHelper.js
+++ b/server/game/TextHelper.js
@@ -49,11 +49,11 @@ const TextHelper = {
         const seconds = totalSeconds % 60;
 
         if (minutes > 0 && seconds > 0) {
-            return `${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${seconds !== 1 ? 's' : ''}`;
+            return `${minutes} minute${Math.abs(minutes) !== 1 ? 's' : ''} and ${seconds} second${Math.abs(seconds) !== 1 ? 's' : ''}`;
         } else if (minutes > 0) {
-            return `${minutes} minute${minutes !== 1 ? 's' : ''}`;
+            return `${minutes} minute${Math.abs(minutes) !== 1 ? 's' : ''}`;
         } else {
-            return `${seconds} second${seconds !== 1 ? 's' : ''}`;
+            return `${seconds} second${Math.abs(seconds) !== 1 ? 's' : ''}`;
         }
     }
 };


### PR DESCRIPTION
Fixing the following bugs:
- Players leaving after the game is over was accidentally triggering another `gameOver` as a draw (since it was safe for them to leave). Fixed by just ensuring that `gameOver` doesn't trigger if the game is already over (seems like a better wide-range fix)
- Fixed a bug with clearing stale games, where I made an oopsie and was checking the game closing warning **before** the game close check, meaning it never could reach the game closing section.
  - I have fixed this, and just slightly improved the wording on the warning as well so it actually tells you the remaining time, rather than the "waiting time"
 
Apologies! Message me on discord for any questions