### PR TITLE
Bulk of small fixes

### DIFF
--- a/client/Components/GameBoard/GameBoardLayouts/JoustGameBoardLayout.jsx
+++ b/client/Components/GameBoard/GameBoardLayouts/JoustGameBoardLayout.jsx
@@ -104,7 +104,7 @@ const JoustGameBoardLayout = ({
         ]
     );
     return (
-        <div className='min-h-full min-w-max grid grid-cols-1 grid-rows-[repeat(2,auto)]'>
+        <div className='min-h-full min-w-max grid grid-cols-1 grid-rows-[repeat(2,1fr)]'>
             {renderPlayerBoard(otherPlayer, 'top')}
             {renderPlayerBoard(thisPlayer, 'bottom')}
         </div>

--- a/client/Components/GameBoard/GameBoardLayouts/MeleeGameBoardLayout.jsx
+++ b/client/Components/GameBoard/GameBoardLayouts/MeleeGameBoardLayout.jsx
@@ -169,7 +169,7 @@ const MeleeGameBoardLayout = ({
     }, [otherPlayers, thisPlayer, renderPlayerBoard]);
 
     return (
-        <div className='min-h-full min-w-max grid grid-flow-col auto-cols-auto grid-rows-[repeat(2,auto)]'>
+        <div className='min-h-full min-w-max grid grid-flow-col auto-cols-auto grid-rows-[repeat(2,1fr)]'>
             {playerBoardsGrid}
         </div>
     );

--- a/deck-helper/AgendaRules.js
+++ b/deck-helper/AgendaRules.js
@@ -147,7 +147,7 @@ const agendaRules = {
     },
     // Kingdom of Shadows
     13079: {
-        mayInclude: (card) => !card.loyal && hasKeyword(card, /Shadow \(\d+\)/)
+        mayInclude: (card) => !card.loyal && hasKeyword(card, /Shadow \((\d+|X)\)/)
     },
     // The White Book
     13099: {
@@ -209,7 +209,7 @@ const agendaRules = {
     },
     // Kingdom of Shadows (Redesign)
     17148: {
-        mayInclude: (card) => !card.loyal && hasKeyword(card, /Shadow \(\d+\)/)
+        mayInclude: (card) => !card.loyal && hasKeyword(card, /Shadow \((\d+|X)\)/)
     },
     // Sea of Blood (Redesign)
     17149: {

--- a/server/game/cards/12-KotI/HeirToTheIronThrone.js
+++ b/server/game/cards/12-KotI/HeirToTheIronThrone.js
@@ -14,27 +14,27 @@ class HeirToTheIronThrone extends PlotCard {
                 message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay((context) => ({
                     card: context.searchTarget
-                })).then({
-                    condition: (context) =>
-                        context.parentContext.searchTarget.location === 'play area',
-                    activePromptTitle: 'Select character to sacrifice',
-                    target: {
-                        cardCondition: {
-                            type: 'character',
-                            trait: ['Lord', 'Lady'],
-                            location: 'play area',
-                            controller: 'current'
-                        },
-                        gameAction: 'sacrifice'
+                }))
+            }).then({
+                condition: (context) =>
+                    context.parentContext.searchTarget?.location === 'play area',
+                activePromptTitle: 'Select character to sacrifice',
+                target: {
+                    cardCondition: {
+                        type: 'character',
+                        trait: ['Lord', 'Lady'],
+                        location: 'play area',
+                        controller: 'current'
                     },
-                    message: 'Then, {player} sacrifices {target}',
-                    handler: (context) => {
-                        this.game.resolveGameAction(
-                            GameActions.sacrificeCard((context) => ({ card: context.target })),
-                            context
-                        );
-                    }
-                })
+                    gameAction: 'sacrifice'
+                },
+                message: 'Then, {player} sacrifices {target}',
+                handler: (context) => {
+                    this.game.resolveGameAction(
+                        GameActions.sacrificeCard((context) => ({ card: context.target })),
+                        context
+                    );
+                }
             })
         });
     }

--- a/server/game/cards/25.5-TIC/GilbertOfTheVines.js
+++ b/server/game/cards/25.5-TIC/GilbertOfTheVines.js
@@ -2,14 +2,11 @@ import GameActions from '../../GameActions/index.js';
 import DrawCard from '../../drawcard.js';
 
 class GilbertOfTheVines extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
+        this.xValue({ min: () => 1, max: () => this.controller.drawDeck.length });
         this.action({
             title: 'Reveal top X cards of your deck',
             phase: 'challenge',
-            cost: ability.costs.payXGold(
-                () => 1,
-                (context) => context.player.drawDeck.length
-            ),
             message: {
                 format: '{player} plays {source} to reveal the top {amount} cards of their deck',
                 args: { amount: (context) => context.xValue }

--- a/server/game/cards/26.2-WoW/BeneathThePetals.js
+++ b/server/game/cards/26.2-WoW/BeneathThePetals.js
@@ -34,10 +34,11 @@ class BeneathThePetals extends DrawCard {
             }
         });
         this.interrupt({
-            location: ['draw deck'],
             when: {
                 onCardRevealed: (event) => event.card == this && event.card.location === 'draw deck'
             },
+            ignoreEventCosts: true,
+            location: 'draw deck',
             message: '{player} places {source} in shadows and gains 1 gold',
             gameAction: GameActions.simultaneously([
                 GameActions.placeCard({ card: this, location: 'shadows' }),

--- a/server/game/cards/26.2-WoW/JoffreysCrossbow.js
+++ b/server/game/cards/26.2-WoW/JoffreysCrossbow.js
@@ -9,7 +9,9 @@ class JoffreysCrossbow extends DrawCard {
         this.persistentEffect({
             condition: () =>
                 this.game.isDuringChallenge({ challengeType: 'military' }) &&
+                this.parent &&
                 this.parent.isAttacking(),
+            targetController: 'any',
             match: (card) => card.getType() === 'character' && card.isUnique(),
             effect: ability.effects.mustChooseAsClaim()
         });

--- a/test/server/gamesteps/revealplots.spec.js
+++ b/test/server/gamesteps/revealplots.spec.js
@@ -2,20 +2,19 @@ import RevealPlots from '../../../server/game/gamesteps/revealplots.js';
 
 describe('RevealPlots', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'getPlayers', 'raiseEvent']);
+        this.gameSpy = jasmine.createSpyObj('game', [
+            'addMessage',
+            'getPlayers',
+            'raiseEvent',
+            'queueStep'
+        ]);
         this.phase = new RevealPlots(this.gameSpy, []);
     });
 
     describe('getInitiativeResult()', function () {
         beforeEach(function () {
-            this.player1Spy = jasmine.createSpyObj('player', [
-                'getInitiative',
-                'getTotalPower'
-            ]);
-            this.player2Spy = jasmine.createSpyObj('player', [
-                'getInitiative',
-                'getTotalPower'
-            ]);
+            this.player1Spy = jasmine.createSpyObj('player', ['getInitiative', 'getTotalPower']);
+            this.player2Spy = jasmine.createSpyObj('player', ['getInitiative', 'getTotalPower']);
             this.gameSpy.getPlayers.and.returnValue([this.player1Spy, this.player2Spy]);
         });
 
@@ -61,7 +60,28 @@ describe('RevealPlots', function () {
                     })
                 );
             });
-            // TODO: Add scenario to choose winner from tie
+        });
+
+        describe('when initiative is tied and a player can choose the winner', function () {
+            beforeEach(function () {
+                this.player1Spy.getInitiative.and.returnValue(5);
+                this.player1Spy.getTotalPower.and.returnValue(3);
+                this.player1Spy.choosesWinnerForInitiativeTies = true;
+
+                this.player2Spy.getInitiative.and.returnValue(5);
+                this.player2Spy.getTotalPower.and.returnValue(5);
+
+                this.phase.determineInitiative();
+            });
+
+            it('should prompt the player to choose the winner', function () {
+                expect(this.gameSpy.queueStep).toHaveBeenCalledWith(
+                    jasmine.objectContaining({
+                        player: this.player1Spy,
+                        activePromptTitle: 'Choose player to win initiative'
+                    })
+                );
+            });
         });
 
         describe('when initiative and power are tied', function () {


### PR DESCRIPTION
All these fixes were reported on the GOT discord:

✅ Prompt height incorrectly affecting player row height. Player rows will now remain the same height always
✅ Joffrey's Crossbow not working, and erroring when discarded during a challenge
✅ Gilbert of the Vines fixed (was missed in the X update)
✅ Kingdom of Shadows now allows for `Shadow (X)` cards, like House Umber Berserkers
✅ Timing of Heir to the Iron Throne has been corrected so that shuffle happens _before_ the sacrifice. This mattered for Wyman, as it meant you would draw the first card (and see it) before shuffling your deck
✅ Fixed & improved the initiative logic so that it does not trigger twice
✅ Beneath the Petals Interrupt has been fixed

Also added unit test for player choosing ties for initiative.