### PR TITLE
Fixing recent bugs introduces to immunity clearing for Flags

### DIFF
--- a/server/game/ChallengeRestriction.js
+++ b/server/game/ChallengeRestriction.js
@@ -1,5 +1,8 @@
-class ChallengeRestriction {
+import Restriction from './restriction.js';
+
+class ChallengeRestriction extends Restriction {
     constructor(type, opponentCondition = () => true) {
+        super('challenge');
         this.type = type;
         this.opponentCondition = opponentCondition;
     }

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -677,8 +677,7 @@ class BaseCard {
         let currentAbilityContext = context || this.game.currentAbilityContext;
         return !this.abilityRestrictions.some(
             (restriction) =>
-                !this.hasFlag(restriction.name) &&
-                restriction.isMatch(actionType, currentAbilityContext)
+                restriction.isActive(this) && restriction.isMatch(actionType, currentAbilityContext)
         );
     }
 

--- a/server/game/immunityrestriction.js
+++ b/server/game/immunityrestriction.js
@@ -3,9 +3,13 @@ import Restriction from './restriction.js';
 
 class ImmunityRestriction extends Restriction {
     constructor(cardCondition, immunitySource) {
-        super(Flags.losesAspect.immunity);
+        super('immunity');
         this.cardCondition = cardCondition;
         this.immunitySource = immunitySource;
+    }
+
+    isActive(card) {
+        return !card.hasFlag(Flags.losesAspect.immunity);
     }
 
     isMatch(type, abilityContext) {

--- a/server/game/restriction.js
+++ b/server/game/restriction.js
@@ -3,6 +3,10 @@ class Restriction {
         this.name = name;
     }
 
+    isActive() {
+        return true;
+    }
+
     isMatch() {
         return false;
     }

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -200,10 +200,12 @@ describe('BaseCard', function () {
         describe('when there are restrictions', function () {
             beforeEach(function () {
                 this.game.currentAbilityContext = { context: 1 };
-                this.restrictionSpy1 = jasmine.createSpyObj('restriction', ['isMatch']);
+                this.restrictionSpy1 = jasmine.createSpyObj('restriction', ['isMatch', 'isActive']);
                 this.restrictionSpy1.name = 'restriction1';
-                this.restrictionSpy2 = jasmine.createSpyObj('restriction', ['isMatch']);
+                this.restrictionSpy1.isActive.and.returnValue(true);
+                this.restrictionSpy2 = jasmine.createSpyObj('restriction', ['isMatch', 'isActive']);
                 this.restrictionSpy2.name = 'restriction2';
+                this.restrictionSpy2.isActive.and.returnValue(true);
                 this.card.addAbilityRestriction(this.restrictionSpy1);
                 this.card.addAbilityRestriction(this.restrictionSpy2);
             });
@@ -239,6 +241,12 @@ describe('BaseCard', function () {
             describe('but a restriction type is lost', function () {
                 beforeEach(function () {
                     this.card.flags.add('restriction1');
+                    this.restrictionSpy1.isActive.and.callFake(
+                        (card) => !card.hasFlag('restriction1')
+                    );
+                    this.restrictionSpy2.isActive.and.callFake(
+                        (card) => !card.hasFlag('restriction2')
+                    );
                     this.card.markAsDirty();
                 });
 

--- a/test/server/cards/26.1-WAID/MilkwaterCrossing.spec.js
+++ b/test/server/cards/26.1-WAID/MilkwaterCrossing.spec.js
@@ -1,0 +1,43 @@
+describe('Milkwater Crossing', function () {
+    integration(function () {
+        beforeEach(function () {
+            const deck = this.buildDeck('thenightswatch', [
+                'Late Summer Feast',
+                'A Tourney for the King',
+                'Milkwater Crossing',
+                'Hedge Knight',
+                'Nightmares'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.milkwaterCrossing = this.player1.findCardByName('Milkwater Crossing', 'hand');
+            this.nightmares = this.player1.findCardByName('Nightmares', 'hand');
+            this.knight = this.player2.findCardByName('Hedge Knight', 'hand');
+            this.player1.clickCard(this.milkwaterCrossing);
+            this.player2.clickCard(this.knight);
+
+            this.completeSetup();
+        });
+
+        describe('when milkwater crossing is triggered', function () {
+            beforeEach(function () {
+                this.player1Object.gold = 1;
+                this.player1.triggerAbility(this.milkwaterCrossing);
+                this.player1.selectPlot('Late Summer Feast');
+                this.player2.selectPlot('A Tourney for the King');
+            });
+
+            it('should remove all keywords from characters', function () {
+                expect(this.knight.hasKeyword('Renown')).toBe(false);
+            });
+
+            it('should remove all immunity from characters', function () {
+                this.player1.clickCard(this.nightmares);
+                expect(this.player1).toAllowSelect(this.knight);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Checking on restriction name now isn't accurate with how flags are used, and checking that the restriction name is a flag is not accurate to how those names should be used, or how the flags are represented.

Instead, I've added an `isActive` function for restrictions, which should realistically only be used for immunity checks thus far to explicitly check the card does not have that `losesAspect.immunity` flag. If there is somehow a loses aspect flag for "cannot" effects, that restriction type would also be updated.

Other checks like `allowGameAction('kill')` is handled properly in the `CannotRestriction` by checking the "type" of restriction actually matches.