### PR TITLE
Implementing Lord of the Waters

### DIFF
--- a/deck-helper/AgendaRules.js
+++ b/deck-helper/AgendaRules.js
@@ -340,6 +340,23 @@ const agendaRules = {
             }
         ]
     },
+    // Trading with Braavos
+    26080: {
+        mayInclude: (card) => card.type === 'location' && hasTrait(card, 'Warship') && !card.loyal,
+        rules: [
+            {
+                message: 'Cannot include more than 1 copy of each non-limited location',
+                condition: (deck) => {
+                    const locations = deck.drawCards.filter(
+                        (cardQuantity) =>
+                            cardQuantity.card.type === 'location' &&
+                            !hasKeyword(cardQuantity.card, /Limited/)
+                    );
+                    return locations.every((location) => location.count <= 1);
+                }
+            }
+        ]
+    },
     // Draft Agendas
     // The Power of Wealth
     '00001': {

--- a/server/game/GameActions/GainPower.js
+++ b/server/game/GameActions/GainPower.js
@@ -7,22 +7,26 @@ class GainPower extends GameAction {
     }
 
     message({ card, amount = 1, context }) {
+        const actualAmount = card.getPowerToGain(amount);
         if (card.getType() === 'faction') {
             return Message.fragment(
                 `gains {amount} power on ${context.player !== card.controller ? "{player}'s" : 'their'} faction card`,
-                { amount, player: card.controller }
+                { amount: actualAmount, player: card.controller }
             );
         }
 
-        return Message.fragment('gains {amount} power on {card}', { amount, card });
+        return Message.fragment('gains {amount} power on {card}', { amount: actualAmount, card });
     }
 
     canChangeGameState({ card, amount = 1 }) {
-        return ['active plot', 'faction', 'play area'].includes(card.location) && amount > 0;
+        const actualAmount = card.getPowerToGain(amount);
+        return ['active plot', 'faction', 'play area'].includes(card.location) && actualAmount > 0;
     }
 
     createEvent({ card, amount = 1, reason = 'ability' }) {
-        return this.event('onCardPowerGained', { card, power: amount, reason }, (event) => {
+        const actualAmount = card.getPowerToGain(amount);
+        return this.event('onCardPowerGained', { card, power: actualAmount, reason }, (event) => {
+            event.card.controller.gainedPower += event.power;
             event.card.power += event.power;
         });
     }

--- a/server/game/PropertyTypes/StackProperty.js
+++ b/server/game/PropertyTypes/StackProperty.js
@@ -14,10 +14,16 @@ class StackProperty {
     }
 
     remove(value, source) {
-        const tracking = this.stack.findIndex((t) => t.value === value && t.source === source);
+        const tracking = this.stack.findIndex(
+            (t) => (!value || t.value === value) && t.source === source
+        );
         if (tracking >= 0) {
             this.stack.splice(tracking, 1);
         }
+    }
+
+    clear() {
+        this.stack = [];
     }
 
     get() {

--- a/server/game/PropertyTypes/StackProperty.js
+++ b/server/game/PropertyTypes/StackProperty.js
@@ -1,0 +1,37 @@
+class StackProperty {
+    constructor(defaultValue) {
+        this.default = defaultValue;
+        this.stack = [];
+    }
+
+    set(value, source) {
+        const tracking = { value, source };
+        if (!source) {
+            this.stack = [tracking];
+        } else {
+            this.stack.push(tracking);
+        }
+    }
+
+    remove(value, source) {
+        const tracking = this.stack.findIndex((t) => t.value === value && t.source === source);
+        if (tracking >= 0) {
+            this.stack.splice(tracking, 1);
+        }
+    }
+
+    get() {
+        if (this.stack.length === 0) {
+            return this.default;
+        }
+        return this.stack[this.stack.length - 1];
+    }
+
+    clone() {
+        const clonedStack = new StackProperty(this.default);
+        clonedStack.stack = this.stack.map((tracking) => ({ ...tracking }));
+        return clonedStack;
+    }
+}
+
+export default StackProperty;

--- a/server/game/PropertyTypes/StackProperty.js
+++ b/server/game/PropertyTypes/StackProperty.js
@@ -24,7 +24,7 @@ class StackProperty {
         if (this.stack.length === 0) {
             return this.default;
         }
-        return this.stack[this.stack.length - 1];
+        return this.stack[this.stack.length - 1].value;
     }
 
     clone() {

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -4,6 +4,7 @@ import AbilityMessage from './AbilityMessage.js';
 import AbilityTarget from './AbilityTarget.js';
 import ChooseGameAction from './GameActions/ChooseGameAction.js';
 import HandlerGameActionWrapper from './GameActions/HandlerGameActionWrapper.js';
+import StackProperty from './PropertyTypes/StackProperty.js';
 
 /**
  * Base class representing an ability that can be done by the player. This
@@ -31,7 +32,7 @@ class BaseAbility {
         this.choosePlayerDefinition = AbilityChoosePlayerDefinition.create(properties);
         this.limit = properties.limit;
         this.message = AbilityMessage.create(properties.message);
-        this.cannotBeCanceled = !!properties.cannotBeCanceled;
+        this.cannotBeCanceledStack = new StackProperty(!!properties.cannotBeCanceled);
         this.abilitySourceType = properties.abilitySourceType || 'card';
         this.gameAction = this.buildGameAction(properties);
     }
@@ -298,6 +299,18 @@ class BaseAbility {
 
     shouldHideSourceInMessage() {
         return false;
+    }
+
+    get cannotBeCanceled() {
+        return this.cannotBeCanceledStack.get();
+    }
+
+    setCannotBeCanceled(value, source) {
+        this.cannotBeCanceledStack.set(value, source);
+    }
+
+    clearCannotBeCanceled(value, source) {
+        this.cannotBeCanceledStack.remove(value, source);
     }
 }
 

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -483,7 +483,7 @@ class BaseCard {
     }
 
     canGainPower() {
-        return this.allowGameAction('gainPower');
+        return GameActions.gainPower({ card: this }).allow();
     }
 
     getPower() {
@@ -528,6 +528,10 @@ class BaseCard {
         for (let effect of this.getPersistentEffects()) {
             this.game.addEffect(this, effect);
         }
+    }
+
+    getTriggeredAbilities() {
+        return [...this.abilities.actions, ...this.abilities.reactions];
     }
 
     leavesPlay() {}

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -490,6 +490,20 @@ class BaseCard {
         return this.power;
     }
 
+    getPowerToGain(amount) {
+        if (amount < 0) {
+            return 0;
+        }
+        if (this.controller.maxPowerGain.getMax() !== undefined) {
+            return Math.min(
+                amount,
+                this.controller.maxPowerGain.getMax() - this.controller.gainedPower
+            );
+        }
+
+        return amount;
+    }
+
     modifyPower(power) {
         let action =
             power > 0

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -13,6 +13,7 @@ import KeywordsProperty from './PropertyTypes/KeywordsProperty.js';
 import ReferenceCountedSetProperty from './PropertyTypes/ReferenceCountedSetProperty.js';
 import XValueDefinition from './XValueDefinition.js';
 import { Flags, Tokens } from './Constants/index.js';
+import StackProperty from './PropertyTypes/StackProperty.js';
 
 const ValidKeywords = [
     'ambush',
@@ -56,8 +57,8 @@ class BaseCard {
         this.keywords = new KeywordsProperty();
         this.flags = new ReferenceCountedSetProperty();
         this.traits = new ReferenceCountedSetProperty();
-        this.controllerStack = [];
-        this.loyalStack = [];
+        this.controllerStack = new StackProperty(this.owner);
+        this.loyalStack = new StackProperty(!!this.cardData.loyal);
         this.eventsForRegistration = [];
         this.keywordSources = [];
 
@@ -316,8 +317,8 @@ class BaseCard {
     createSnapshot() {
         let clone = new BaseCard(this.owner, this.cardData);
 
-        clone.controllerStack = [...this.controllerStack];
-        clone.loyalStack = [...this.loyalStack];
+        clone.controllerStack = this.controllerStack.clone();
+        clone.loyalStack = this.loyalStack.clone();
         clone.factions = this.factions.clone();
         clone.flags = this.flags.clone();
         clone.location = this.location;
@@ -343,32 +344,20 @@ class BaseCard {
     }
 
     get controller() {
-        if (this.controllerStack.length === 0) {
-            return this.owner;
-        }
-
-        return this.controllerStack[this.controllerStack.length - 1].controller;
+        return this.controllerStack.get();
     }
 
     takeControl(controller, source) {
         if (!source && controller === this.owner) {
-            // On permanent take control by the original owner, revert all take
-            // control effects
-            this.controllerStack = [];
+            this.controllerStack.clear();
             return;
         }
 
-        let tracking = { controller: controller, source: source };
-        if (!source) {
-            // Clear all other take control effects for permanent control
-            this.controllerStack = [tracking];
-        } else {
-            this.controllerStack.push(tracking);
-        }
+        this.controllerStack.set(controller, source);
     }
 
     revertControl(source) {
-        this.controllerStack = this.controllerStack.filter((control) => control.source !== source);
+        this.controllerStack.remove(null, source);
     }
 
     hasFlag(flag) {
@@ -458,24 +447,15 @@ class BaseCard {
     }
 
     isLoyal() {
-        if (this.loyalStack.length === 0) {
-            return !!this.cardData.loyal;
-        }
-
-        return this.loyalStack[this.loyalStack.length - 1];
+        return this.loyalStack.get();
     }
 
     setLoyal(loyal, source) {
-        const tracking = { loyal, source };
-        if (!source) {
-            this.loyalStack = [tracking];
-        } else {
-            this.loyalStack.push(tracking);
-        }
+        this.loyalStack.set(loyal, source);
     }
 
     clearLoyal(source) {
-        this.loyalStack = this.loyalStack.filter((loyalty) => loyalty.source !== source);
+        this.loyalStack.remove(null, source);
     }
 
     canBeSaved() {

--- a/server/game/cards/01-Core/TheQueensAssassin.js
+++ b/server/game/cards/01-Core/TheQueensAssassin.js
@@ -6,7 +6,7 @@ class TheQueensAssassin extends DrawCard {
             when: {
                 onCardEntersPlay: (event) => event.card === this && event.playingType === 'ambush'
             },
-            chooseOpponent: (opponent) => opponent.hand.length < this.controller.hand.length,
+            chooseOpponent: (opponent) => opponent.getHandCount() < this.controller.getHandCount(),
             handler: (context) => {
                 this.game.promptForSelect(context.opponent, {
                     source: this,

--- a/server/game/cards/05-LoCR/GoldenTooth.js
+++ b/server/game/cards/05-LoCR/GoldenTooth.js
@@ -1,4 +1,5 @@
 import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
 
 class GoldenTooth extends DrawCard {
     setupCardAbilities(ability) {
@@ -6,23 +7,17 @@ class GoldenTooth extends DrawCard {
             title: 'Gain gold',
             condition: () => this.controller.canGainGold(),
             cost: ability.costs.kneelSelf(),
-            handler: () => {
-                let gold = this.opponentHasEmptyHand() ? 3 : 1;
-                gold = this.game.addGold(this.controller, gold);
-
-                this.game.addMessage(
-                    '{0} kneels {1} to gain {2} gold',
-                    this.controller,
-                    this,
-                    gold
-                );
-            }
+            message: {
+                format: '{player} kneels {source} to gain {amount} gold',
+                args: { amount: () => this.getAmount() }
+            },
+            gameAction: GameActions.gainGold(() => ({ amount: this.getAmount() }))
         });
     }
 
-    opponentHasEmptyHand() {
+    getAmount() {
         let opponents = this.game.getOpponents(this.controller);
-        return opponents.some((opponent) => opponent.hand.length === 0);
+        return opponents.some((opponent) => opponent.hasNoCardsInHand()) ? 3 : 1;
     }
 }
 

--- a/server/game/cards/05-LoCR/InsidiousScheme.js
+++ b/server/game/cards/05-LoCR/InsidiousScheme.js
@@ -13,7 +13,7 @@ class InsidiousScheme extends DrawCard {
             },
             handler: (context) => {
                 let opponent = context.event.challenge.loser;
-                let cards = opponent.hand.length === 0 ? 4 : 2;
+                let cards = opponent.getHandCount() === 0 ? 4 : 2;
                 cards = this.controller.drawCardsToHand(cards).length;
 
                 this.game.addMessage(

--- a/server/game/cards/05-LoCR/RedKeepSpy.js
+++ b/server/game/cards/05-LoCR/RedKeepSpy.js
@@ -10,7 +10,7 @@ class RedKeepSpy extends DrawCard {
                 cardCondition: (card) =>
                     card.location === 'play area' &&
                     card.controller !== this.controller &&
-                    card.controller.hand.length < this.controller.hand.length &&
+                    card.controller.getHandCount() < this.controller.getHandCount() &&
                     card.getType() === 'character' &&
                     card.getPrintedCost() <= 3
             },

--- a/server/game/cards/05-LoCR/SerBarristanSelmy.js
+++ b/server/game/cards/05-LoCR/SerBarristanSelmy.js
@@ -7,7 +7,7 @@ class SerBarristanSelmy extends DrawCard {
                 afterChallenge: (event) =>
                     event.challenge.winner === this.controller &&
                     this.isParticipating() &&
-                    this.controller.hand.length < event.challenge.loser.hand.length
+                    this.controller.getHandCount() < event.challenge.loser.getHandCount()
             },
             handler: () => {
                 this.controller.standCard(this);

--- a/server/game/cards/05-LoCR/TommenBaratheon.js
+++ b/server/game/cards/05-LoCR/TommenBaratheon.js
@@ -4,7 +4,7 @@ class TommenBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             targetController: 'any',
-            match: (player) => player.hand.length === 0,
+            match: (player) => player.getHandCount() === 0,
             effect: ability.effects.cannotGainChallengeBonus()
         });
     }

--- a/server/game/cards/06.2-GtR/TheDornishmansWife.js
+++ b/server/game/cards/06.2-GtR/TheDornishmansWife.js
@@ -54,7 +54,7 @@ class TheDornishmansWife extends DrawCard {
     }
 
     opponentHasMoreCardsInHand(opponent) {
-        return opponent.hand.length > this.controller.hand.length;
+        return opponent.getHandCount() > this.controller.getHandCount();
     }
 
     opponentControlsMoreCharacters(opponent) {

--- a/server/game/cards/06.3-TFoA/CerseisAttendant.js
+++ b/server/game/cards/06.3-TFoA/CerseisAttendant.js
@@ -16,8 +16,8 @@ class CerseisAttendant extends DrawCard {
         }
 
         return (
-            (this.isAttacking() && challenge.defendingPlayer.hand.length === 0) ||
-            (this.isDefending() && challenge.attackingPlayer.hand.length === 0)
+            (this.isAttacking() && challenge.defendingPlayer.getHandCount() === 0) ||
+            (this.isDefending() && challenge.attackingPlayer.getHandCount() === 0)
         );
     }
 }

--- a/server/game/cards/07-WotW/DothrakiHonorGuard.js
+++ b/server/game/cards/07-WotW/DothrakiHonorGuard.js
@@ -4,7 +4,7 @@ class DothrakiHonorGuard extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            effect: ability.effects.dynamicDecreaseStrength(() => this.controller.hand.length)
+            effect: ability.effects.dynamicDecreaseStrength(() => this.controller.getHandCount())
         });
     }
 }

--- a/server/game/cards/10-SoD/MyrcellaBaratheon.js
+++ b/server/game/cards/10-SoD/MyrcellaBaratheon.js
@@ -18,7 +18,7 @@ class MyrcellaBaratheon extends DrawCard {
 
         return (
             challenge.attackingPlayer === this.controller &&
-            this.controller.hand.length > challenge.defendingPlayer.hand.length
+            this.controller.getHandCount() > challenge.defendingPlayer.getHandCount()
         );
     }
 }

--- a/server/game/cards/11.3-SoKL/PoorFellows.js
+++ b/server/game/cards/11.3-SoKL/PoorFellows.js
@@ -40,7 +40,7 @@ class PoorFellows extends DrawCard {
 
     gainsPower() {
         this.modifyPower(1);
-        this.game.addMessage('{0} gains 1 power on {2}', this.controller, this);
+        this.game.addMessage('{0} gains 1 power on {1}', this.controller, this);
         return true;
     }
 

--- a/server/game/cards/11.5-IDP/ThreeFingerHobb.js
+++ b/server/game/cards/11.5-IDP/ThreeFingerHobb.js
@@ -6,7 +6,7 @@ class ThreeFingerHobb extends DrawCard {
         this.reaction({
             when: {
                 onReserveChecked: () =>
-                    this.controller.hand.length < this.controller.getReserve() &&
+                    this.controller.getHandCount() < this.controller.getReserve() &&
                     this.controller.canDraw()
             },
             handler: (context) => {

--- a/server/game/cards/11.6-DitD/DaggersInTheDark.js
+++ b/server/game/cards/11.6-DitD/DaggersInTheDark.js
@@ -21,7 +21,7 @@ class DaggersInTheDark extends DrawCard {
                 let loser = context.event.challenge.loser;
                 let target = context.target;
 
-                if (!this.playerHas2Characters(loser) || !context.ability.cannotBeCanceled) {
+                if (!this.playerHas2Characters(loser) || context.ability.cannotBeCanceled) {
                     this.resolveKill(target);
                     return;
                 }

--- a/server/game/cards/11.6-DitD/DaggersInTheDark.js
+++ b/server/game/cards/11.6-DitD/DaggersInTheDark.js
@@ -21,7 +21,7 @@ class DaggersInTheDark extends DrawCard {
                 let loser = context.event.challenge.loser;
                 let target = context.target;
 
-                if (!this.playerHas2Characters(loser)) {
+                if (!this.playerHas2Characters(loser) || !context.ability.cannotBeCanceled) {
                     this.resolveKill(target);
                     return;
                 }

--- a/server/game/cards/14-FotS/SiegePreparations.js
+++ b/server/game/cards/14-FotS/SiegePreparations.js
@@ -8,9 +8,9 @@ class SiegePreparations extends PlotCard {
             phase: 'dominance',
             condition: () =>
                 this.controller.canDraw() &&
-                this.controller.getReserve() > this.controller.hand.length,
+                this.controller.getReserve() > this.controller.getHandCount(),
             handler: (context) => {
-                let cardsToDraw = context.player.getReserve() - context.player.hand.length;
+                let cardsToDraw = context.player.getReserve() - context.player.getHandCount();
                 let numDrawn = context.player.drawCardsToHand(cardsToDraw).length;
                 this.game.addMessage(
                     '{0} uses {1} to draw {2}',

--- a/server/game/cards/16-TTWDFL/NarrowEscape.js
+++ b/server/game/cards/16-TTWDFL/NarrowEscape.js
@@ -23,8 +23,8 @@ class NarrowEscape extends DrawCard {
         });
     }
 
-    promptForCancel() {
-        if (this.remainingOpponents.length === 0) {
+    promptForCancel(context) {
+        if (this.remainingOpponents.length === 0 || context.ability.cannotBeCanceled) {
             this.resolvePutIntoPlay();
             return true;
         }

--- a/server/game/cards/16-TTWDFL/RuleByDecree.js
+++ b/server/game/cards/16-TTWDFL/RuleByDecree.js
@@ -8,7 +8,7 @@ class RuleByDegree extends PlotCard {
         this.whenRevealed({
             target: {
                 choosingPlayer: (player) =>
-                    player.hand.length > 4 && player.hand.length === this.getHighestHandSize(),
+                    player.hand.length > 4 && player.getHandCount() === this.getHighestHandSize(),
                 activePromptTitle: 'Select 4 cards to keep',
                 mode: 'exactly',
                 cardCondition: (card, context) =>

--- a/server/game/cards/17.1-R/ThreeFingerHobb.js
+++ b/server/game/cards/17.1-R/ThreeFingerHobb.js
@@ -6,11 +6,11 @@ class ThreeFingerHobb extends DrawCard {
         this.reaction({
             when: {
                 onReserveChecked: () =>
-                    this.controller.hand.length < this.controller.getReserve() &&
+                    this.controller.getHandCount() < this.controller.getReserve() &&
                     this.controller.canDraw()
             },
             handler: (context) => {
-                let cards = context.player.getReserve() > context.player.hand.length + 4 ? 2 : 1;
+                let cards = context.player.getReserve() > context.player.getHandCount() + 4 ? 2 : 1;
                 cards = context.player.drawCardsToHand(cards).length;
                 this.game.addMessage(
                     '{0} uses {1} to draw {2}',

--- a/server/game/cards/19-JS/GreyWorm.js
+++ b/server/game/cards/19-JS/GreyWorm.js
@@ -5,8 +5,8 @@ class GreyWorm extends DrawCard {
         this.persistentEffect({
             condition: () =>
                 this.game.currentChallenge &&
-                this.controller.hand.length <
-                    this.game.currentChallenge.attackingPlayer.hand.length,
+                this.controller.getHandCount() <
+                    this.game.currentChallenge.attackingPlayer.getHandCount(),
             match: this,
             effect: ability.effects.doesNotKneelAsDefender()
         });

--- a/server/game/cards/24-TSoW/Hero.js
+++ b/server/game/cards/24-TSoW/Hero.js
@@ -8,7 +8,7 @@ class Hero extends DrawCard {
                 afterChallenge: (event) =>
                     event.challenge.winner === this.controller &&
                     this.isParticipating() &&
-                    this.controller.hand.length < event.challenge.loser.hand.length
+                    this.controller.getHandCount() < event.challenge.loser.getHandCount()
             },
             target: {
                 cardCondition: {

--- a/server/game/cards/24-TSoW/HighgardenSept.js
+++ b/server/game/cards/24-TSoW/HighgardenSept.js
@@ -5,7 +5,7 @@ class HighgardenSept extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () =>
-                this.controller.hand.length >= 7 && this.game.currentPhase === 'challenge',
+                this.controller.getHandCount() >= 7 && this.game.currentPhase === 'challenge',
             targetController: 'any',
             effect: ability.effects.cannotPutIntoPlay(
                 (card) => card.getType() === 'character' && !card.hasTrait('The Seven')

--- a/server/game/cards/24-TSoW/SerDavenLannister.js
+++ b/server/game/cards/24-TSoW/SerDavenLannister.js
@@ -33,7 +33,9 @@ class SerDavenLannister extends DrawCard {
                 condition: (context) =>
                     context.game
                         .getOpponents(context.player)
-                        .every((opponent) => opponent.hand.length < context.player.hand.length),
+                        .every(
+                            (opponent) => opponent.getHandCount() < context.player.getHandCount()
+                        ),
                 message: 'Then, {player} draws 1 card',
                 gameAction: GameActions.drawCards((context) => ({
                     amount: 1,

--- a/server/game/cards/26.4 LotW/ANewHand.js
+++ b/server/game/cards/26.4 LotW/ANewHand.js
@@ -1,0 +1,32 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class ANewHand extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardLeftPlay: (event) =>
+                    event.cardStateWhenLeftPlay.hasTrait('Small Council') &&
+                    event.cardStateWhenLeftPlay.controller === this.controller
+            },
+            max: ability.limit.perPhase(1),
+            gameAction: GameActions.search({
+                title: 'Select a character',
+                match: {
+                    type: 'character',
+                    trait: 'Small Council',
+                    condition: (card, context) =>
+                        card.name !== context.event.cardStateWhenLeftPlay.name
+                },
+                message: '{player} {gameAction}',
+                gameAction: GameActions.addToHand((context) => ({
+                    card: context.searchTarget
+                }))
+            })
+        });
+    }
+}
+
+ANewHand.code = '26062';
+
+export default ANewHand;

--- a/server/game/cards/26.4 LotW/AboveTheRest.js
+++ b/server/game/cards/26.4 LotW/AboveTheRest.js
@@ -1,0 +1,42 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class AboveTheRest extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardPowerGained: {
+                    aggregateBy: (event) => ({
+                        card: event.card
+                    }),
+                    condition: (aggregate, events) =>
+                        events.length === 1 &&
+                        aggregate.card.controller === this.controller &&
+                        aggregate.card.getType() === 'character'
+                }
+            },
+            max: ability.limit.perPhase(1),
+            message: {
+                format: '{player} plays {source} to have {character} gain 1 power',
+                args: { character: (context) => context.aggregate.card }
+            },
+            gameAction: GameActions.gainPower((context) => ({
+                card: context.aggregate.card,
+                amount: 1
+            })).then((context) => ({
+                condition: () => context.parentcontext.aggregate.card.hasTrait('House Tully'),
+                message: {
+                    format: 'Then, {player} stands {character}',
+                    args: { character: (context) => context.parentContext.aggregate.card }
+                },
+                gameAction: GameActions.standCard((context) => ({
+                    card: context.parentContext.aggregate.card
+                }))
+            }))
+        });
+    }
+}
+
+AboveTheRest.code = '26072';
+
+export default AboveTheRest;

--- a/server/game/cards/26.4 LotW/ConspiratorsBlade.js
+++ b/server/game/cards/26.4 LotW/ConspiratorsBlade.js
@@ -1,0 +1,29 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class ConspiratorsBlade extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.parent && this.parent.isParticipating(),
+            match: (card) => card.getType() === 'event' && card.controller === this.controller,
+            effect: ability.effects.cannotBeCanceled()
+        });
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            message:
+                '{player} uses {source} to reduce the cost of the next card they bring out of shadows this phase by 2',
+            gameAction: GameActions.genericHandler(() => {
+                this.untilEndOfPhase((ability) => ({
+                    targetController: 'current',
+                    effect: ability.effects.reduceNextOutOfShadowsCardCost(2)
+                }));
+            })
+        });
+    }
+}
+
+ConspiratorsBlade.code = '26070';
+
+export default ConspiratorsBlade;

--- a/server/game/cards/26.4 LotW/ConspiratorsBlade.js
+++ b/server/game/cards/26.4 LotW/ConspiratorsBlade.js
@@ -5,6 +5,7 @@ class ConspiratorsBlade extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.parent && this.parent.isParticipating(),
+            targetLocation: 'any',
             match: (card) => card.getType() === 'event' && card.controller === this.controller,
             effect: ability.effects.cannotBeCanceled()
         });

--- a/server/game/cards/26.4 LotW/Dirk.js
+++ b/server/game/cards/26.4 LotW/Dirk.js
@@ -1,0 +1,28 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class Dirk extends DrawCard {
+    setupCardAbilities() {
+        this.forcedReaction({
+            when: {
+                onCardDiscarded: (event) =>
+                    event.card.getType() === 'character' && event.card.location === 'play area'
+            },
+            message: {
+                format: '{controller} is forced by {source} to place {card} in their dead pile',
+                args: {
+                    controller: (context) => context.event.card.controller,
+                    card: (context) => context.event.card
+                }
+            },
+            gameAction: GameActions.placeCard((context) => ({
+                card: context.event.card,
+                location: 'dead pile'
+            }))
+        });
+    }
+}
+
+Dirk.code = '26069';
+
+export default Dirk;

--- a/server/game/cards/26.4 LotW/DornishSloop.js
+++ b/server/game/cards/26.4 LotW/DornishSloop.js
@@ -1,0 +1,43 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class DornishSloop extends DrawCard {
+    setupCardAbilities() {
+        this.plotModifiers({
+            reserve: 1
+        });
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            target: {
+                cardCondition: {
+                    location: 'play area',
+                    type: 'character',
+                    printedCostOrLower: 5,
+                    condition: (card) => GameActions.loseIcon({ card }).allow()
+                }
+            },
+            handler: (context) => {
+                this.game.promptForIcon(this.controller, this, (icon) => {
+                    this.untilEndOfPhase((ability) => ({
+                        match: context.target,
+                        effect: ability.effects.removeIcon(icon)
+                    }));
+
+                    this.game.addMessage(
+                        '{0} chooses to have {1} lose {2} {3} icon until the end of the phase',
+                        this.controller,
+                        context.target,
+                        icon === 'intrigue' ? 'an' : 'a',
+                        icon
+                    );
+                });
+            }
+        });
+    }
+}
+
+DornishSloop.code = '26068';
+
+export default DornishSloop;

--- a/server/game/cards/26.4 LotW/EdricStorm.js
+++ b/server/game/cards/26.4 LotW/EdricStorm.js
@@ -1,0 +1,14 @@
+import DrawCard from '../../drawcard.js';
+
+class EdricStorm extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'any',
+            effect: ability.effects.setMaxPowerGain(3)
+        });
+    }
+}
+
+EdricStorm.code = '26061';
+
+export default EdricStorm;

--- a/server/game/cards/26.4 LotW/GylesRosby.js
+++ b/server/game/cards/26.4 LotW/GylesRosby.js
@@ -1,0 +1,52 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class GylesRosby extends DrawCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+
+        // TODO: Update all gold movements to encompass a single event name
+        this.registerEvents([
+            'onPhaseStarted',
+            'onGoldTransferred',
+            'onCardEntersPlay',
+            'onCardAbilityInitiated'
+        ]);
+    }
+    setupCardAbilities() {
+        this.plotModifiers({
+            gold: 2
+        });
+    }
+
+    onPhaseStarted() {
+        this.checkKill();
+    }
+
+    onGoldTransferred() {
+        this.checkKill();
+    }
+
+    onCardEntersPlay() {
+        this.checkKill();
+    }
+
+    onCardAbilityInitiated() {
+        this.checkKill();
+    }
+
+    checkKill() {
+        if (this.game.currentPhase === 'challenge' && this.controller.gold === 0) {
+            this.game.resolveGameAction(GameActions.kill({ card: this }));
+            this.game.addMessage(
+                '{0} is forced to kill {1} due to having no gold in their gold pool',
+                this.controller,
+                this
+            );
+        }
+    }
+}
+
+GylesRosby.code = '26065';
+
+export default GylesRosby;

--- a/server/game/cards/26.4 LotW/IbbeneseWhaler.js
+++ b/server/game/cards/26.4 LotW/IbbeneseWhaler.js
@@ -5,7 +5,7 @@ class IbbeneseWhaler extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             targetController: 'current',
-            effect: ability.effects.reduceFirstCardCostEachRound('marshalIntoShadows', 1)
+            effect: ability.effects.reduceFirstMarshaledCardIntoShadowsEachRound(1)
         });
         this.action({
             title: 'Draw cards',

--- a/server/game/cards/26.4 LotW/IbbeneseWhaler.js
+++ b/server/game/cards/26.4 LotW/IbbeneseWhaler.js
@@ -1,0 +1,23 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class IbbeneseWhaler extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'current',
+            effect: ability.effects.reduceFirstCardCostEachRound('marshalIntoShadows', 1)
+        });
+        this.action({
+            title: 'Draw cards',
+            phase: 'taxation',
+            condition: (context) => context.player.getHandCount() === 0,
+            cost: [ability.costs.kneelSelf(), ability.costs.putSelfIntoShadows()],
+            message: '{player} kneels {costs.kneel} and returns it to shadows to draw 2 cards',
+            gameAction: GameActions.drawCards({ amount: 2 })
+        });
+    }
+}
+
+IbbeneseWhaler.code = '26078';
+
+export default IbbeneseWhaler;

--- a/server/game/cards/26.4 LotW/KingsLandingDromond.js
+++ b/server/game/cards/26.4 LotW/KingsLandingDromond.js
@@ -1,0 +1,34 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class KingsLandingDromond extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            effect: ability.effects.reduceNumberOfUnspentGoldReturned(1)
+        });
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            target: {
+                cardCondition: {
+                    location: 'play area',
+                    type: 'character',
+                    printedCostOrLower: 2,
+                    condition: (card) => GameActions.returnCardToHand({ card }).allow()
+                }
+            },
+            message: "{player} uses {source} to return {target} to its owner's hand",
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.returnCardToHand((context) => ({ card: context.target })),
+                    context
+                );
+            }
+        });
+    }
+}
+
+KingsLandingDromond.code = '26066';
+
+export default KingsLandingDromond;

--- a/server/game/cards/26.4 LotW/MeggaTyrell.js
+++ b/server/game/cards/26.4 LotW/MeggaTyrell.js
@@ -1,0 +1,27 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class MeggaTyrell extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onRemovedFromChallenge: {
+                    aggregateBy: (event) => ({
+                        cardType: event.card.getType()
+                    }),
+                    condition: (aggregate) => aggregate.cardType === 'character'
+                }
+            },
+            message: '{player} uses {source} to gain 1 power for their faction',
+            gameAction: GameActions.gainPower((context) => ({
+                amount: 1,
+                card: context.player.faction
+            })),
+            limit: ability.limit.perRound(2)
+        });
+    }
+}
+
+MeggaTyrell.code = '26075';
+
+export default MeggaTyrell;

--- a/server/game/cards/26.4 LotW/OrkmontElite.js
+++ b/server/game/cards/26.4 LotW/OrkmontElite.js
@@ -1,0 +1,52 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class OrkmontElite extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.attachments.length >= 1,
+            match: this,
+            effect: ability.effects.addKeyword('Renown')
+        });
+        this.reaction({
+            when: {
+                onCardDiscarded: (event) => event.isPillage && event.source === this
+            },
+            target: {
+                activePromptTitle: 'Select an attachment',
+                cardCondition: (card, context) => this.cardCondition(card, context)
+            },
+            message: {
+                format: "{player} uses {source} to put {target} into play from {opponent}'s discard pile",
+                args: { opponent: () => this.game.currentChallenge.loser }
+            },
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.putIntoPlay((context) => ({
+                        player: context.player,
+                        card: context.target,
+                        attachmentTargets: (card) => card.controller === context.player
+                    })),
+                    context
+                );
+            }
+        });
+    }
+
+    cardCondition(card, context) {
+        return (
+            card.controller === this.game.currentChallenge.loser &&
+            card.getType() === 'attachment' &&
+            card.location === 'discard pile' &&
+            GameActions.putIntoPlay({
+                player: context.player,
+                card,
+                attachmentTargets: (card) => card.controller === context.player
+            }).allow()
+        );
+    }
+}
+
+OrkmontElite.code = '26063';
+
+export default OrkmontElite;

--- a/server/game/cards/26.4 LotW/QartheenGalleas.js
+++ b/server/game/cards/26.4 LotW/QartheenGalleas.js
@@ -1,0 +1,35 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class QartheenGalleas extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'current',
+            effect: ability.effects.modifyHandCount(-1)
+        });
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            target: {
+                cardCondition: {
+                    location: 'discard pile',
+                    controller: 'current',
+                    condition: (card) => card.isShadow()
+                }
+            },
+            message:
+                '{player} uses {source} to return {target} to their hand from their discard pile',
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.returnCardToHand((context) => ({ card: context.target })),
+                    context
+                );
+            }
+        });
+    }
+}
+
+QartheenGalleas.code = '26074';
+
+export default QartheenGalleas;

--- a/server/game/cards/26.4 LotW/ReaversGreataxe.js
+++ b/server/game/cards/26.4 LotW/ReaversGreataxe.js
@@ -1,0 +1,28 @@
+import DrawCard from '../../drawcard.js';
+
+class ReaversGreataxe extends DrawCard {
+    setupCardAbilities(ability) {
+        this.attachmentRestriction({ unique: false, faction: 'greyjoy' });
+        this.whileAttached({
+            effect: ability.effects.addTrait('Raider')
+        });
+        this.whileAttached({
+            condition: () =>
+                this.game.isDuringChallenge({ attackingPlayer: this.controller, number: 1 }) &&
+                this.hasMoreAttachmentsThanDefender(this.game.currentChallenge.defendingPlayer),
+            match: this.parent,
+            effect: ability.effects.doesNotKneelAsAttacker()
+        });
+    }
+
+    hasMoreAttachmentsThanDefender(defendingPlayer) {
+        return (
+            this.controller.getNumberOfCardsInPlay({ type: 'attachment' }) >
+            defendingPlayer.getNumberOfCardsInPlay({ type: 'attachment' })
+        );
+    }
+}
+
+ReaversGreataxe.code = '26064';
+
+export default ReaversGreataxe;

--- a/server/game/cards/26.4 LotW/RedwyneMerchanter.js
+++ b/server/game/cards/26.4 LotW/RedwyneMerchanter.js
@@ -1,0 +1,31 @@
+import DrawCard from '../../drawcard.js';
+
+class RedwyneMerchanter extends DrawCard {
+    setupCardAbilities() {
+        this.plotModifiers({
+            gold: 1
+        });
+        this.reaction({
+            when: {
+                onCardOutOfShadows: (event) => event.card === this
+            },
+            target: {
+                cardCondition: {
+                    location: 'play area',
+                    type: 'character'
+                }
+            },
+            message: '{player} uses {source} to give {target} +2 STR until the end of the phase',
+            handler: (context) => {
+                this.untilEndOfPhase((ability) => ({
+                    match: context.target,
+                    effect: ability.effects.modifyStrength(2)
+                }));
+            }
+        });
+    }
+}
+
+RedwyneMerchanter.code = '26076';
+
+export default RedwyneMerchanter;

--- a/server/game/cards/26.4 LotW/SerHarryStrickland.js
+++ b/server/game/cards/26.4 LotW/SerHarryStrickland.js
@@ -1,0 +1,51 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class SerHarryStrickland extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardEntersPlay: (event) => event.card === this
+            },
+            target: {
+                cardCondition: {
+                    location: 'play area',
+                    type: 'character',
+                    trait: 'Mercenary',
+                    cardCondition: (card) =>
+                        GameActions.standCard({ card }).allow() ||
+                        GameActions.gainIcon({ card }).allow()
+                }
+            },
+            handler: (context) => {
+                this.game.promptForIcon(context.player, this, (icon) => {
+                    this.game.resolveGameAction(
+                        GameActions.simultaneously([
+                            GameActions.standCard((context) => ({ card: context.target })),
+                            GameActions.genericHandler((context) => {
+                                this.untilEndOfPhase((ability) => ({
+                                    match: context.target,
+                                    effect: ability.effects.addIcon(icon)
+                                }));
+                            })
+                        ]),
+                        context
+                    );
+
+                    this.game.addMessage(
+                        '{0} uses {1} to stand and give {2} {3} icon to {4} until the end of the phase',
+                        this.controller,
+                        this,
+                        icon === 'intrigue' ? 'an' : 'a',
+                        icon,
+                        context.target
+                    );
+                });
+            }
+        });
+    }
+}
+
+SerHarryStrickland.code = '26073';
+
+export default SerHarryStrickland;

--- a/server/game/cards/26.4 LotW/SouthronInformant.js
+++ b/server/game/cards/26.4 LotW/SouthronInformant.js
@@ -1,0 +1,37 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class SouthronInformant extends DrawCard {
+    setupCardAbilities() {
+        this.forcedReaction({
+            when: {
+                onCardEntersPlay: (event) =>
+                    event.card === this && this.game.currentPhase === 'challenge'
+            },
+            chooseOpponent: true,
+            message: '{player} is forced by {source} to give control of {source} to {opponent}',
+            handler: (context) => {
+                this.game.resolveGameAction(
+                    GameActions.takeControl({ card: this, player: context.opponent }).then({
+                        message: {
+                            format: "Then, {player} discards 1 card at random from {opponent}'s hand and draws 1 card",
+                            args: { opponent: (context) => context.opponent }
+                        },
+                        gameAction: GameActions.simultaneously((context) => [
+                            GameActions.discardAtRandom({
+                                player: context.parentContext.opponent,
+                                amount: 1
+                            }),
+                            GameActions.drawCards({ player: context.player, amount: 1 })
+                        ])
+                    }),
+                    context
+                );
+            }
+        });
+    }
+}
+
+SouthronInformant.code = '26067';
+
+export default SouthronInformant;

--- a/server/game/cards/26.4 LotW/TheBastardOfDriftmark.js
+++ b/server/game/cards/26.4 LotW/TheBastardOfDriftmark.js
@@ -1,0 +1,22 @@
+import DrawCard from '../../drawcard.js';
+import GameActions from '../../GameActions/index.js';
+
+class TheBastardOfDriftmark extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardEntersPlay: (event) =>
+                    event.card.controller === this.controller &&
+                    event.card.getType() === 'location' &&
+                    event.card.hasTrait('Warship')
+            },
+            limit: ability.limit.perPhase(2),
+            message: '{player} uses {source} to stand {source}',
+            gameAction: GameActions.standCard({ card: this })
+        });
+    }
+}
+
+TheBastardOfDriftmark.code = '26077';
+
+export default TheBastardOfDriftmark;

--- a/server/game/cards/26.4 LotW/TheWarOfTheFiveKings.js
+++ b/server/game/cards/26.4 LotW/TheWarOfTheFiveKings.js
@@ -4,14 +4,14 @@ class TheWarOfTheFiveKings extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            effect: ability.effects.modifyClaim(() => this.getNumberOfRivals().length)
+            effect: ability.effects.modifyClaim(() => this.getNumberOfRivals())
         });
     }
 
     getNumberOfRivals() {
         return this.game
             .getOpponents(this.controller)
-            .map((player) => player.isRival(this.controller));
+            .filter((player) => player.isRival(this.controller)).length;
     }
 }
 

--- a/server/game/cards/26.4 LotW/TheWarOfTheFiveKings.js
+++ b/server/game/cards/26.4 LotW/TheWarOfTheFiveKings.js
@@ -1,0 +1,20 @@
+import PlotCard from '../../plotcard.js';
+
+class TheWarOfTheFiveKings extends PlotCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.modifyClaim(() => this.getNumberOfRivals().length)
+        });
+    }
+
+    getNumberOfRivals() {
+        return this.game
+            .getOpponents(this.controller)
+            .map((player) => player.isRival(this.controller));
+    }
+}
+
+TheWarOfTheFiveKings.code = '26079';
+
+export default TheWarOfTheFiveKings;

--- a/server/game/cards/26.4 LotW/TradingWithBraavos.js
+++ b/server/game/cards/26.4 LotW/TradingWithBraavos.js
@@ -1,0 +1,46 @@
+import AgendaCard from '../../agendacard.js';
+import GameActions from '../../GameActions/index.js';
+
+class TradingWithBraavos extends AgendaCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onClaimApplied: (event) => event.challenge && event.player === this.controller
+            },
+            cost: ability.costs.kneelFactionCard(),
+            message:
+                '{player} uses {source} to search the top 10 cards of their deck for a non-limited location',
+            gameAction: GameActions.search({
+                topCards: 10,
+                title: 'Select a location',
+                match: { type: 'location', limited: false },
+                gameAction: GameActions.ifCondition({
+                    condition: (context) => !context.searchTarget.hasTrait('Warship'),
+                    thenAction: {
+                        message: '{player} {gameAction}',
+                        gameAction: GameActions.addToHand((context) => ({
+                            card: context.searchTarget
+                        }))
+                    },
+                    elseAction: GameActions.choose({
+                        title: 'Put card in shadows?',
+                        message: '{player} {gameAction}',
+                        choices: {
+                            'Add to hand': GameActions.addToHand((context) => ({
+                                card: context.searchTarget
+                            })),
+                            'Put in shadows': GameActions.placeCard((context) => ({
+                                card: context.searchTarget,
+                                location: 'shadows'
+                            }))
+                        }
+                    })
+                })
+            })
+        });
+    }
+}
+
+TradingWithBraavos.code = '26080';
+
+export default TradingWithBraavos;

--- a/server/game/cards/26.4 LotW/TytosBlackwood.js
+++ b/server/game/cards/26.4 LotW/TytosBlackwood.js
@@ -1,0 +1,16 @@
+import DrawCard from '../../drawcard.js';
+
+class TytosBlackwood extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'any',
+            condition: () => this.isParticipating(),
+            match: (card) => card.getType() === 'character' && card !== this && card.power === 0,
+            effect: ability.effects.blankExcludingTraits
+        });
+    }
+}
+
+TytosBlackwood.code = '26071';
+
+export default TytosBlackwood;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -30,7 +30,7 @@ class DrawCard extends BaseCard {
 
         clone.attachments = this.attachments.map((attachment) => attachment.createSnapshot());
         clone.childCards = this.childCards.map((card) => card.createSnapshot());
-        clone.controllerStack = [...this.controllerStack];
+        clone.controllerStack = this.controllerStack.clone();
         clone.dupes = this.dupes.map((dupe) => dupe.createSnapshot());
         clone.factions = this.factions.clone();
         clone.flags = this.flags.clone();

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -12,7 +12,6 @@ import ImmunityRestriction from './immunityrestriction.js';
 import GoldSource from './GoldSource.js';
 import { Flags, Tokens } from './Constants/index.js';
 import ForcedChallenge from './ForcedChallenge.js';
-import { flatten } from 'underscore';
 
 function cannotEffect(type) {
     return function (predicate) {
@@ -164,20 +163,13 @@ const Effects = {
     cannotBeCanceled: function (abilityFunc = () => true) {
         return {
             apply: function (card, context) {
-                // Get all abilities of this card and apply cannotBeCancelled to those which match function
-                const abilities = flatten(Object.values(card.abilities));
-                for (const ability of abilities) {
-                    if (abilityFunc(ability)) {
-                        ability.setCannotBeCanceled(true, context.source);
-                    }
+                for (const ability of card.getTriggeredAbilities().filter(abilityFunc)) {
+                    ability.setCannotBeCanceled(true, context.source);
                 }
             },
             unapply: function (card, context) {
-                const abilities = flatten(Object.values(card.abilities));
-                for (const ability of abilities) {
-                    if (abilityFunc(ability)) {
-                        ability.clearCannotBeCanceled(true, context.source);
-                    }
+                for (const ability of card.getTriggeredAbilities().filter(abilityFunc)) {
+                    ability.clearCannotBeCanceled(true, context.source);
                 }
             }
         };

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -160,15 +160,15 @@ const Effects = {
             }
         };
     },
-    cannotBeCanceled: function (abilityFunc = () => true) {
+    cannotBeCanceled: function () {
         return {
             apply: function (card, context) {
-                for (const ability of card.getTriggeredAbilities().filter(abilityFunc)) {
+                for (const ability of card.getTriggeredAbilities()) {
                     ability.setCannotBeCanceled(true, context.source);
                 }
             },
             unapply: function (card, context) {
-                for (const ability of card.getTriggeredAbilities().filter(abilityFunc)) {
+                for (const ability of card.getTriggeredAbilities()) {
                     ability.clearCannotBeCanceled(true, context.source);
                 }
             }
@@ -1498,6 +1498,9 @@ const Effects = {
     },
     reduceFirstMarshalledOrPlayedCardCostEachRound: function (amount, match) {
         return this.reduceFirstCardCostEachRound(['marshal', 'play'], amount, match);
+    },
+    reduceFirstMarshaledCardIntoShadowsEachRound: function (amount, match) {
+        return this.reduceFirstCardCostEachRound('marshalIntoShadows', amount, match);
     },
     reduceFirstOutOfShadowsCardCostEachRound: function (amount, match) {
         return this.reduceFirstCardCostEachRound(['outOfShadows'], amount, match);

--- a/server/game/gamesteps/taxation/DiscardToReservePrompt.js
+++ b/server/game/gamesteps/taxation/DiscardToReservePrompt.js
@@ -23,7 +23,7 @@ class DiscardToReservePrompt extends BaseStep {
     }
 
     promptPlayerToDiscard(currentPlayer) {
-        let overReserve = currentPlayer.hand.length - currentPlayer.getReserve();
+        let overReserve = currentPlayer.getHandCount() - currentPlayer.getReserve();
         this.game.promptForSelect(currentPlayer, {
             ordered: true,
             mode: 'exactly',

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -17,8 +17,28 @@ class TaxationPhase extends Phase {
 
     returnGold() {
         for (const player of this.game.getPlayersInFirstPlayerOrder()) {
-            if (!player.hasFlag(Flags.player.doesNotReturnUnspentGold)) {
-                this.game.returnGoldToTreasury({ player: player, amount: player.gold });
+            const amountToReturn = !player.hasFlag(Flags.player.doesNotReturnUnspentGold)
+                ? Math.max(0, player.gold - player.amountUnspentGoldToKeep)
+                : 0;
+            const amountToKeep = player.gold - amountToReturn;
+            if (amountToKeep > 0) {
+                this.game.addMessage(
+                    '{0} keeps {1} unspent gold, and returns {2} to the treasury',
+                    player,
+                    amountToKeep,
+                    amountToReturn > 0 ? amountToReturn : 'none'
+                );
+            } else if (amountToReturn > 0) {
+                this.game.addMessage(
+                    '{0} returns {1} unspent gold to the treasury',
+                    player,
+                    amountToReturn
+                );
+            } else {
+                this.game.addMessage('{0} has no unspent gold to return to the treasury', player);
+            }
+            if (amountToReturn > 0) {
+                this.game.returnGoldToTreasury({ player: player, amount: amountToReturn });
             }
         }
     }

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -23,7 +23,7 @@ class TaxationPhase extends Phase {
             const amountToKeep = player.gold - amountToReturn;
             if (amountToKeep > 0) {
                 this.game.addMessage(
-                    '{0} keeps {1} unspent gold, and returns {2} to the treasury',
+                    '{0} keeps {1} unspent gold and returns {2} to the treasury',
                     player,
                     amountToKeep,
                     amountToReturn > 0 ? amountToReturn : 'none'

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -55,12 +55,16 @@ class Player extends Spectator {
         this.playableLocations = this.createDefaultPlayableLocations();
         this.usedPlotsModifier = 0;
         this.usedPlotsModifierByTrait = new ReferenceCountedSetProperty();
+        this.handCountModifier = 0;
         this.attackerLimits = new MinMaxProperty({ defaultMin: 0, defaultMax: 0 });
         this.defenderLimits = new MinMaxProperty({ defaultMin: 0, defaultMax: 0 });
         this.gainedGold = 0;
         this.maxGoldGain = new MinMaxProperty({ defaultMin: 0, defaultMax: undefined });
         this.drawnCards = 0;
         this.maxCardDraw = new MinMaxProperty({ defaultMin: 0, defaultMax: undefined });
+        this.gainedPower = 0;
+        this.maxPowerGain = new MinMaxProperty({ defaultMin: 0, defaultMax: undefined });
+        this.amountUnspentGoldToKeep = 0;
         this.triggerRestrictions = [];
         this.playCardRestrictions = [];
         this.putIntoShadowsRestrictions = [];
@@ -211,6 +215,10 @@ class Player extends Spectator {
         return this.plotDeck.filter(
             (plot) => !plot.hasFlag(Flags.card.notConsideredToBeInPlotDeck)
         );
+    }
+
+    getHandCount() {
+        return Math.max(0, this.hand.length + this.handCountModifier);
     }
 
     addGoldSource(source) {
@@ -1246,7 +1254,7 @@ class Player extends Spectator {
     }
 
     isBelowReserve() {
-        return this.hand.length <= this.getReserve();
+        return this.getHandCount() <= this.getReserve();
     }
 
     isRival(opponent) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -793,6 +793,7 @@ class Player extends Spectator {
 
         this.gainedGold = 0;
         this.drawnCards = 0;
+        this.gainedPower = 0;
 
         this.limitedPlayed = 0;
 

--- a/test/server/GameActions/GainPower.spec.js
+++ b/test/server/GameActions/GainPower.spec.js
@@ -3,11 +3,12 @@ import GainPower from '../../../server/game/GameActions/GainPower.js';
 describe('GainPower', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['']);
-        this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction']);
-        this.cardSpy.controller = 'PLAYER_OBJ';
+        this.cardSpy = jasmine.createSpyObj('card', ['allowGameAction', 'getPowerToGain']);
+        this.cardSpy.controller = { gainedPower: 0 };
         this.cardSpy.game = this.gameSpy;
         this.cardSpy.power = 0;
         this.props = { card: this.cardSpy, amount: 3 };
+        this.cardSpy.getPowerToGain.and.returnValue(3);
     });
 
     describe('allow()', function () {


### PR DESCRIPTION
# 🆕 Lord of the Waters ⛵ 🎏 
Implements all 20 cards from the new Lord of the Waters pack. All cards are currently available at https://thronesdb.com/set/LotW.

### 🔧 Engine Adjustments
Some engine adjustments to account for certain cards:
- Allowing card abilities to be "cannot be canceled" for **Conspirator's Blade**.
  - Includes an alterations for Daggers in the Dark and Narrow Escape, as they can cancel themselves.
- Adding hand count modifications for **Qartheen Galleas**.
  - All cards which refer to a hand size (eg. comparing sizes, or fixed number like Dothraki Honor Guard) will be using that calculated number rather than the actual hand size. All other effects which target physical cards in hands remain unchanged. Quite tricky, and may have missed some effects.
- Adding a variable of gold to keep for **King's Landing Dromond**.
- Adding maximum power gain per round for **Edric Storm (LotW)**.
  - Includes some improvements to power gain effects and checking.
- Improving properties which rely on stacking effects, such as controller changing, loyalty changing and now cannotBeCanceled changing, with the addition of a simple `StackProperty` to handle the inner logic rather than repeating it all.
- General improvements to wording, such as actually mentioning how much unspent gold players return in taxation (and how much they keep, if applicable).

### ⏫ Potential Improvements
- [ ] When effects are to gain power simultaneously, such as renown, and the amount being gained would exceed the maximum gainable power, it should automatically ask the player to choose the order of resolution, ensuring that it only allows you to trigger abilities that keep you under that maximum.
- [ ] Fix a bug with "first X this round" reducers not considering cards meeting that condition before the effect enters play.

### ☑️ Remaining Tasks
- [x] **Before merging this PR**, merge JSON data (https://github.com/throneteki/throneteki-json-data/pull/186), and pull JSON data changes into this branch.
- [x] **After merging this PR**, pull data changes into playtesting JSON data, update development packs, and push changes to ThronesDB. @Patane97 will handle this.
- [ ] **After merging this PR**, pull card changes into playtesting, resolve conflicts (there should be a few with above engine adjustments; accept all incoming changes), and push.